### PR TITLE
always get set data when harvesting records

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/oai/OaiResponseProcessor.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/OaiResponseProcessor.scala
@@ -54,6 +54,18 @@ object OaiResponseProcessor {
     }
 
   /**
+    * Get all set ids from a single record.
+    * Return empty Seq if none exist.
+    *
+    * @return Seq[String]
+    *         The set ids.
+    */
+  def getSetIdsFromRecord(xml: NodeSeq): Seq[String] = {
+    val sets = xml \\ "setSpec"
+    sets.map(s => s.text)
+  }
+
+  /**
     * Get the error property if it exists
     *
     * @return Option[String]


### PR DESCRIPTION
Before, for an OAI harvest, set data was collected for each record ONLY in the following circumstances:

1. A setlist is given
2. A set blacklist is given
3. `harvestAllSets` is set to `true`

This PR gets set data for records by default.

This has been tested locally with a hub in which all records belong to at least one set (Illinois), and a hub in which sets are not implemented (Kentucky).  This has _not_ been tested for a hub in which only _some_ records belong to sets, because such a hub does not currently exist.

This addresses [ticket DT-1472](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1472).