### PR TITLE
split oai harvester into three discrete tasks:

### DIFF
--- a/src/main/scala/dpla/ingestion3/OaiRecordHarvesterMain.scala
+++ b/src/main/scala/dpla/ingestion3/OaiRecordHarvesterMain.scala
@@ -1,0 +1,116 @@
+package dpla.ingestion3
+
+import java.io.File
+
+import dpla.ingestion3.utils.Utils
+import com.databricks.spark.avro._
+import org.apache.log4j.LogManager
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions._
+import org.apache.spark.storage.StorageLevel
+
+
+/**
+  * Entry point for running an OAI harvest of records
+  *
+  * args Output directory: String
+  *             OAI URL: String
+  *             Metadata Prefix: String oai_dc oai_qdc, mods, MODS21 etc.
+  *             Provider: Provider name (we need to standardize this).
+  *             Sets (Optional): Comma-separated String of sets to harvest from.
+  */
+object OaiRecordHarvesterMain {
+
+  val schemaStr =
+    """{
+        "namespace": "la.dp.avro",
+        "type": "record",
+        "name": "OriginalRecord.v1",
+        "doc": "",
+        "fields": [
+          {"name": "id", "type": "string"},
+          {"name": "document", "type": "string"},
+          {"name": "provider", "type": "string"},
+          {"name": "mimetype", "type": { "name": "MimeType",
+           "type": "enum", "symbols": ["application_json", "application_xml", "text_turtle"]}
+           }
+        ]
+      }
+    """//.stripMargin // TODO we need to template the document field so we can record info there
+
+  val logger = LogManager.getLogger(OaiRecordHarvesterMain.getClass)
+
+  def main(args: Array[String]): Unit = {
+
+    validateArgs(args)
+    println(schemaStr)
+
+    val outputFile = args(0)
+    val endpoint = args(1)
+    val metadataPrefix = args(2)
+    val provider = args(3)
+
+    // This is an Option (as opposed to a String) b/c the param args(4) is optional.
+    val sets: Option[String] = if (args.isDefinedAt(4)) Some(args(4)) else None
+
+    val verb = "ListRecords"
+
+    Utils.deleteRecursively(new File(outputFile))
+
+    // Initiate spark session.
+    val sparkConf = new SparkConf().setAppName("Oai Record Harvest")
+    val spark = SparkSession.builder().config(sparkConf).getOrCreate()
+    val sc = spark.sparkContext
+
+    val start = System.currentTimeMillis()
+
+    val baseOptions = Map("metadataPrefix" -> metadataPrefix, "verb" -> verb)
+    val readerOptions = getReaderOptions(baseOptions, sets)
+
+    val results = spark.read
+      .format("dpla.ingestion3.harvesters.oai")
+      .options(readerOptions)
+      .load(endpoint)
+
+    results.persist(StorageLevel.DISK_ONLY)
+
+    val dataframe = results.withColumn("provider", lit(provider))
+      .withColumn("mimetype", lit("application_xml"))
+
+    val recordsHarvestedCount = dataframe.count()
+
+    // This task may require a large amount of driver memory.
+    dataframe.write
+      .format("com.databricks.spark.avro")
+      .option("avroSchema", schemaStr)
+      .avro(outputFile)
+
+    // Stop spark session.
+    sc.stop()
+
+    val end = System.currentTimeMillis()
+
+    Utils.printResults((end-start),recordsHarvestedCount)
+  }
+
+  def validateArgs(args: Array[String]) = {
+    // Complains about not being typesafe...
+    if(args.length < 4 || args.length > 5) {
+      logger.error("Bad number of arguments passed to OAI harvester. Expecting:\n" +
+        "\t<OUTPUT AVRO FILE>\n" +
+        "\t<OAI URL>\n" +
+        "\t<METADATA PREFIX>\n" +
+        "\t<PROVIDER>\n" +
+        "\t<SETS> (optional)")
+    }
+  }
+
+  def getReaderOptions(baseOptions: Map[String, String],
+                       sets: Option[String]): Map[String, String] = {
+    sets match {
+      case Some(sets) => baseOptions + ("sets" -> sets)
+      case None => baseOptions
+    }
+  }
+}

--- a/src/main/scala/dpla/ingestion3/OaiSetHarvesterMain.scala
+++ b/src/main/scala/dpla/ingestion3/OaiSetHarvesterMain.scala
@@ -12,15 +12,13 @@ import org.apache.spark.storage.StorageLevel
 
 
 /**
-  * Entry point for running an OAI harvest
+  * Entry point for running an OAI harvest of sets
   *
   * args Output directory: String
   *             OAI URL: String
-  *             Metadata Prefix: String oai_dc oai_qdc, mods, MODS21 etc.
-  *             OAI Verb: String ListRecords, ListSets etc.
-  *             Provider: Provider name (we need to standardize this)
+  *             Provider: Provider name (we need to standardize this).
   */
-object OaiHarvesterMain {
+object OaiSetHarvesterMain {
 
   val schemaStr =
     """{
@@ -39,7 +37,7 @@ object OaiHarvesterMain {
       }
     """//.stripMargin // TODO we need to template the document field so we can record info there
 
-  val logger = LogManager.getLogger(OaiHarvesterMain.getClass)
+  val logger = LogManager.getLogger(OaiSetHarvesterMain.getClass)
 
   def main(args: Array[String]): Unit = {
 
@@ -48,21 +46,20 @@ object OaiHarvesterMain {
 
     val outputFile = args(0)
     val endpoint = args(1)
-    val metadataPrefix = args(2)
-    val verb = args(3)
-    val provider = args(4)
-    val sets: Option[String] = if (args.isDefinedAt(5)) Some(args(5)) else None
+    val provider = args(2)
+
+    val verb = "ListSets"
 
     Utils.deleteRecursively(new File(outputFile))
 
-    val sparkConf = new SparkConf().setAppName("Oai Harvest")
+    // Initiate spark session.
+    val sparkConf = new SparkConf().setAppName("Oai Set Harvest")
     val spark = SparkSession.builder().config(sparkConf).getOrCreate()
     val sc = spark.sparkContext
 
     val start = System.currentTimeMillis()
 
-    val baseOptions = Map( "metadataPrefix" -> metadataPrefix, "verb" -> verb)
-    val readerOptions = getReaderOptions(baseOptions, sets)
+    val readerOptions = Map("verb" -> verb)
 
     val results = spark.read
       .format("dpla.ingestion3.harvesters.oai")
@@ -82,6 +79,7 @@ object OaiHarvesterMain {
       .option("avroSchema", schemaStr)
       .avro(outputFile)
 
+    // Stop spark session
     sc.stop()
 
     val end = System.currentTimeMillis()
@@ -91,11 +89,11 @@ object OaiHarvesterMain {
 
   def validateArgs(args: Array[String]) = {
     // Complains about not being typesafe...
-    if(args.length < 5) {
-      logger.error("Bad number of args: <OUTPUT FILE>, <OAI URL>, " +
-        "<METADATA PREFIX>, <OAI VERB>, <PROVIDER>, " +
-        "<SETS> (optional)")
-      sys.exit(-1)
+    if(args.length != 3) {
+      logger.error("Bad number of arguments passed to OAI harvester. Expecting:\n" +
+        "\t<OUTPUT AVRO FILE>\n" +
+        "\t<OAI URL>\n" +
+        "\t<PROVIDER>\n")
     }
   }
 

--- a/src/main/scala/dpla/ingestion3/OaiSetListGeneratorMain.scala
+++ b/src/main/scala/dpla/ingestion3/OaiSetListGeneratorMain.scala
@@ -1,0 +1,50 @@
+package dpla.ingestion3
+
+import com.databricks.spark.avro._
+import org.apache.log4j.LogManager
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+
+/**
+  * Entry point for generating an list of OAI sets.
+  * The set list can be input for OaiRecordHarvesterMain
+  *
+  * args Input directory: String
+  */
+object OaiSetListGeneratorMain {
+
+  val logger = LogManager.getLogger(OaiSetListGeneratorMain.getClass)
+
+  def main(args: Array[String]): Unit = {
+
+    validateArgs(args)
+
+    val inputFile = args(0)
+
+    // Initiate spark session.
+    val sparkConf = new SparkConf().setAppName("Oai Set List Generator")
+    val spark = SparkSession.builder().config(sparkConf).getOrCreate()
+    val sc = spark.sparkContext
+
+    val dataFrame = spark.read.avro(inputFile)
+
+    // Convert the ID column into an Array of IDs.
+    val setArray = dataFrame.select("id").rdd.map(r => r.getString(0)).collect
+
+    // Convert Array to comma-separated String.
+    val string = setArray.mkString(",")
+
+    println(string)
+
+    // Stop spark session
+    sc.stop()
+  }
+
+  def validateArgs(args: Array[String]) = {
+    // Complains about not being typesafe...
+    if(args.length != 1) {
+      logger.error("Bad number of arguments passed to OAI harvester. Expecting:\n" +
+        "\t<INPUT AVRO FILE>\n")
+    }
+  }
+}

--- a/src/main/scala/dpla/ingestion3/harvesters/QueryUrlBuilder.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/QueryUrlBuilder.scala
@@ -19,20 +19,11 @@ class OaiQueryUrlBuilder extends QueryUrlBuilder with Serializable {
     // Required properties, not sure if this is the right style
     assume(params.get("endpoint").isDefined)
     assume(params.get("verb").isDefined)
-    assume(params.get("metadataPrefix").isDefined)
-
-    /*
-     * The following OAI verbs require a metadataPrefix argument.
-     * If an OAI call contains a verb NOT in this list AND a metadataPrefix,
-     * a badArgument errors is returned.
-     *
-     * @see https://www.openarchives.org/OAI/openarchivesprotocol.html#ProtocolMessages
-     */
-    val verbsWithMetadataPrefix = List("GetRecord", "ListIdentifiers", "ListRecords")
-
-    val verb = params("verb")
-    val metadataPrefix = params("metadataPrefix")
     val url = new URL(params("endpoint"))
+    val verb = params("verb")
+
+    // Optional properties.
+    val metadataPrefix: Option[String] = params.get("metadataPrefix")
     val resumptionToken: Option[String] = params.get("resumptionToken")
     val set: Option[String] = params.get("set")
 
@@ -54,18 +45,18 @@ class OaiQueryUrlBuilder extends QueryUrlBuilder with Serializable {
      *   - there is no resumption token (if an OAI call with a resumption token
      *     also contains a set, an OAI badArgument error is returned).
      */
-    if (set.isDefined && !resumptionToken.isDefined) {
-      urlParams.setParameter("set", set.get)
+    if (!resumptionToken.isDefined) {
+      set.foreach(s => urlParams.setParameter("set", s))
     }
 
     /*
      * Set metadataPrefix param if:
-     *   - the verb allows a metadataPrefix argument AND
+     *   - metadataPrefix is defined
      *   - there is no resumption token (if an OAI call with a resumption token
      *     also contains a metadataPrefix, an OAI badArgument error is returned).
      */
-    if(verbsWithMetadataPrefix.contains(verb) && !resumptionToken.isDefined) {
-      urlParams.setParameter("metadataPrefix", metadataPrefix)
+    if (!resumptionToken.isDefined) {
+      metadataPrefix.foreach(prefix => urlParams.setParameter("metadataPrefix", prefix))
     }
 
     urlParams.build.toURL

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/DefaultSource.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/DefaultSource.scala
@@ -4,7 +4,9 @@ import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.sources._
 
 class DefaultSource extends RelationProvider {
-  
+
+  // The parameters must be of type Map[String, String]
+  // @see https://spark.apache.org/docs/1.6.1/api/java/org/apache/spark/ml/source/libsvm/DefaultSource.html
   override def createRelation(sqlContext: SQLContext,
                               parameters: Map[String, String]) : OaiRelation = {
 

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/OaiRelation.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/OaiRelation.scala
@@ -50,7 +50,10 @@ class OaiRelation (parameters: Map[String, String])
     // A ListRecords OAI request must have a metadataPrefix.
     assume(metadataPrefix.isDefined)
 
-    val prefix = if (metadataPrefix.isDefined) metadataPrefix.get else ""
+    val prefix = metadataPrefix match {
+      case Some(prefix) => prefix
+      case None => ""
+    }
 
     val oaiParams = Map("endpoint" -> endpoint,
                         "verb" -> verb,

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/OaiRelation.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/OaiRelation.scala
@@ -16,41 +16,54 @@ class OaiRelation (parameters: Map[String, String])
                   (@transient val sqlContext: SQLContext)
                   extends BaseRelation with TableScan with Serializable {
 
-  // Required properties.
+  // Required properties for all OAI requests.
   assume(parameters.get("path").isDefined)
   assume(parameters.get("verb").isDefined)
-  assume(parameters.get("metadataPrefix").isDefined)
 
   val endpoint = parameters("path")
   val verb = parameters("verb")
-  val metadataPrefix = parameters("metadataPrefix")
 
+  // Optional properties.
+  val metadataPrefix: Option[String] = parameters.get("metadataPrefix")
   val sets: Option[String] = parameters.get("sets")
 
   val oaiResponseBuilder = new OaiResponseBuilder(sqlContext)
+
+  // Get the appropriate response based on the value of the OAI verb.
+  def response: RDD[String] = {
+    verb match {
+      case "ListSets" => setsResponse
+      case "ListRecords" => recordsResponse
+    }
+  }
+
+  def setsResponse: RDD[String] = {
+    val oaiParams =  Map("endpoint" -> endpoint, "verb" -> verb)
+    oaiResponseBuilder.getResponse(oaiParams)
+  }
 
   /*
    * Make appropriate call to OaiResponseBuilder based on presence or absence of
    * sets.
    */
-  def response: RDD[String] = {
+  def recordsResponse: RDD[String] = {
+    // A ListRecords OAI request must have a metadataPrefix.
+    assume(metadataPrefix.isDefined)
+
+    val prefix = if (metadataPrefix.isDefined) metadataPrefix.get else ""
+
+    val oaiParams = Map("endpoint" -> endpoint,
+                        "verb" -> verb,
+                        "metadataPrefix" -> prefix)
+
     sets match {
-      case None => {
-        oaiResponseBuilder.getResponse(oaiParams)
-      }
+      case None => oaiResponseBuilder.getResponse(oaiParams)
       case Some(sets) => {
         val setArray: Array[String] = parseSets(sets)
         oaiResponseBuilder.getResponseBySets(oaiParams, setArray)
       }
     }
   }
-
-  // Params for an OAI request.
-  def oaiParams: Map[String, String] = Map(
-    "endpoint" -> endpoint,
-    "verb" -> verb,
-    "metadataPrefix" -> metadataPrefix
-  )
 
   /*
    * Sets are passed to this class as a comma-separated String.

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/OaiResponseBuilder.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/OaiResponseBuilder.scala
@@ -69,6 +69,7 @@ class OaiResponseBuilder (@transient val sqlContext: SQLContext)
   // Returns a single page response as a single String
   def getSinglePageResponse(queryParams: Map[String, String]): String = {
     val url = urlBuilder.buildQueryUrl(queryParams)
+    println(url) // for testing purposes, can delete later
     getStringResponse(url)
   }
 


### PR DESCRIPTION
This divides the Oai Harvester into three discrete Main tasks:
1. Harvest sets (output = avro dump)
2. Generate set list (input = avro dump of sets; output = comma-separated list of strings printed to command line console)
3. Harvest records (input can include set list generated in step 2)

This accomplished the following objectives:
1. We can now generate a whitelist of all sets to be used in a record harvest (see DT-1426).
2. The interfaces are simpler.  

In future, we may want to build some sort of wrapper around the three harvesting tasks, but for now, this will allow us to complete harvests.