### PR TITLE
Add named command line arguments to OAI harvester

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,5 +32,6 @@ libraryDependencies ++= Seq(
   "org.eclipse.rdf4j" % "rdf4j-model" % "2.2",
   "org.eclipse.rdf4j" % "rdf4j-rio-api" % "2.2",
   "org.eclipse.rdf4j" % "rdf4j-rio-turtle" % "2.2",
-  "org.scalaj" % "scalaj-http_2.11" % "2.3.0"
+  "org.scalaj" % "scalaj-http_2.11" % "2.3.0",
+  "org.rogach" % "scallop_2.11" % "3.0.3"
 )

--- a/src/main/scala/dpla/ingestion3/confs/OaiHarvesterConf.scala
+++ b/src/main/scala/dpla/ingestion3/confs/OaiHarvesterConf.scala
@@ -1,0 +1,55 @@
+package dpla.ingestion3.confs
+
+import org.rogach.scallop.{ScallopConf, ScallopOption}
+
+
+/**
+  * https://github.com/scallop/scallop/wiki
+  *
+  * Arguments to be passed into the OAI-PMH harvester
+  *
+  * Output directory: String
+  * OAI URL: String
+  * Metadata Prefix: String oai_dc oai_qdc, mods, MODS21 etc.
+  * Provider: Provider name (we need to standardize this).
+  * Sets (Optional): Comma-separated String of sets to harvest from.
+  * Blacklist (Optional): Comma-separated String of sets to exclude from harvest
+  * sparkMaster (Optional): If omitted the defaults to local[*]
+  */
+
+class OaiHarvesterConf(arguments: Seq[String]) extends ScallopConf(arguments) {
+  // Required parameters
+  val outputDir: ScallopOption[String] = opt[String]("outputDir",
+    required = true,
+    noshort = true,
+    validate = (_.nonEmpty))
+  val endpoint: ScallopOption[String] = opt[String]("endpoint",
+    required = true,
+    noshort = true,
+    // TODO is there a better validation of the URL rather than nonEmpty?
+    validate = (_.nonEmpty))
+  val prefix: ScallopOption[String] = opt[String]("prefix",
+    required = true,
+    noshort = true,
+    validate = (_.nonEmpty))
+  val provider: ScallopOption[String] = opt[String]("provider",
+    required = true,
+    noshort = true,
+    validate = (_.nonEmpty))
+  // Optional parameters
+  val sets: ScallopOption[String] = opt[String]("sets",
+    required = false,
+    noshort = true,
+    validate = (_.nonEmpty))
+  val blacklist: ScallopOption[String] = opt[String]("blacklist",
+    required = false,
+    noshort = true,
+    validate = (_.nonEmpty))
+  // If a master URL is not provider then default to local[*]
+  val sparkMaster: ScallopOption[String] = opt[String]("sparkMaster",
+    required = false,
+    noshort = true,
+    default = Some("local[*]"))
+
+  verify()
+}


### PR DESCRIPTION
Uses Scallop (https://github.com/scallop/scallop/wiki) to implement named command line arguments for the OAI harvester. 

Arguments to be passed into the OAI-PMH harvester
  * Output directory: String
  * OAI URL: String
  * Metadata Prefix: String oai_dc oai_qdc, mods, MODS21 etc.
  * Provider: Provider name (we need to standardize this).
  * Sets (Optional): Comma-separated String of sets to harvest from.
  * Blacklist (Optional): Comma-separated String of sets to exclude from harvest
  * sparkMaster (Optional): If omitted it defaults to local[*]