### PR TITLE
Use DataSource API for OAI harvest

### DIFF
--- a/src/main/scala/dpla/ingestion3/OaiHarvesterMain.scala
+++ b/src/main/scala/dpla/ingestion3/OaiHarvesterMain.scala
@@ -1,16 +1,15 @@
 package dpla.ingestion3
 
-import dpla.ingestion3.harvesters.OaiQueryUrlBuilder
 import java.io.File
 import java.util.concurrent.TimeUnit
 
 import com.databricks.spark.avro._
-import dpla.ingestion3.utils.OaiRdd
 import org.apache.avro.Schema
 import org.apache.log4j.LogManager
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions._
 import org.apache.spark.storage.StorageLevel
 
 /**
@@ -31,8 +30,8 @@ object OaiHarvesterMain extends App {
         "doc": "",
         "fields": [
           {"name": "id", "type": "string"},
-          {"name": "provider", "type": "string"},
           {"name": "document", "type": "string"},
+          {"name": "provider", "type": "string"},
           {"name": "mimetype", "type": { "name": "MimeType",
            "type": "enum", "symbols": ["application_json", "application_xml", "text_turtle"]}
            }
@@ -50,13 +49,10 @@ object OaiHarvesterMain extends App {
 
   println(schemaStr)
 
-  val urlBuilder = new OaiQueryUrlBuilder
   val outputFile = args(0)
-  val oaiParams = Map[String,String](
-    "endpoint" -> args(1),
-    "metadataPrefix" -> args(2),
-    "verb" -> args(3))
-
+  val endpoint = args(1)
+  val metadataPrefix = args(2)
+  val verb = args(3)
   val provider = args(4)
 
   deleteRecursively(new File(outputFile))
@@ -73,18 +69,28 @@ object OaiHarvesterMain extends App {
   val avroSchema = new Schema.Parser().parse(schemaStr)
   val schemaType = SchemaConverters.toSqlType(avroSchema)
   val structSchema = schemaType.dataType.asInstanceOf[StructType]
-  val oaiRdd: OaiRdd = new OaiRdd(sc, oaiParams, urlBuilder).persist(StorageLevel.DISK_ONLY)
-  val rows = oaiRdd.map(data => { Row(data._1, provider, data._2, "application_xml") })
-  val dataframe = spark.createDataFrame(rows, structSchema)
 
-  //TODO: should probably do this by loading the avro into a new dataframe and calling count()
+  val oaiResults = spark.read
+                        .format("dpla.ingestion3.harvesters.oai")
+                        .option("metadataPrefix", metadataPrefix)
+                        .option("verb", verb)
+                        .load(endpoint)
+
+  oaiResults.persist(StorageLevel.DISK_ONLY)
+
+  val dataframe = oaiResults.withColumn("provider", lit(provider))
+                            .withColumn("mimetype", lit("application_xml"))
+
   val recordsHarvestedCount = dataframe.count()
 
-  dataframe.write.format("com.databricks.spark.avro").option("avroSchema", schemaStr).avro(outputFile)
+  dataframe.write
+           .format("com.databricks.spark.avro")
+           .option("avroSchema", schemaStr)
+           .avro(outputFile)
+
   sc.stop()
 
   val end = System.currentTimeMillis()
-
 
   printResults((end-start),recordsHarvestedCount)
 

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/DefaultSource.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/DefaultSource.scala
@@ -1,0 +1,17 @@
+package dpla.ingestion3.harvesters.oai
+
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.sources._
+
+class DefaultSource extends RelationProvider {
+  
+  override def createRelation(sqlContext: SQLContext,
+                              parameters: Map[String, String]) : OaiRelation = {
+
+    val endpoint = parameters("path")
+    val metadataPrefix = parameters("metadataPrefix")
+    val verb = parameters("verb")
+    
+    new OaiRelation(endpoint, metadataPrefix, verb)(sqlContext)
+  }
+}

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/OaiRelation.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/OaiRelation.scala
@@ -1,0 +1,52 @@
+package dpla.ingestion3.harvesters.oai
+
+import dpla.ingestion3.harvesters.OaiQueryUrlBuilder
+import org.apache.spark.sql._
+import org.apache.spark.sql.sources._
+import org.apache.spark.sql.types._
+import org.apache.spark.rdd.RDD
+import java.net.URL
+import scala.xml.{NodeSeq, XML}
+
+class OaiRelation (endpoint: String, metadataPrefix: String, verb: String)
+                  (@transient val sqlContext: SQLContext)
+                  extends BaseRelation with TableScan {
+
+  val oaiParams = Map[String,String](
+    "endpoint" -> endpoint,
+    "metadataPrefix" -> metadataPrefix,
+    "verb" -> verb)
+  
+  override def schema: StructType =  {
+    StructType(Seq(StructField("id", StringType, true), 
+                   StructField("document", StringType, true)))
+  }
+
+  /*
+  * Each Row contains two Strings. The first is the document ID and the second
+  * is the XML text of the record.
+  */
+  override def buildScan(): RDD[Row] = {
+    sqlContext.sparkContext.parallelize(results.map(x => Row(x._1, x._2)))
+  }
+
+  def results: Seq[(String, String)] = {
+    val urlBuilder = new OaiQueryUrlBuilder
+    val url = urlBuilder.buildQueryUrl(oaiParams)
+    val xml = getXmlResponse(url)
+    val oaiProcessor = new OaiResponseProcessor
+    oaiProcessor.getRecordsAsMap(xml)
+  }
+
+  /**
+  * Executes the request and returns the response
+  *
+  * @param url URL
+  *            OAI request URL
+  * @return NodeSeq
+  *         XML response
+  */
+  def getXmlResponse(url: URL): NodeSeq = {
+    XML.load(url)
+  }
+}


### PR DESCRIPTION
This implements the DataSource API for an OAI harvest instead of the RDD API.
I tested this locally using the following params:
```
endpoint: http://oai.artstor.org/oaicatmuseum/OAIHandler
metadataPrefix: oai_dc
verb: ListRecords
```
It addresses [ticket DT-1278](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1278).