### PR TITLE
Add enrichment functionality, starting with geocoding.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,5 @@ ENV/
 
 # End of https://www.gitignore.io/api/sbt,scala,intellij,python
 log/*
+
+*.sublime-project

--- a/build.sbt
+++ b/build.sbt
@@ -13,14 +13,17 @@ libraryDependencies ++= Seq(
   "com.databricks" %% "spark-avro" % "3.2.0",
   "org.json4s" %% "json4s-core" % "3.2.11" % "provided",
   "org.json4s" %% "json4s-jackson" % "3.2.11" % "provided",
-  "org.eclipse.rdf4j" % "rdf4j" % "2.1.4",
+  "org.eclipse.rdf4j" % "rdf4j" % "2.2",
+  "org.eclipse.rdf4j" % "rdf4j-model" % "2.2",
+  "org.eclipse.rdf4j" % "rdf4j-rio-api" % "2.2",
+  "org.eclipse.rdf4j" % "rdf4j-rio-turtle" % "2.2",
   "org.elasticsearch" % "elasticsearch-hadoop" % "2.0.3" excludeAll(
     ExclusionRule("cascading", "cascading-hadoop"),
     ExclusionRule("cascading", "cascading-local")
   ),
   // ApiHarvester depends
   "org.apache.httpcomponents" % "httpclient" % "4.5.2",
-  "org.eclipse.rdf4j" % "rdf4j-model" % "2.2",
-  "org.eclipse.rdf4j" % "rdf4j-rio-api" % "2.2",
-  "org.eclipse.rdf4j" % "rdf4j-rio-turtle" % "2.2"
+  // Enricher dependencies
+  // TODO: reconcile with httpclient above.
+  "org.scalaj" %% "scalaj-http" % "2.3.0"
 )

--- a/src/main/scala/dpla/ingestion3/EnricherMain.scala
+++ b/src/main/scala/dpla/ingestion3/EnricherMain.scala
@@ -1,0 +1,129 @@
+package dpla.ingestion3
+
+import java.io._
+
+import com.databricks.spark.avro._
+import org.apache.avro.Schema
+import org.apache.log4j.LogManager
+import org.apache.spark.SparkConf
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.storage.StorageLevel
+import org.eclipse.rdf4j.model.Model
+import org.eclipse.rdf4j.model.util.ModelBuilder
+import org.eclipse.rdf4j.rio._
+import dpla.ingestion3.utils.Utils
+import dpla.ingestion3.enrichments.Spatial
+
+/**
+ * Driver for running an enrichment
+ *
+ * This is a prototype that is hardcoded to run the spatial enrichment,
+ * SpatialEnricher.
+ *
+ * See https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Ingestion+3+Storage+Specification#Ingestion3StorageSpecification-S3BucketFolderStructureandContents
+ * with suggestions for how to organize input and output locations. 
+ *
+ * Example invocation:
+ * $ sbt "run-main dpla.ingestion3.EnricherMain local[2] <from> <to>"
+ * ... where <from> is the Avro resource (file / directory) and <to> is the
+ *     destination (directory or s3 folder)
+ *
+ */
+object EnricherMain {
+
+  // Avro schema for our output
+  val schemaStr: String =
+    """
+    {
+      "namespace": "la.dp.avro",
+      "type": "record",
+      "name": "MAPRecord.v1",
+      "doc": "Prototype enriched record",
+      "fields": [
+        {"name": "id", "type": "string"},
+        {"name": "document", "type": "string"}
+      ]
+    }
+    """
+  val logger = LogManager.getLogger(EnricherMain.getClass)
+
+  /*
+   * args:
+   *   master: String -- Spark master descriptor
+   *   inputURI: String -- URI of Avro input
+   *   outputURI: String -- URI of Avro output
+   */
+  def main(args: Array[String]) {
+
+    if (args.length != 3) {
+      logger.error("Arguments should be <master>, <inputURI>, <outputURI>")
+      sys.exit(-1)
+    }
+    val sparkMaster = args(0)
+    val inputURI = args(1)
+    val outputURI = args(2)
+
+    val start_time = System.currentTimeMillis()
+
+    val sparkConf = new SparkConf()
+      .setAppName("Enricher")
+      .setMaster(sparkMaster)
+    val spark = SparkSession.builder().config(sparkConf).getOrCreate()
+    val sc = spark.sparkContext
+
+    val rdd: RDD[Row] = spark.read
+      .format("com.databricks.spark.avro")
+      .option("avroSchema", schemaStr)
+      .load(inputURI)
+      .rdd
+
+    // Process all of the records and wrap them with a dataframe
+    val rows = rdd.map(
+      record => (
+        record.getAs[String]("id"),
+        process(record.getAs[String]("document"))
+      )
+    )
+    // The dataframe is created with fields named "id" and "document" which is
+    // not as nice as actually embedding the schema that we've defined in
+    // schemaStr. I've tried to embed that using
+    // .options("avroSchema", schemaStr) below in the call to dataframe.write(),
+    // but that silently does nothing.
+    // -mb
+    val dataframe = spark.createDataFrame(rows).toDF("id", "document")
+
+    val recordCount = dataframe.count()
+    Utils.deleteRecursively(new File(outputURI))
+    dataframe.write
+             .format("com.databricks.spark.avro")
+             .avro(outputURI)
+    sc.stop()
+
+    val end_time = System.currentTimeMillis()
+    Utils.printResults((end_time - start_time), recordCount)
+
+  }
+
+  def process(rdfString: String): String = {
+    try {
+      val rdfByteStream = new StringReader(rdfString)
+      val in_model = Rio.parse(rdfByteStream, "", RDFFormat.TURTLE)
+      val out_model: Model = Spatial.enrich(in_model)
+      // out_model could be passed to other enrichments in turn
+      val out = new StringWriter()
+      Rio.write(out_model, out, RDFFormat.TURTLE)
+      out.toString
+    } catch {
+      case e: Exception => {
+        val sw = new StringWriter
+        val pw = new PrintWriter(sw)
+        e.printStackTrace(pw)
+        logger.warn(sw.toString)
+        sw.toString
+      }
+    }
+  }
+
+}

--- a/src/main/scala/dpla/ingestion3/enrichments/Spatial.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/Spatial.scala
@@ -1,0 +1,172 @@
+package dpla.ingestion3.enrichments
+
+// JavaConversions is for iterating over Sets of
+// org.eclipse.rdf4j.model.Resource and org.eclipse.rdf4j.model.Model
+import collection.JavaConversions._
+import org.eclipse.rdf4j.model._
+import org.eclipse.rdf4j.model.util.Models
+import dpla.ingestion3.mappers.rdf.MappingUtils
+import dpla.ingestion3.mappers.rdf.DefaultVocabularies
+import scalaj.http._ // Used here because it's easy, but see ApiHarvester
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+import org.apache.log4j.Logger
+
+
+/*
+ * See https://gist.github.com/markbreedlove/b93e8bfca73b430e034af2e073c8112e
+ * for a demo of how to get a field out of one of our item aggregations.
+ * The code here departs from it and goes straight for the node that's an
+ * edm:Place, but it's similar.
+ */
+
+/*
+ * Example incoming mapped data from Ingestion 2, Digital Commonwealth.
+ * Note big newline-delimited string with multiple place names. Note bad
+ * geo:lat value that contains both lat and long -- not sure if that's something
+ * that's been fixed. It's technically a data-cleanup issue.
+ *
+ * [ ... abridged ... ]
+ * @prefix dc: <http://purl.org/dc/terms/> .
+ * @prefix dpla: <http://dp.la/about/map/> .
+ * @prefix edm: <http://www.europeana.eu/schemas/edm/> .
+ * @prefix geo: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
+ * @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+ * [...]
+ * <http://ldp.staging.dp.la/ldp/items/00ea7274bf61874a7b8df90eb0042ef0> a <http://www.w3.org/ns/ldp#Resource>,
+ * [...]
+ *   dc:spatial [
+ *    a edm:Place;
+ *    dpla:providedLabel """
+ *     North and Central America
+ *     United States
+ *     Texas
+ *     Dallas
+ *     Dallas
+ *   """;
+ *    geo:lat "32.7833,-96.80";
+ *    skos:exactMatch "http://vocab.getty.edu/tgn/7013503"
+ *  ];
+ *
+ * ... Otherwise, the one other provider whose unenriched RDF I've examined,
+ * NARA, has one-line strings for the spatial statements:
+ *
+ *   dc:spatial [
+ *    a edm:Place;
+ *    dpla:providedLabel "Arlington (Va.)"
+ *  ];
+ *
+ * Example output enriched data from Ingestion 2, Cal. Digital Library:
+ *
+ *  dc:spatial [
+ *    a edm:Place;
+ *    dpla:providedLabel "Los Angeles (Calif.)";
+ *    gn:countryCode "US";
+ *    geo:lat 3.405223e1;
+ *    geo:long -1.1824368e2;
+ *    skos:closeMatch <http://id.loc.gov/authorities/names/n79021240>;
+ *    skos:exactMatch <http://sws.geonames.org/5368361/>;
+ *    skos:prefLabel "Los Angeles, CA, United States"
+ *  ];
+ *
+ * Note that Ingestion 2 (specifically, the Audumbla::CoarseGeocode enrichment)
+ * was bailing on the assignment of parent features, probably due to the fact
+ * that MAPv4 specifies them as URIs, which is inconvenient for us when it comes
+ * time to serialize the records into JSON-LD and have it indexed effectively
+ * by Elasticsearch, where you want strings for the parent features (E.g.
+ * "Los Angeles County" or "California"), not URIs. Our users search for those
+ * strings!
+ *
+ * We have work to do to determine if MAPv4 is actually the right thing, and
+ * whether we need a revision; or if we want to jump through hoops to resolve
+ * parent features as part of the process to writing JSON for Elasticsearch to
+ * index.
+ */
+
+/* Case classes for JSON parser ... */
+case class Coords(lat: Double, lng: Double)
+
+case class Bounds(ne: Coords, sw: Coords)
+
+case class Geometry(center: Coords, bounds: Bounds)
+
+case class Feature(geometry: Geometry, woeType: Int, displayName: String)
+
+case class Interpretation(feature: Feature)
+
+case class Result(interpretations: List[Interpretation])
+
+object Spatial extends MappingUtils with DefaultVocabularies {
+
+  implicit val formats = DefaultFormats // Formats for json4s
+  val log = Logger.getLogger(getClass.getName)
+
+  def enrich(m: Model): Model = {
+
+    val spatialModel = m.filter(null, rdf.`type`, edm.Place)
+    if (spatialModel.isEmpty) return m
+
+    for {
+      s <- spatialModel.subjects
+      provLabels = m.filter(s, dpla.providedLabel, null)
+      pl <- provLabels
+    } {
+
+      /* We expect the provided label below not to need any special processing,
+       * like stripping newlines, etc. That should be handled by an earlier
+       * enrichment.
+       *
+       * If it's a multiline string, as we've encountered with Digital
+       * Commonwealth, I really don't know if we can handle it well. Twofishes
+       * will not do what you want with a string like "Dallas Dallas Texas
+       * United States North and Central America". This particular instance will
+       * work if the values are reversed (as "North and Central America United
+       * States Texas Dallas Dallas") but I wouldn't want to count on that in
+       * general.
+       *
+       * We need some research to determine how common this is. Ideally we'd
+       * have multiple dc:spatial statements instead of one statement with a
+       * multiline string as the object.
+       *
+       * Is this an issue with Krikri that won't happen with Ingestion 3?
+       */
+
+      try {
+
+        val providedLabel = pl.getObject.stringValue
+        m.add(s, dpla.providedLabel, literal(providedLabel))
+
+        // Look up the place by name (providedLabel) ...
+        val baseURI = "http://geo-prod:8081/query"
+        val response: HttpResponse[String] =
+          Http(baseURI).param("lang", "en")
+            .param("responseIncludes", "PARENTS,DISPLAY_NAME")
+            .param("query",  providedLabel).asString
+        val jsonDoc = parse(response.body)
+
+        val name = ((jsonDoc \ "interpretations") (0) \ "feature")
+          .extract[Feature].displayName
+        val coords = ((((jsonDoc \ "interpretations") (0) \ "feature") \ "geometry") \ "center")
+          .extract[Coords]
+        m.add(s, skos.prefLabel, literal(name))
+        m.add(s, wgs84.lat, literal(coords.lat.toString))
+        m.add(s, wgs84.long, literal(coords.lng.toString))
+
+        // Next do something with parents (requires adding case classes above
+        // for parent features, etc.)
+
+      } catch {
+        // Best way to log a message?
+        case e: java.lang.IndexOutOfBoundsException => {
+          log.error(s"No interpretations for ${pl.getObject.stringValue}")
+        }
+        case e: Exception => {
+          log.error(e.toString)
+        }
+      }
+
+    } // for
+
+    m
+  } // enrich
+}

--- a/src/main/scala/dpla/ingestion3/mappers/rdf/MappingUtils.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/rdf/MappingUtils.scala
@@ -55,7 +55,7 @@ trait MappingUtils extends DefaultVocabularies with RdfValueUtils {
 
     builder
       .subject(aggregatedCHO)
-      .add(rdf.`type`, dpla.sourceResource)
+      .add(rdf.`type`, dpla.SourceResource)
 
     addAll(dc.date, choData.dates)
     addAll(dcTerms.title, choData.titles)

--- a/src/main/scala/dpla/ingestion3/mappers/rdf/Vocabularies.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/rdf/Vocabularies.scala
@@ -366,7 +366,7 @@ case class ORE()
 }
 
 case class SKOS()
-  extends Vocabulary("skos", "http://www.w3.org/2004/02/skos/core") {
+  extends Vocabulary("skos", "http://www.w3.org/2004/02/skos/core/") {
   val Concept: IRI = apply("Concept")
   val ConceptScheme: IRI = apply("ConceptScheme")
   val Collection: IRI = apply("Collection")

--- a/src/main/scala/dpla/ingestion3/mappers/rdf/Vocabularies.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/rdf/Vocabularies.scala
@@ -39,11 +39,11 @@ case class RDF() extends Vocabulary("rdf", "http://www.w3.org/1999/02/22-rdf-syn
   val HTML = org.eclipse.rdf4j.model.vocabulary.RDF.HTML
 }
 
-case class DPLA() extends Vocabulary("dpla", "http://dp.dpla/about/map/") {
+case class DPLA() extends Vocabulary("dpla", "http://dp.la/about/map/") {
   val Place: IRI = apply("Place")
+  val SourceResource: IRI = apply("SourceResource")
   val intermediateProvider: IRI = apply("intermediateProvider")
   val originalRecord: IRI = apply("originalRecord")
-  val sourceResource: IRI = apply("sourceResource")
   val isReplacedBy: IRI = apply("isReplacedBy")
   val providedLabel: IRI = apply("providedLabel")
   val replaces: IRI = apply("replaces")

--- a/src/main/scala/dpla/ingestion3/utils/Utils.scala
+++ b/src/main/scala/dpla/ingestion3/utils/Utils.scala
@@ -1,13 +1,12 @@
 package dpla.ingestion3.utils
 
 import java.io.File
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{Path, FileSystem}
 import org.apache.hadoop.io.SequenceFile.Reader
 import org.apache.hadoop.io.Text
-
 import scala.xml.Node
+import java.util.concurrent.TimeUnit
 
 /**
   * Created by scott on 1/18/17.
@@ -60,4 +59,43 @@ object Utils {
     val prettyPrinter = new scala.xml.PrettyPrinter(80, 2)
     prettyPrinter.format(xml).toString
   }
+
+  /**
+    * Print the results of an activity
+    *
+    * Example:
+    *   Harvest count: 242924 records harvested
+    *   Runtime: 4 minutes 24 seconds
+    *   Throughput: 920 records/second
+    *
+    * @param runtime Runtime in milliseconds
+    * @param recordCount Number of records output
+    */
+  def printResults(runtime: Long, recordCount: Long): Unit = {
+    val formatter = java.text.NumberFormat.getIntegerInstance
+    val minutes: Long = TimeUnit.MILLISECONDS.toMinutes(runtime)
+    val seconds: Long = TimeUnit.MILLISECONDS.toSeconds(runtime) -
+      TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(runtime))
+    val runtimeInSeconds: Long = TimeUnit.MILLISECONDS.toSeconds(runtime) + 1
+    // add 1 to avoid divide by zero error
+    val recordsPerSecond: Long = recordCount/runtimeInSeconds
+
+    println(s"File count: ${formatter.format(recordCount)}")
+    println(s"Runtime: $minutes:$seconds")
+    println(s"Throughput: ${formatter.format(recordsPerSecond)} records/second")
+  }
+
+
+  /**
+    * Delete a directory
+    * Taken from http://stackoverflow.com/questions/25999255/delete-directory-recursively-in-scala#25999465
+    * @param file
+    */
+  def deleteRecursively(file: File): Unit = {
+    if (file.isDirectory)
+      file.listFiles.foreach(deleteRecursively)
+    if (file.exists && !file.delete)
+      throw new Exception(s"Unable to delete ${file.getAbsolutePath}")
+  }
+
 }

--- a/src/test/scala/dpla/ingestion3/mappers/rdf/MappingUtilsTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/rdf/MappingUtilsTest.scala
@@ -29,7 +29,7 @@ class MappingUtilsTest extends FlatSpec with BeforeAndAfter with MappingUtils {
   }
 
   it should "create an aggregatedCHO that's a dpla:sourceResource" in {
-    testCHOMapping(ChoData(), rdf.`type`, Seq(dpla.sourceResource))
+    testCHOMapping(ChoData(), rdf.`type`, Seq(dpla.SourceResource))
   }
 
   it should "map dates" in {


### PR DESCRIPTION
Add an EnricherMain class, and add a spatial enrichment, with provisions for more enrichments to be added later.

Known issues:
1. (Major one) Our MAPv4 schema is inadequate for capturing parent geographic features the way we need them for indexing by Elasticsearch. Ingestion 2 (the `Adumbla::CoarseGeocode` enrichment) did not resolve parent features, either. This is something we're continuing to discuss internally. For a given place, we are not inserting parent features like county, state, and country. See the comments in `Spatial.scala`.
2. Given an Avro file with an Avro schema embedded in its header, the EnricherMain does not add it to the Avro files that it writes out. These files end up with fields named `_1` and `_2` instead of `id` and `field`.
3. The Turtle that is output represents blank nodes (of which there are many) differently than Krikri. I don't know if this is a problem.

*I should squash these commits before they're merged!*