### PR TITLE
First crack at fatal error handling

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,6 +1,9 @@
-log4j.appender.myConsoleAppender=org.apache.log4j.ConsoleAppender
-log4j.appender.myConsoleAppender.layout=org.apache.log4j.PatternLayout
-log4j.appender.myConsoleAppender.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
+
+log4j.appender.stdout = org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Threshold = ERROR
+log4j.appender.stdout.Target   = System.out
+log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern = %-5p %d [%t][%F:%L] : %m%n
 
 log4j.appender.RollingAppender=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.RollingAppender.File=log/spark.log
@@ -16,13 +19,13 @@ log4j.appender.RollingAppenderU.layout.ConversionPattern=[%p] %d %c %M - %m%n
 
 
 # By default, everything goes to console and file
-log4j.rootLogger=FATAL, RollingAppender, myConsoleAppender
+log4j.rootLogger=ERROR, RollingAppender, stdout
 
 log4j.logger.org.spark_project.jetty.server=off, stdout
 log4j.logger.org.apache.hadoop.fs.FileSystem=off, stdout
 
 # My custom logging goes to another file
-log4j.logger.myLogger=FATAL, RollingAppenderU
+log4j.logger.myLogger=ERROR, RollingAppenderU
 
 # The noisier spark logs go to file only
 log4j.logger.spark.storage=INFO, RollingAppender

--- a/src/main/scala/dpla/ingestion3/confs/OaiHarvesterConf.scala
+++ b/src/main/scala/dpla/ingestion3/confs/OaiHarvesterConf.scala
@@ -1,7 +1,7 @@
 package dpla.ingestion3.confs
 
 import org.rogach.scallop.{ScallopConf, ScallopOption}
-
+import dpla.ingestion3.utils.Utils.validateUrl
 
 /**
   * https://github.com/scallop/scallop/wiki
@@ -27,16 +27,13 @@ class OaiHarvesterConf(arguments: Seq[String]) extends ScallopConf(arguments) {
   val outputDir: ScallopOption[String] = opt[String]("outputDir",
     required = true,
     noshort = true,
-    validate = (_.nonEmpty))
+    validate = _.nonEmpty)
   val endpoint: ScallopOption[String] = opt[String]("endpoint",
     required = true,
-    noshort = true,
-    // TODO is there a better validation of the URL rather than nonEmpty?
-    validate = (_.nonEmpty))
+    noshort = true)
   val verb: ScallopOption[String] = opt[String]("verb",
     required = true,
-    noshort = true,
-    validate = (_.nonEmpty))
+    noshort = true)
   val provider: ScallopOption[String] = opt[String]("provider",
     required = true,
     noshort = true)
@@ -44,7 +41,7 @@ class OaiHarvesterConf(arguments: Seq[String]) extends ScallopConf(arguments) {
   val prefix: ScallopOption[String] = opt[String]("prefix",
     required = false,
     noshort = true,
-    validate = (_.nonEmpty))
+    validate = _.nonEmpty)
   val harvestAllSets: ScallopOption[String] = opt[String]("harvestAllSets",
     required = false,
     noshort = true,
@@ -52,11 +49,11 @@ class OaiHarvesterConf(arguments: Seq[String]) extends ScallopConf(arguments) {
   val setlist: ScallopOption[String] = opt[String]("setlist",
     required = false,
     noshort = true,
-    validate = (_.nonEmpty))
+    validate = _.nonEmpty)
   val blacklist: ScallopOption[String] = opt[String]("blacklist",
     required = false,
     noshort = true,
-    validate = (_.nonEmpty))
+    validate = _.nonEmpty)
   // If a master URL is not provider then default to local[*]
   val sparkMaster: ScallopOption[String] = opt[String]("sparkMaster",
     required = false,

--- a/src/main/scala/dpla/ingestion3/utils/Utils.scala
+++ b/src/main/scala/dpla/ingestion3/utils/Utils.scala
@@ -1,6 +1,7 @@
 package dpla.ingestion3.utils
 
 import java.io.File
+import java.net.URL
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -11,11 +12,42 @@ import scala.xml.Node
 import java.util.concurrent.TimeUnit
 
 import org.apache.commons.codec.digest.DigestUtils
+import org.apache.http.client.fluent.Request
+
+import scala.util.{Failure, Success, Try}
 
 /**
   * Created by scott on 1/18/17.
   */
 object Utils {
+  /**
+    * Accepts a String URL and validates it by making a request and returning true only if
+    * the response code is a 200.
+    *
+    * @param str
+    * @return
+    */
+  def validateUrl(str: String): Boolean = {
+    def url() : Try[URL] = Try {
+      new URL(str) // with throw exception if string is not valid URL
+    }
+
+    url() match {
+      case Success(endpoint) => {
+        val code = Request.Get(endpoint.toURI)
+          .execute()
+          .returnResponse()
+          .getStatusLine
+          .getStatusCode
+        // TODO Other appropriate codes or something like (code / 100) match case 2 => ?
+        code match {
+          case 200 => true
+          case _ => false
+        }
+      }
+      case Failure(_) => false
+    }
+  }
 
   /**
     * The only shared method between harvester implementations. Generates

--- a/src/test/scala/dpla/ingestion3/harvesters/oai/DefaultSourceTest.scala
+++ b/src/test/scala/dpla/ingestion3/harvesters/oai/DefaultSourceTest.scala
@@ -7,7 +7,7 @@ import org.scalatest._
   */
 class DefaultSourceTest extends FlatSpec {
   val source = new DefaultSource
-  val endpoint = "http://repox.example.edu:8080/repox/OAIHandler"
+  val endpoint = "http://google.com" // TODO replace with HTTP simulation
   val verb = "ListRecords"
   val list = "manuscripts, newspapers, maps"
   val prefix = "mods"
@@ -17,8 +17,9 @@ class DefaultSourceTest extends FlatSpec {
     val params = Map("foo" -> "bar")
     assertThrows[Exception](source.getEndpoint(params))
   }
-  it should "return endpoint as String" in {
-    val params = Map("path" -> endpoint)
+  // TODO rewrite with HTTP simulation
+  it should "return endpoint as String if the endpoint is provided and reachable" in {
+    val params = Map("endpoint" -> endpoint)
     assert(source.getEndpoint(params) === endpoint)
   }
 
@@ -26,7 +27,7 @@ class DefaultSourceTest extends FlatSpec {
     val params = Map("foo" -> "bar")
     assertThrows[Exception](source.getVerb(params))
   }
-  it should "return endpoint as String" in {
+  it should "return verb as String" in {
     val params = Map("verb" -> verb)
     assert(source.getVerb(params) === verb)
   }


### PR DESCRIPTION
* Updates configuration of log4j to send error messages to console
* Adds `endpoint` param to `readerOptions` so it can be validated in DefaultSource
* Wraps the invocation of the harvest in a try/catch block
* Adds validation to DefaultSource for the `verb` and `endpoint` params. For `verb` the parameter must be provided and for right now can only be either `ListRecords` or `ListSets`. Other verbs may be supported at a later date. For `endpoint` it checks that a URL object can be created from the string and the url is reachable. 
* Adds a `validateUrl` method to Utils that performs the endpoint validation described above.
