### PR TITLE
Dt 1466 oai unit tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,5 +33,6 @@ libraryDependencies ++= Seq(
   "org.eclipse.rdf4j" % "rdf4j-rio-api" % "2.2",
   "org.eclipse.rdf4j" % "rdf4j-rio-turtle" % "2.2",
   "org.scalaj" % "scalaj-http_2.11" % "2.3.0",
-  "org.rogach" % "scallop_2.11" % "3.0.3"
+  "org.rogach" % "scallop_2.11" % "3.0.3",
+  "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0" % "test"
 )

--- a/src/test/scala/dpla/ingestion3/data/TestOaiData.scala
+++ b/src/test/scala/dpla/ingestion3/data/TestOaiData.scala
@@ -341,4 +341,32 @@ object TestOaiData {
         <resumptionToken expirationDate="2017-01-21T17:33:16Z" cursor="0">90d421891feba6922f57a59868d7bcd1</resumptionToken>
       </ListRecords>
     </OAI-PMH>
+
+  val inOaiListSetsRsp: Elem =
+    <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+      <responseDate>2017-07-20T19:58:26Z</responseDate>
+      <request verb="ListSets">http://dpla.library.in.gov/OAIHandler</request>
+      <ListSets>
+        <set>
+          <setSpec>PALNI_winona</setSpec>
+          <setName>Grace College - Winona Railroad Collection</setName>
+        </set>
+        <set>
+          <setSpec>BSU_INArtsDesk</setSpec>
+          <setName>Indiana ArtsDesk Broadcasts</setName>
+        </set>
+        <set>
+          <setSpec>IPFW_cc_fw_elect</setSpec>
+          <setName>Fort Wayne Area Election Returns</setName>
+        </set>
+        <set>
+          <setSpec>PPO_IndianaAlbum</setSpec>
+          <setName>Indiana Album</setName>
+        </set>
+        <set>
+          <setSpec>IMCPL_shs</setSpec>
+          <setName>Shortridge High School Yearbook Collection</setName>
+        </set>
+    </ListSets>
+  </OAI-PMH>
 }

--- a/src/test/scala/dpla/ingestion3/harvesters/OaiQueryUrlBuilderTest.scala
+++ b/src/test/scala/dpla/ingestion3/harvesters/OaiQueryUrlBuilderTest.scala
@@ -1,0 +1,64 @@
+package dpla.ingestion3.harvesters
+
+import org.scalatest._
+
+/**
+  * Tests for OaiQueryUrlBuilder
+  */
+class OaiQueryUrlBuilderTest extends FlatSpec {
+  val builder = new OaiQueryUrlBuilder
+  val endpoint = "http://repox.example.edu:8080/repox/OAIHandler"
+  val verb = "ListRecords"
+  val set = "manuscripts"
+  val prefix = "mods"
+  val token = "1234"
+
+  "buildQueryUrl" should "throw AssertionError if endpoint is not defined" in {
+    val params = Map("verb" -> verb)
+    assertThrows[AssertionError](builder.buildQueryUrl(params))
+  }
+  it should "throw Exception if verb is not defined" in {
+    val params = Map("endpoint" -> endpoint)
+    assertThrows[AssertionError](builder.buildQueryUrl(params))
+  }
+  it should "make URL with given protocol" in {
+    val params = Map("endpoint" -> endpoint, "verb" -> verb)
+    val url = builder.buildQueryUrl(params)
+    assert(url.getProtocol === "http")
+  }
+  it should "make URL with given host" in {
+    val params = Map("endpoint" -> endpoint, "verb" -> verb)
+    val url = builder.buildQueryUrl(params)
+    assert(url.getHost === "repox.example.edu")
+  }
+  it should "make URL with given port" in {
+    val params = Map("endpoint" -> endpoint, "verb" -> verb)
+    val url = builder.buildQueryUrl(params)
+    assert(url.getPort === 8080)
+  }
+  it should "make URL with given path" in {
+    val params = Map("endpoint" -> endpoint, "verb" -> verb)
+    val url = builder.buildQueryUrl(params)
+    assert(url.getPath === "/repox/OAIHandler")
+  }
+  it should "make URL with given verb" in {
+    val params = Map("endpoint" -> endpoint, "verb" -> verb)
+    val url = builder.buildQueryUrl(params)
+    assert(url.getQuery.contains(s"verb=$verb"))
+  }
+  it should "make URL with given set" in {
+    val params = Map("endpoint" -> endpoint, "verb" -> verb, "set" -> set)
+    val url = builder.buildQueryUrl(params)
+    assert(url.getQuery.contains(s"set=$set"))
+  }
+  it should "make URL with given metadataPrefix" in {
+    val params = Map("endpoint" -> endpoint, "verb" -> verb, "metadataPrefix" -> prefix)
+    val url = builder.buildQueryUrl(params)
+    assert(url.getQuery.contains(s"metadataPrefix=$prefix"))
+  }
+  it should "make URL with given resumptionToken" in {
+    val params = Map("endpoint" -> endpoint, "verb" -> verb, "resumptionToken" -> token)
+    val url = builder.buildQueryUrl(params)
+    assert(url.getQuery.contains(s"resumptionToken=$token"))
+  }
+}

--- a/src/test/scala/dpla/ingestion3/harvesters/oai/DefaultSourceTest.scala
+++ b/src/test/scala/dpla/ingestion3/harvesters/oai/DefaultSourceTest.scala
@@ -1,0 +1,74 @@
+package dpla.ingestion3.harvesters.oai
+
+import org.scalatest._
+
+/**
+  * Tests for DefaultSourceTest
+  */
+class DefaultSourceTest extends FlatSpec {
+  val source = new DefaultSource
+  val endpoint = "http://repox.example.edu:8080/repox/OAIHandler"
+  val verb = "ListRecords"
+  val list = "manuscripts, newspapers, maps"
+  val prefix = "mods"
+  val token = "1234"
+
+  "getEndpoint" should "throw Exception if endpoint missing" in {
+    val params = Map("foo" -> "bar")
+    assertThrows[Exception](source.getEndpoint(params))
+  }
+  it should "return endpoint as String" in {
+    val params = Map("path" -> endpoint)
+    assert(source.getEndpoint(params) === endpoint)
+  }
+
+  "getVerb" should "throw Exception if verb missing" in {
+    val params = Map("foo" -> "bar")
+    assertThrows[Exception](source.getVerb(params))
+  }
+  it should "return endpoint as String" in {
+    val params = Map("verb" -> verb)
+    assert(source.getVerb(params) === verb)
+  }
+
+  "getHarvestAllRecords" should "return false if harvestAllSets missing" in {
+    val params = Map("foo" -> "bar")
+    assert(source.getHarvestAllSets(params) === false)
+  }
+  it should "return true if harvestAllSets is true" in {
+    val params = Map("harvestAllSets" -> "true")
+    assert(source.getHarvestAllSets(params) === true)
+  }
+  it should "return false if harvestAllSets is false" in {
+    val params = Map("harvestAllSets" -> "false")
+    assert(source.getHarvestAllSets(params) === false)
+  }
+  it should "ignore case" in {
+    val params = Map("harvestAllSets" -> "TRUE")
+    assert(source.getHarvestAllSets(params) === true)
+  }
+  it should "throw Exception if harvestAllSets is neither true nor false" in {
+    val params = Map("harvestAllSets" -> "foo")
+    assertThrows[Exception](source.getHarvestAllSets(params))
+  }
+
+  "getSetlist" should "return None if setlist missing" in {
+    val params = Map("foo" -> "bar")
+    assert(source.getSetlist(params) === None)
+  }
+  it should "return set list as Some[Array[String]]" in {
+    val params = Map("setlist" -> list)
+    val sourceOption = source.getSetlist(params).getOrElse(Array())
+    assert(sourceOption.deep === Array("manuscripts", "newspapers", "maps").deep)
+  }
+
+  "getBlacklist" should "return None if blacklist missing" in {
+    val params = Map("foo" -> "bar")
+    assert(source.getBlacklist(params) === None)
+  }
+  it should "return set list as Some[Array[String]]" in {
+    val params = Map("blacklist" -> list)
+    val sourceOption = source.getBlacklist(params).getOrElse(Array())
+    assert(sourceOption.deep === Array("manuscripts", "newspapers", "maps").deep)
+  }
+}

--- a/src/test/scala/dpla/ingestion3/harvesters/oai/OaiResponseProcessorTest.scala
+++ b/src/test/scala/dpla/ingestion3/harvesters/oai/OaiResponseProcessorTest.scala
@@ -1,45 +1,66 @@
 package dpla.ingestion3.harvesters.oai
 
 import org.scalatest._
-
+import org.scalamock.scalatest.MockFactory
 
 /**
   * Tests for OaiResponseProcessor
-  *
-  * TODO: Figure out how to simulate http requests/responses.
-  *
   */
-class OaiResponseProcessorTest extends FlatSpec with Matchers with BeforeAndAfter {
+class OaiResponseProcessorTest extends FlatSpec with MockFactory {
 
-//  val validOaiXml = dpla.ingestion3.data.TestOaiData.paOaiListRecordsRsp
-//  val invalidOaiXml = dpla.ingestion3.data.TestOaiData.paOaiErrorRsp
-//
-//  val outDir = new File("/dev/null")
-//  val oaiUrl = new java.net.URL("http://aggregator.padigital.org/oai")
-//  val oaiVerb = "ListRecords"
-//  val prefix = "oai_dc"
-//  val fileIO = new FlatFileIO
-//  val urlBuilder = new OaiQueryUrlBuilder
-//  val harvester = new OaiResponseProcessor()
-//
-//  "getOaiErrorCode " should " return Option.None if there is no error code" in {
-//    harvester.getOaiErrorCode(validOaiXml) shouldBe None
-//  }
-//
-//  it should " throw a HarvesterException if there is an error code " in {
-//    assertThrows[HarvesterException] {
-//      harvester.getOaiErrorCode(invalidOaiXml)
-//    }
-//  }
-//
-//  "getResumptionToken() " should " return None if there is an error in the response " in {
-//    assert(harvester.getResumptionToken(invalidOaiXml) === None)
-//  }
-//
-//  it should " return a non-empty String value if the response is valid and incomplete" in {
-//    assert(harvester.getResumptionToken(validOaiXml).get.nonEmpty)
-//  }
-//  it should " equal '90d421891feba6922f57a59868d7bcd1'" in {
-//    assert(harvester.getResumptionToken(validOaiXml).get === "90d421891feba6922f57a59868d7bcd1")
-//  }
+  val validRecordOaiXml = dpla.ingestion3.data.TestOaiData.paOaiListRecordsRsp
+  val validSetOaiXml = dpla.ingestion3.data.TestOaiData.inOaiListSetsRsp
+  val errorOaiXml = dpla.ingestion3.data.TestOaiData.paOaiErrorRsp
+
+  "getRecords" should "return the correct number of records" in {
+    val records = OaiResponseProcessor.getRecords(validRecordOaiXml)
+    assert(records.size === 10)
+  }
+  it should "add OaiSet to OaiRecord if OaiSet is given" in {
+    val mockOaiSet = mock[OaiSet]
+    val records = OaiResponseProcessor.getRecords(validRecordOaiXml, Some(mockOaiSet))
+    assert(records(0).set.nonEmpty)
+  }
+  it should "return empty sequence if XML page contains no records" in {
+    val records = OaiResponseProcessor.getRecords(validSetOaiXml)
+    assert(records.size === 0)
+  }
+  it should "parse record id" in {
+    val expectedId = "oai:libcollab.temple.edu:fedora-system:ContentModel-3.0"
+    val records = OaiResponseProcessor.getRecords(validRecordOaiXml)
+    // Use contains instead of === to handle whitespace in test data.
+    assert(records(0).id.contains(expectedId))
+  }
+
+  "getSets" should "return the correct number of sets" in {
+    val sets = OaiResponseProcessor.getSets(validSetOaiXml)
+    assert(sets.size === 5)
+  }
+  it should "return empty sequence if XML page contains no sets" in {
+    val sets = OaiResponseProcessor.getSets(validRecordOaiXml)
+    assert(sets.size === 0)
+  }
+  it should "parse set id" in {
+    val expectedId = "PALNI_winona"
+    val sets = OaiResponseProcessor.getSets(validSetOaiXml)
+    assert(sets(0).id === expectedId)
+  }
+
+  "getResumptionToken" should "return the resumption token" in {
+    val expectedToken = "90d421891feba6922f57a59868d7bcd1"
+    val token = OaiResponseProcessor.getResumptionToken(validRecordOaiXml.toString)
+    assert(token === Some(expectedToken))
+  }
+  it should "return None in absence of resumption token" in {
+    val token = OaiResponseProcessor.getResumptionToken(validSetOaiXml.toString)
+    assert(token === None)
+  }
+
+  "getOaiErrorCode" should "return Unit if there is no error code" in {
+    val error = OaiResponseProcessor.getOaiErrorCode(validRecordOaiXml)
+    assert(error.isInstanceOf[Unit])
+  }
+  it should "throw an Exception if there is an error code" in {
+    assertThrows[Exception](OaiResponseProcessor.getOaiErrorCode(errorOaiXml))
+  }
 }


### PR DESCRIPTION
This adds unit tests for three classes in the OAI harvester.  We can add tests for other classes later -
 this was a timeboxed ticket.  This also adds ScalaMock.  There are other mock testing frameworks available if we decide we don't like ScalaMock - I only needed it here for a very simple use case.

This addresses [DT-1471](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1471).