### PR TITLE
Harvest OAI set

### DIFF
--- a/src/main/scala/dpla/ingestion3/OaiHarvesterMain.scala
+++ b/src/main/scala/dpla/ingestion3/OaiHarvesterMain.scala
@@ -1,13 +1,12 @@
 package dpla.ingestion3
 
 import java.io.File
+
 import dpla.ingestion3.utils.Utils
 import com.databricks.spark.avro._
-import org.apache.avro.Schema
 import org.apache.log4j.LogManager
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.functions._
 import org.apache.spark.storage.StorageLevel
 
@@ -21,7 +20,8 @@ import org.apache.spark.storage.StorageLevel
   *             OAI Verb: String ListRecords, ListSets etc.
   *             Provider: Provider name (we need to standardize this)
   */
-object OaiHarvesterMain extends App {
+object OaiHarvesterMain {
+
   val schemaStr =
     """{
         "namespace": "la.dp.avro",
@@ -41,58 +41,69 @@ object OaiHarvesterMain extends App {
 
   val logger = LogManager.getLogger(OaiHarvesterMain.getClass)
 
-  // Complains about not being typesafe...
-  if(args.length != 5 ) {
-    logger.error("Bad number of args: <OUTPUT FILE>, <OAI URL>, <METADATA PREFIX>, <OAI VERB>, <PROVIDER>")
-    sys.exit(-1)
+  def main(args: Array[String]): Unit = {
+
+    validateArgs(args)
+    println(schemaStr)
+
+    val outputFile = args(0)
+    val endpoint = args(1)
+    val metadataPrefix = args(2)
+    val verb = args(3)
+    val provider = args(4)
+    val sets: Option[String] = if (args.isDefinedAt(5)) Some(args(5)) else None
+
+    Utils.deleteRecursively(new File(outputFile))
+
+    val sparkConf = new SparkConf().setAppName("Oai Harvest")
+    val spark = SparkSession.builder().config(sparkConf).getOrCreate()
+    val sc = spark.sparkContext
+
+    val start = System.currentTimeMillis()
+
+    val baseOptions = Map( "metadataPrefix" -> metadataPrefix, "verb" -> verb)
+    val readerOptions = getReaderOptions(baseOptions, sets)
+
+    val results = spark.read
+      .format("dpla.ingestion3.harvesters.oai")
+      .options(readerOptions)
+      .load(endpoint)
+
+    results.persist(StorageLevel.DISK_ONLY)
+
+    val dataframe = results.withColumn("provider", lit(provider))
+      .withColumn("mimetype", lit("application_xml"))
+
+    val recordsHarvestedCount = dataframe.count()
+
+    // This task may require a large amount of driver memory.
+    dataframe.write
+      .format("com.databricks.spark.avro")
+      .option("avroSchema", schemaStr)
+      .avro(outputFile)
+
+    sc.stop()
+
+    val end = System.currentTimeMillis()
+
+    Utils.printResults((end-start),recordsHarvestedCount)
   }
 
-  println(schemaStr)
+  def validateArgs(args: Array[String]) = {
+    // Complains about not being typesafe...
+    if(args.length < 5) {
+      logger.error("Bad number of args: <OUTPUT FILE>, <OAI URL>, " +
+        "<METADATA PREFIX>, <OAI VERB>, <PROVIDER>, " +
+        "<SETS> (optional)")
+      sys.exit(-1)
+    }
+  }
 
-  val outputFile = args(0)
-  val endpoint = args(1)
-  val metadataPrefix = args(2)
-  val verb = args(3)
-  val provider = args(4)
-
-  Utils.deleteRecursively(new File(outputFile))
-
-  val sparkConf = new SparkConf()
-    .setAppName("Oai Harvest")
-    .setMaster("local") //todo parameterize
-
-  val spark = SparkSession.builder().config(sparkConf).getOrCreate()
-  val sc = spark.sparkContext
-
-  val start = System.currentTimeMillis()
-
-  val avroSchema = new Schema.Parser().parse(schemaStr)
-  val schemaType = SchemaConverters.toSqlType(avroSchema)
-  val structSchema = schemaType.dataType.asInstanceOf[StructType]
-
-  val oaiResults = spark.read
-                        .format("dpla.ingestion3.harvesters.oai")
-                        .option("metadataPrefix", metadataPrefix)
-                        .option("verb", verb)
-                        .load(endpoint)
-
-  oaiResults.persist(StorageLevel.DISK_ONLY)
-
-  val dataframe = oaiResults.withColumn("provider", lit(provider))
-                            .withColumn("mimetype", lit("application_xml"))
-
-  val recordsHarvestedCount = dataframe.count()
-
-  // This task may require a large amount of driver memory.
-  dataframe.write
-           .format("com.databricks.spark.avro")
-           .option("avroSchema", schemaStr)
-           .avro(outputFile)
-
-  sc.stop()
-
-  val end = System.currentTimeMillis()
-
-  Utils.printResults((end-start),recordsHarvestedCount)
-
+  def getReaderOptions(baseOptions: Map[String, String],
+                       sets: Option[String]): Map[String, String] = {
+    sets match {
+      case Some(sets) => baseOptions + ("sets" -> sets)
+      case None => baseOptions
+    }
+  }
 }

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/DefaultSource.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/DefaultSource.scala
@@ -8,10 +8,6 @@ class DefaultSource extends RelationProvider {
   override def createRelation(sqlContext: SQLContext,
                               parameters: Map[String, String]) : OaiRelation = {
 
-    val endpoint = parameters("path")
-    val metadataPrefix = parameters("metadataPrefix")
-    val verb = parameters("verb")
-    
-    new OaiRelation(endpoint, metadataPrefix, verb)(sqlContext)
+    new OaiRelation(parameters)(sqlContext)
   }
 }

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/OaiRelation.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/OaiRelation.scala
@@ -1,98 +1,85 @@
 package dpla.ingestion3.harvesters.oai
 
-import dpla.ingestion3.harvesters.OaiQueryUrlBuilder
 import org.apache.spark.sql._
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
 import org.apache.spark.rdd.RDD
-import java.net.URL
-import org.apache.commons.io.IOUtils
-import scala.xml.{NodeSeq, XML}
-import scala.annotation.tailrec
+import scala.xml.{XML}
 
-class OaiRelation (endpoint: String, metadataPrefix: String, verb: String)
+/*
+ * This class interprets the user-submitted params to determine which type of
+ * request to send to the OAI feed (ie. get records or sets of records).
+ * It requests an OAI response via the `OaiResponseBuilder`.
+ * It constructs a DataFrame from the OAI response.
+  */
+class OaiRelation (parameters: Map[String, String])
                   (@transient val sqlContext: SQLContext)
                   extends BaseRelation with TableScan {
 
-  val oaiParams = Map[String,String](
-    "endpoint" -> endpoint,
-    "metadataPrefix" -> metadataPrefix,
-    "verb" -> verb)
+  // Required properties.
+  assume(parameters.get("path").isDefined)
+  assume(parameters.get("verb").isDefined)
+  assume(parameters.get("metadataPrefix").isDefined)
 
-  val urlBuilder = new OaiQueryUrlBuilder
-  
-  override def schema: StructType =  {
-    StructType(Seq(StructField("id", StringType, true), 
+  val endpoint = parameters("path")
+  val verb = parameters("verb")
+  val metadataPrefix = parameters("metadataPrefix")
+
+  val sets: Option[String] = parameters.get("sets")
+
+  val oaiResponseBuilder = new OaiResponseBuilder(sqlContext)
+
+  /*
+   * Make appropriate call to OaiResponseBuilder based on presence or absence of
+   * sets.
+   */
+  def response: RDD[String] = {
+    sets match {
+      case None => {
+        oaiResponseBuilder.getRecords(recordsParams)
+      }
+      case Some(sets) => {
+        val setArray = parseSets(sets)
+        oaiResponseBuilder.getRecordsBySets(recordsParams, setArray)
+      }
+    }
+  }
+
+  // Base params for `records` request or `recordsBySets` request.
+  def recordsParams: Map[String, String] = Map(
+    "endpoint" -> endpoint,
+    "verb" -> verb,
+    "metadataPrefix" -> metadataPrefix
+  )
+
+  /*
+   * Sets are passed to this class as a comma-separated String.
+   * This parses the String to an Array.
+   */
+  def parseSets(string: String): Array[String] = {
+    string.split(",").map(_.trim)
+  }
+
+  // Set the schema for the DataFrame that will be returned on load.
+  override def schema: StructType = {
+    StructType(Seq(StructField("id", StringType, true),
                    StructField("document", StringType, true)))
   }
 
-  /*
-  * Each Row contains two Strings. The first is the document ID and the second
-  * is the XML text of the record.
-  */
+  // Build the rows for the DataFrame.
   override def buildScan(): RDD[Row] = {
-    val resultsRdd = sqlContext.sparkContext.parallelize(results)
-    resultsRdd.flatMap(
-      string => {
-        val xml = XML.loadString(string)
+    response.flatMap(
+      // page [String] one page of records
+      page => {
+        val xml = XML.loadString(page)
         OaiResponseProcessor.getRecordsAsTuples(xml).map(
           tuple => {
+            // tuple._1 [String] the record ID
+            // tuple._2 [String] the full contents of the record
             Row(tuple._1, tuple._2)
           }
         )
       }
     )
-  }
-
-  /*
-  * Get all pages of results from an OAI feed.
-  * Makes an inital call to the feed to get the first page of results.
-  * For this and all subsequent pages, calls the next page if a resumption token
-  * is present.
-  * Returns a single List of single-page responses as Strings.
-  */
-  def results: List[String] = {
-
-    @tailrec
-    def loop(data: List[String], 
-             resumptionToken: Option[String]): List[String] = {
-      if(!(resumptionToken.isDefined)) return data
-      val queryParams = paramsWithToken(resumptionToken.get)
-      val nextResponse = singlePageResponse(queryParams)
-      val nextToken = OaiResponseProcessor.getResumptionToken(nextResponse)
-      loop(nextResponse :: data, nextToken)
-    }
-
-    val firstResponse = singlePageResponse(oaiParams)
-    val firstToken = OaiResponseProcessor.getResumptionToken(firstResponse)
-    loop(List(firstResponse), firstToken)
-  }
-
-  def paramsWithToken(resumptionToken: String): Map[String, String] = {
-    oaiParams ++ Map("resumptionToken" -> resumptionToken)
-  }
-
-  // Returns a single page response as a single String
-  def singlePageResponse(queryParams: Map[String,String]): String = {
-    val url = urlBuilder.buildQueryUrl(queryParams)
-    println(url)  // For testing purposes, can delete later
-    getStringResponse(url)
-  }
-
-  /**
-  * Executes the request and returns the response
-  *
-  * @param url URL
-  *            OAI request URL
-  * @return String
-  *         String response
-  *
-  * OAI-PMH XML responses must be enncoded as UTF-8.
-  * @see https://www.openarchives.org/OAI/openarchivesprotocol.html#XMLResponse
-  *
-  * TODO: Handle failed HTTP request.
-  */
-  def getStringResponse(url: URL) : String = {
-    IOUtils.toString(url, "UTF-8")
   }
 }

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/OaiResponseBuilder.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/OaiResponseBuilder.scala
@@ -1,0 +1,91 @@
+package dpla.ingestion3.harvesters.oai
+
+import java.net.URL
+import dpla.ingestion3.harvesters.OaiQueryUrlBuilder
+import org.apache.commons.io.IOUtils
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SQLContext
+import scala.annotation.tailrec
+
+/*
+ * This class handles requests to the OAI feed.
+ * It partitions data at strategic points.
+ */
+class OaiResponseBuilder (@transient val sqlContext: SQLContext)
+  extends Serializable {
+
+  val urlBuilder = new OaiQueryUrlBuilder
+
+  // Get one to many pages of records.
+  def getRecords(oaiParams: Map[String, String]): RDD[String] = {
+    val response = getMultiPageResponse(oaiParams)
+    sqlContext.sparkContext.parallelize(response)
+  }
+
+  // Get one to many pages of records from given sets.
+  def getRecordsBySets(baseParams: Map[String, String],
+                    sets: Array[String]): RDD[String] = {
+
+    val rdd = sqlContext.sparkContext.parallelize(sets)
+
+    val response: RDD[List[String]] = rdd.map(
+      set => {
+        val oaiParams = baseParams + ("set" -> set)
+        getMultiPageResponse(oaiParams)
+      }
+    )
+
+    response.flatMap(x => x)
+  }
+
+  /*
+    * Get all pages of results from an OAI feed.
+    * Makes an initial call to the feed to get the first page of results.
+    * For this and all subsequent pages, calls the next page if a resumption
+    * token is present.
+    * Returns a single List of single-page responses as Strings.
+    */
+  def getMultiPageResponse(parameters: Map[String, String]): List[String] = {
+
+    @tailrec
+    def loop(data: List[String]): List[String] = {
+
+      val token = OaiResponseProcessor.getResumptionToken(data.head)
+
+      token match {
+        case None => data
+        case Some(token) => {
+          val queryParams = parameters + ("resumptionToken" -> token)
+          val nextResponse = getSinglePageResponse(queryParams)
+          loop(nextResponse :: data)
+        }
+      }
+    }
+
+    val firstResponse = getSinglePageResponse(parameters)
+    loop(List(firstResponse))
+  }
+
+  // Returns a single page response as a single String
+  def getSinglePageResponse(queryParams: Map[String, String]): String = {
+    val url = urlBuilder.buildQueryUrl(queryParams)
+    getStringResponse(url)
+  }
+
+  /**
+    * Executes the request and returns the response
+    *
+    * @param url URL
+    *            OAI request URL
+    * @return String
+    *         String response
+    *
+    *         OAI-PMH XML responses must be enncoded as UTF-8.
+    * @see https://www.openarchives.org/OAI/openarchivesprotocol.html#XMLResponse
+    *
+    *      TODO: Handle failed HTTP request.
+    */
+  def getStringResponse(url: URL) : String = {
+    IOUtils.toString(url, "UTF-8")
+  }
+}

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/OaiResponseProcessor.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/OaiResponseProcessor.scala
@@ -75,7 +75,7 @@ object OaiResponseProcessor {
     *         that there are no more records that can be fetched.
     */
   def getResumptionToken(string: String): Option[String] = {
-    val pattern = """<resumptionToken>(.*)</resumptionToken>""".r
+    val pattern = """<resumptionToken.*>(.*)</resumptionToken>""".r
     pattern.findFirstMatchIn(string) match {
       case Some(m) => Some(m.group(1))
       case None => None


### PR DESCRIPTION
This adds the capability to harvest sets from an OAI feed. Per the scope of this ticket, sets names are passed into the `OaiHarversterMain` from the command line.

A couple points of interest:
* A new class, `OaiResponseBuilder` handles responses to the OAI feed.  It also takes on all of the partitioning logic associated with constructing the requests and handling the responses.  It contains some logic that was previously in `OaiRelation`.
* The process of fetching sets from the OAI feed is parallelized, which greatly improves the speed of harvest.  I harvested all our sets from `artstor` in 18 minutes (128,098 records at 118 records per second).
* I tried re-partitioning the fetched records pages before beginning the process of parsing out XML records (to deal with any potential skew).  This did not help performance, and in fact worsened it a little bit.
* `OaiHarvesterMain`defines a `def main(args: Array[String])` method instead of extending `App` to fix closure issues when serializing.

This has been tested locally.  It addresses [ticket DT-1280](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1280).

