### PR TITLE
Two indexer fixes

### DIFF
--- a/src/main/scala/dpla/ingestion3/indexer/IndexerMain.scala
+++ b/src/main/scala/dpla/ingestion3/indexer/IndexerMain.scala
@@ -26,8 +26,9 @@ object IndexerMain {
   def main(args:Array[String]): Unit = {
 
     val input = args(0)
-    val cluster = args(1)
-    val index = args(2)
+    val esCluster = args(1)
+    val esPort = args(2)
+    val index = args(3)
 
     val conf = new SparkConf()
       .setAppName("Ingest 3 Indexer")
@@ -61,8 +62,10 @@ object IndexerMain {
     jobConf.set("mapred.output.format.class",  "org.elasticsearch.hadoop.mr.EsOutputFormat")
     //This means we're giving it json instead of ES API record objects:
     jobConf.set(ConfigurationOptions.ES_INPUT_JSON, "yes")
-    //This passes info about the cluster we're writing to
-    jobConf.set(ConfigurationOptions.ES_NODES, cluster)
+    //This is the host name of the Elasticsearch cluster we're writing to
+    jobConf.set(ConfigurationOptions.ES_NODES, esCluster)
+    //This is the port number that Elasticsearch listens on
+    jobConf.set(ConfigurationOptions.ES_PORT, esPort)
     //This tells it to create the index if it doesn't exist.
     jobConf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "true")
     //Tells elastisearch-hadoop what field to use as the ID to formulate the correct ES API calls

--- a/src/main/scala/dpla/ingestion3/indexer/IndexerMain.scala
+++ b/src/main/scala/dpla/ingestion3/indexer/IndexerMain.scala
@@ -10,15 +10,16 @@ import org.elasticsearch.hadoop.mr.EsOutputFormat.EsOldAPIOutputCommitter
 
 object IndexerMain {
 
+  // See https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Ingestion+3+Storage+Specification
   val schema: String = """
   | {
-  |   "namespace": "dpla.dp.avro.MAP_3.1",
+  |   "namespace": "la.dp.avro.MAP_3.1",
   |   "type": "record",
-  |   "name": "EnrichedRecord",
-  |   "doc": "Dumped from PA cqa box in Ingestion 1",
+  |   "name": "IndexRecord.v1",
+  |   "doc": "",
   |   "fields": [
   |     { "name": "id", "type": "string" },
-  |     { "name": "json_document", "type": "string" }
+  |     { "name": "document", "type": "string" }
   |   ]
   | }
   """.stripMargin //todo retrieve this from S3
@@ -81,7 +82,7 @@ object IndexerMain {
     val es: RDD[(String, String)] = rawData.map(
       row => (
         row.getAs[String]("id"),
-        row.getAs[String]("json_document")
+        row.getAs[String]("document")
       )
     )
 


### PR DESCRIPTION
* Update `IndexerMain` arguments to take an Elasticsearch port number and to disambiguate the term "cluster".
* Align the Avro schema expressed in `IndexerMain` with the one we've published at https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Ingestion+3+Storage+Specification
