### PR TITLE
harvest primary source sets

### DIFF
--- a/src/main/scala/dpla/ingestion3/PssHarvesterMain.scala
+++ b/src/main/scala/dpla/ingestion3/PssHarvesterMain.scala
@@ -1,0 +1,81 @@
+package dpla.ingestion3
+
+import java.io.File
+
+import dpla.ingestion3.utils.Utils
+import com.databricks.spark.avro._
+import org.apache.log4j.LogManager
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions._
+
+
+/**
+  * Entry point for running a Primary Source Set (PSS) harvest
+  *
+  * args Output directory: String
+  *             PSS URL: String
+  */
+object PssHarvesterMain {
+
+  val schemaStr =
+    """{
+        "namespace": "la.dp.avro",
+        "type": "primary source set",
+        "doc": "",
+        "fields": [
+          {"name": "id", "type": "string"},
+          {"name": "document", "type": "string"},
+          {"name": "mimetype", "type": { "name": "MimeType",
+           "type": "enum", "symbols": ["application_json", "application_xml", "text_turtle"]}
+           }
+        ]
+      }
+    """//.stripMargin
+
+  val logger = LogManager.getLogger(PssHarvesterMain.getClass)
+
+  def main(args: Array[String]): Unit = {
+
+    validateArgs(args)
+    println(schemaStr)
+
+    val outputFile = args(0)
+    val endpoint = args(1)
+
+    Utils.deleteRecursively(new File(outputFile))
+
+    val sparkConf = new SparkConf().setAppName("PSS Harvest")
+    val spark = SparkSession.builder().config(sparkConf).getOrCreate()
+    val sc = spark.sparkContext
+
+    val start = System.currentTimeMillis()
+
+    val results = spark.read
+      .format("dpla.ingestion3.harvesters.pss")
+      .load(endpoint)
+
+    val dataframe = results.withColumn("mimetype", lit("application_json"))
+
+    val recordsHarvestedCount = dataframe.count()
+
+    dataframe.write
+      .format("com.databricks.spark.avro")
+      .option("avroSchema", schemaStr)
+      .avro(outputFile)
+
+    sc.stop()
+
+    val end = System.currentTimeMillis()
+
+    Utils.printResults((end-start),recordsHarvestedCount)
+  }
+
+  def validateArgs(args: Array[String]) = {
+    // Complains about not being typesafe...
+    if(args.length < 2) {
+      logger.error("Bad number of args: <OUTPUT FILE>, <PSS URL>")
+      sys.exit(-1)
+    }
+  }
+}

--- a/src/main/scala/dpla/ingestion3/harvesters/pss/DefaultSource.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/pss/DefaultSource.scala
@@ -1,0 +1,13 @@
+package dpla.ingestion3.harvesters.pss
+
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.sources._
+
+class DefaultSource extends RelationProvider {
+
+  override def createRelation(sqlContext: SQLContext,
+                              parameters: Map[String, String]) : PssRelation = {
+
+    new PssRelation(parameters)(sqlContext)
+  }
+}

--- a/src/main/scala/dpla/ingestion3/harvesters/pss/PssRelation.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/pss/PssRelation.scala
@@ -1,0 +1,41 @@
+package dpla.ingestion3.harvesters.pss
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.sources._
+import org.apache.spark.sql.types._
+import org.apache.spark.rdd.RDD
+
+/*
+ * This class requests a PSS response via the `PssResponseBuilder`.
+ * It constructs a DataFrame from the response.
+ */
+class PssRelation (parameters: Map[String, String])
+                  (@transient val sqlContext: SQLContext)
+  extends BaseRelation with TableScan {
+
+  // Required properties.
+  assume(parameters.get("path").isDefined)
+
+  val endpoint = parameters("path")
+
+  /*
+   * Get partitioned PSS data.
+   * The first value of the response tuple is the set ID (ie. slug).
+   * The second value is the full text of the pss metadata record.
+   */
+  def sets: RDD[(String, String)] = {
+    val pssResponseBuilder = new PssResponseBuilder(sqlContext)
+    pssResponseBuilder.getSets(endpoint)
+  }
+
+  // Set the schema for the DataFrame that will be returned on load.
+  override def schema: StructType = {
+    StructType(Seq(StructField("id", StringType, true),
+      StructField("document", StringType, true)))
+  }
+
+  // Build the rows for the DataFrame.
+  override def buildScan(): RDD[Row] = {
+    sets.map { case (id, set)  => Row(id, set) }
+  }
+}

--- a/src/main/scala/dpla/ingestion3/harvesters/pss/PssResponseBuilder.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/pss/PssResponseBuilder.scala
@@ -1,0 +1,60 @@
+package dpla.ingestion3.harvesters.pss
+
+import java.net.URL
+import org.apache.commons.io.IOUtils
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SQLContext
+
+/*
+ * This class handles requests to the PSS feed.
+ * It partitions data at strategic points.
+ */
+class PssResponseBuilder (@transient val sqlContext: SQLContext)
+  extends Serializable {
+
+  // Get all sets.
+  def getSets(endpoint: String): RDD[(String,String)] = {
+    // The given endpoint returns a list of all set URLs.
+    val url = new URL(endpoint)
+    val allSets = getStringResponse(url)
+    val setEndpoints = PssResponseProcessor.getSetEndpoints(allSets)
+    val setEndpointsRdd = sqlContext.sparkContext.parallelize(setEndpoints)
+    setEndpointsRdd.map(setEndpoint => getSet(setEndpoint))
+  }
+
+  // Get a single set.
+  def getSet(endpoint: String): (String, String) = {
+    // The given endpoint contains metadata for the source, along with a
+    // list of URLs for component parts of the set.
+    val setUrl = new URL(endpoint)
+    val setId = PssResponseProcessor.getSetId(endpoint)
+    val set = getStringResponse(setUrl)
+    val parts = getParts(set)
+    val setWithParts = PssResponseProcessor.combineSetAndParts(set, parts)
+    (setId, setWithParts)
+  }
+
+  // Get all component parts of a set (ie. sources and teaching guides).
+  def getParts(set: String): List[String] = {
+    // The given endpoints contain metadata for component parts of a set.
+    val endpoints = PssResponseProcessor.getPartEndpoints(set)
+    endpoints.map(endpoint => {
+      val url = new URL(endpoint)
+      getStringResponse(url)
+    })
+  }
+
+  /**
+    * Executes the request and returns the response
+    *
+    * @param url URL
+    *            PSS request URL
+    * @return String
+    *         String response
+    *
+    *      TODO: Handle failed HTTP request.
+    */
+  def getStringResponse(url: URL) : String = {
+    IOUtils.toString(url, "UTF-8")
+  }
+}

--- a/src/main/scala/dpla/ingestion3/harvesters/pss/PssResponseProcessor.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/pss/PssResponseProcessor.scala
@@ -1,0 +1,64 @@
+package dpla.ingestion3.harvesters.pss
+
+
+import org.apache.log4j.LogManager
+import org.json4s.{JValue, JArray, DefaultFormats}
+import org.json4s.jackson.JsonMethods._
+import org.json4s.jackson.Serialization
+
+/*
+ * This class parses primary source set response data during harvest.
+ */
+object PssResponseProcessor {
+  private[this] val logger = LogManager.getLogger("OaiHarvester")
+
+  // Setting formats allows you to parse (ie. extract) Strings from JValues.
+  implicit val formats = DefaultFormats
+
+  // Parse the set endpoints (ie. urls) from an ItemList of all sets.
+  def getSetEndpoints(sets: String): List[String] = {
+    val json: JValue = parse(sets)
+    val endpoints: List[JValue] = (json \\ "itemListElement" \\ "@id").children
+    endpoints.map(j => j.extract[String].concat(".json"))
+  }
+
+  // Parse the part endpoints (ie. urls) from a JSON set.
+  // Return endpoints with .json extensions.
+  def getPartEndpoints(set: String): List[String] = {
+    val json: JValue = parse(set)
+    val endpoints: List[JValue] = (json \\ "hasPart" \\ "@id").children
+    endpoints.map(j => j.extract[String].concat(".json"))
+  }
+
+  // Combine a set with its components parts.
+  def combineSetAndParts(set: String, parts: List[String]): String = {
+    val jsonSet: JValue = parse(set)
+    val jsonParts: JArray = JArray(parts.map(part => parse(part)))
+    val cleanJsonParts: JValue = cleanParts(jsonParts)
+
+    // The set has minimal metadata for its component parts in "hasPart".
+    // Replace this minimal metadata with the full parts metadata.
+    val setWithParts: JValue = jsonSet.transformField {
+      case ("hasPart", _) => ("hasPart", cleanJsonParts)
+    }
+    // Convert JValue to String.
+    Serialization.write(setWithParts)
+  }
+
+  // Remove @context from each part.
+  // Identical @context values are present in the set.
+  def cleanParts(parts: JArray): JValue = {
+    parts.removeField {
+      case("@context", _) => true
+      case _ => false
+    }
+  }
+
+  // Parse the set ID (ie. slug) from its endpoint (ie. url).
+  def getSetId(endpoint: String): String = {
+    val id = endpoint.split("/").lastOption.getOrElse {
+      throw new RuntimeException ("""Could not get set ID from: """ + endpoint)
+    }
+    id.stripSuffix(".json")
+  }
+}


### PR DESCRIPTION
This harvests primary source sets.  It closely follows the format and paradigms of the OAI harvester, so we can start to see how well they generalize.  The harvester fetches `JSON` files over `HTTP`.   It writes out an `avro` file with the set ID and a String dump of all the metadata for each set.

Note that I am not minting a DPLA ID - I'm just grabbing the ID that's used in the primary source sets app.  I think this okay for now since we don't have a mapping yet, but let me know if you think I should be minting a new ID here.

This PR depends on [primary-source-sets#186](https://github.com/dpla/primary-source-sets/pull/186), which adds a `JSON` file listing all sets.  The primary-source-sets app already makes `JSON` files available for individual sets, sources, and teaching guides.

This has been tested with a local implementation of ingestion3, along with primary-source-sets#186 deployed to staging. It addresses [ticket 1393](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1393).