### PR TITLE
construct OAI URL with port number

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/QueryUrlBuilder.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/QueryUrlBuilder.scala
@@ -40,6 +40,7 @@ class OaiQueryUrlBuilder extends QueryUrlBuilder with Serializable {
     val urlParams = new URIBuilder()
       .setScheme(url.getProtocol)
       .setHost(url.getHost)
+      .setPort(url.getPort)
       .setPath(url.getPath)
       .setParameter("verb", verb)
 


### PR DESCRIPTION
This includes the port number when constructing a URL in the OAI harvester.  It has been tested locally with the North Carolina feed.  This addresses [ticket DT-1425](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1425).