### PR TITLE
fix namespace in all schema strings

### DIFF
--- a/src/main/resources/avro/OriginalRecord.avsc
+++ b/src/main/resources/avro/OriginalRecord.avsc
@@ -1,5 +1,5 @@
 {
-  "namespace": "la.dp.avro.MAP_3.1",
+  "namespace": "dpla.avro.MAP_3.1",
   "type": "record",
   "name": "OriginalRecord",
   "doc": "",

--- a/src/main/scala/dpla/ingestion3/EnricherMain.scala
+++ b/src/main/scala/dpla/ingestion3/EnricherMain.scala
@@ -37,7 +37,7 @@ object EnricherMain {
   val schemaStr: String =
     """
     {
-      "namespace": "la.dp.avro",
+      "namespace": "dpla.avro",
       "type": "record",
       "name": "MAPRecord.v1",
       "doc": "Prototype enriched record",

--- a/src/main/scala/dpla/ingestion3/OaiHarvesterMain.scala
+++ b/src/main/scala/dpla/ingestion3/OaiHarvesterMain.scala
@@ -41,7 +41,7 @@ object OaiHarvesterMain {
   val setSchemaStr =
     """{
         "namespace": "dpla.avro",
-        "type": "record",
+        "type": "set",
         "name": "OriginalRecord.v1",
         "doc": "",
         "fields": [

--- a/src/main/scala/dpla/ingestion3/PssHarvesterMain.scala
+++ b/src/main/scala/dpla/ingestion3/PssHarvesterMain.scala
@@ -20,7 +20,7 @@ object PssHarvesterMain {
 
   val schemaStr =
     """{
-        "namespace": "la.dp.avro",
+        "namespace": "dpla.avro",
         "type": "primary source set",
         "doc": "",
         "fields": [

--- a/src/main/scala/dpla/ingestion3/RsHarvesterMain.scala
+++ b/src/main/scala/dpla/ingestion3/RsHarvesterMain.scala
@@ -31,7 +31,7 @@ object RsHarvesterMain extends App {
 
   val schemaStr =
     """{
-        "namespace": "la.dp.avro",
+        "namespace": "dpla.avro",
         "type": "record",
         "name": "OriginalRecord.v1",
         "doc": "",

--- a/src/main/scala/dpla/ingestion3/indexer/IndexerMain.scala
+++ b/src/main/scala/dpla/ingestion3/indexer/IndexerMain.scala
@@ -13,7 +13,7 @@ object IndexerMain {
   // See https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Ingestion+3+Storage+Specification
   val schema: String = """
   | {
-  |   "namespace": "la.dp.avro.MAP_3.1",
+  |   "namespace": "dpla.avro.MAP_3.1",
   |   "type": "record",
   |   "name": "IndexRecord.v1",
   |   "doc": "",


### PR DESCRIPTION
This changes the namespace `la.dp` to `dpla` wherever it occurs in schema strings.  It also fixes the `type` value for OAI-harvested sets.