### PR TITLE
harvest oai sets

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/oai/OaiResponseBuilder.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/OaiResponseBuilder.scala
@@ -17,13 +17,13 @@ class OaiResponseBuilder (@transient val sqlContext: SQLContext)
   val urlBuilder = new OaiQueryUrlBuilder
 
   // Get one to many pages of records.
-  def getRecords(oaiParams: Map[String, String]): RDD[String] = {
+  def getResponse(oaiParams: Map[String, String]): RDD[String] = {
     val response = getMultiPageResponse(oaiParams)
     sqlContext.sparkContext.parallelize(response)
   }
 
   // Get one to many pages of records from given sets.
-  def getRecordsBySets(baseParams: Map[String, String],
+  def getResponseBySets(baseParams: Map[String, String],
                     sets: Array[String]): RDD[String] = {
 
     val rdd = sqlContext.sparkContext.parallelize(sets)


### PR DESCRIPTION
This enables the OAI harvester to fetch sets.  Before, it could only fetch records.  This is necessary to harvest DPLA exhibitions.

I renamed some methods to generalize away from the term "records", since we are now dealing with both sets and records.

This has been tested locally against the exhibitions OAI feed currently deployed to staging (https://staging.dp.la/exhibitions/oai-pmh-repository/request?verb=ListSets).  The OAI feed hasn't been activated yet on exhibitions prod.  Here is a sample call:

```
[PATH_TO_SPARK_SUBMIT]
--master local[3] 
--class dpla.ingestion3.OaiHarvesterMain 
--packages com.databricks:spark-avro_2.11:3.2.0 
[PATH TO JAR]
[PATH TO OUTPUT AVRO FILE]
https://staging.dp.la/exhibitions/oai-pmh-repository/request 
oai_dc 
ListSets 
DPLA
```

A couple things to note about this call: the `metadataPrefix` value "oai_dc" is ultimately ignored, as it is not allowed when fetching sets from OAI-PMH; however, since we lack a sophisticated way of making command line params optional, you have to put some value there (even an empty string will do).  `DPLA` serves as the provider name.