### PR TITLE
remove unused import from oai harvester

### DIFF
--- a/src/main/scala/dpla/ingestion3/OaiHarvesterMain.scala
+++ b/src/main/scala/dpla/ingestion3/OaiHarvesterMain.scala
@@ -6,7 +6,7 @@ import dpla.ingestion3.utils.Utils
 import com.databricks.spark.avro._
 import org.apache.log4j.LogManager
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions._
 import org.apache.spark.storage.StorageLevel
 


### PR DESCRIPTION
This removes an unused import from the OAI harvester.  I forgot to delete it back when I submitted the original PR.