### PR TITLE
Standalone implementation of NARA file harvesting. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,5 @@ ENV/
 log/*
 
 *.sublime-project
+
+metastore_db/

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NaraFileHarvestMain.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NaraFileHarvestMain.scala
@@ -1,0 +1,217 @@
+package dpla.ingestion3.harvesters.file
+
+import java.io.{File, FileInputStream}
+import java.util.zip.GZIPInputStream
+
+import dpla.ingestion3.utils.{FlatFileIO, Utils}
+import org.apache.avro.Schema
+import org.apache.avro.file.{CodecFactory, DataFileWriter}
+import org.apache.avro.generic.{GenericData, GenericDatumWriter, GenericRecord}
+import org.apache.commons.io.IOUtils
+import org.apache.log4j.LogManager
+import org.apache.tools.bzip2.CBZip2InputStream
+import org.apache.tools.tar.TarInputStream
+import org.rogach.scallop.{ScallopConf, ScallopOption}
+
+import scala.util.{Failure, Success, Try}
+import scala.xml.{MinimizeMode, Node, Utility, XML}
+
+
+object NaraFileHarvestMain {
+
+
+  private val logger = LogManager.getLogger(getClass)
+
+  def main(args: Array[String]): Unit = {
+    val startTime = System.currentTimeMillis()
+    val unixEpoch = startTime / 1000L
+    val conf = new NaraFileHarvestConf(args)
+    val inFile = new File(conf.inputFile.getOrElse("in"))
+    val outFile = new File(conf.outputFile.getOrElse("out"))
+    Utils.deleteRecursively(outFile)
+    val schemaStr = new FlatFileIO().readFileAsString("/avro/OriginalRecord.avsc")
+    val schema = new Schema.Parser().parse(schemaStr)
+    val avroWriter = getAvroWriter(outFile, schema)
+
+    val inputStream = getInputStream(inFile)
+      .getOrElse(throw new IllegalArgumentException("Couldn't load tar file."))
+
+    val recordCount = (for (tarResult <- iter(inputStream)) yield {
+      handleFile(schema, avroWriter, tarResult, unixEpoch) match {
+        case Failure(exception) =>
+          logger.error(s"Caught exception on $inFile.", exception)
+          0
+
+        case Success(count) =>
+          count
+      }
+    }).sum
+
+    avroWriter.close()
+    IOUtils.closeQuietly(inputStream)
+
+    val endTime = System.currentTimeMillis()
+    Utils.printResults(endTime - startTime, recordCount)
+  }
+
+  /**
+    * Main logic for handling individual entries in the tar.
+    *
+    * @param schema     Parsed Avro schema
+    * @param avroWriter Writer for saving Avros
+    * @param tarResult  Case class representing extracted item from the tar
+    * @return Count of metadata items found.
+    */
+  def handleFile(schema: Schema, avroWriter: DataFileWriter[GenericRecord], tarResult: TarResult, unixEpoch: Long): Try[Int] =
+    tarResult.data match {
+      case None =>
+        Success(0) //a directory, no results
+
+      case Some(data) =>
+        Try {
+          val xml = XML.loadString(new String(data))
+          val items = handleXML(xml)
+          val entryName = tarResult.entryName
+
+          val counts = for {
+            itemOption <- items
+            item <- itemOption //filters out the Nones
+          } yield {
+            val genericRecord = new GenericData.Record(schema)
+            genericRecord.put("id", item.id)
+            genericRecord.put("ingestDate", unixEpoch)
+            genericRecord.put("provider", "NARA")
+            genericRecord.put("document", item.itemXml)
+            genericRecord.put("mimetype", "application_xml")
+            avroWriter.append(genericRecord)
+            1
+          }
+
+          counts.sum
+        }
+    }
+
+  /**
+    * Takes care of parsing an xml file into a list of Nodes each representing an item
+    *
+    * @param xml Root of the xml document
+    * @return List of Options of id/item pairs.
+    */
+  def handleXML(xml: Node): List[Option[XmlResult]] =
+    for {
+    //three different types of nodes contain children that represent records
+      items <- xml \\ "item" :: xml \\ "itemAv" :: xml \\ "fileUnit" :: Nil
+      item <- items
+      if (item \ "digitalObjectArray" \ "digitalObject").nonEmpty
+    } yield item match {
+      case record: Node =>
+        val id = (record \ "digitalObjectArray" \ "digitalObject" \ "objectIdentifier").text.toString
+        val outputXML = xmlToString(record)
+        val label = item.label
+        Some(XmlResult(id, outputXML))
+      case _ =>
+        logger.warn("Got weird result back for item path: " + item.getClass)
+        None
+    }
+
+  /**
+    * Converts a Node to an xml string
+    *
+    * @param node The root of the tree to write to a string
+    * @return a String containing xml
+    */
+  def xmlToString(node: Node): String =
+    Utility.serialize(node, minimizeTags = MinimizeMode.Always).toString
+
+  /**
+    * Builds a writer for saving Avros.
+    *
+    * @param outputFile Place to save Avro
+    * @param schema     Parsed schema of the output
+    * @return DataFileWriter for writing Avros in the given schema
+    */
+  def getAvroWriter(outputFile: File, schema: Schema): DataFileWriter[GenericRecord] = {
+    val datumWriter = new GenericDatumWriter[GenericRecord](schema)
+    val dataFileWriter = new DataFileWriter[GenericRecord](datumWriter)
+    dataFileWriter.setCodec(CodecFactory.deflateCodec(1))
+    dataFileWriter.setSyncInterval(1024 * 1024 * 2) //2M
+    dataFileWriter.create(schema, outputFile)
+  }
+
+  /**
+    * Loads .gz, .tgz, .bz, and .tbz2, and plain old .tar files.
+    *
+    * @param file File to parse
+    * @return TarInputstream of the tar contents
+    */
+  def getInputStream(file: File): Option[TarInputStream] =
+    file.getName match {
+      case gzName if gzName.endsWith("gz") || gzName.endsWith("tgz") =>
+        Some(new TarInputStream(new GZIPInputStream(new FileInputStream(file))))
+
+      case bz2name if bz2name.endsWith("bz2") || bz2name.endsWith("tbz2") =>
+        val inputStream = new FileInputStream(file)
+        inputStream.skip(2)
+        Some(new TarInputStream(new CBZip2InputStream(inputStream)))
+
+      case tarName if tarName.endsWith("tar") =>
+        Some(new TarInputStream(new FileInputStream(file)))
+
+      case _ => None
+    }
+
+  /**
+    * Implements a stream of files from the tar.
+    * Can't use @tailrec here because the compiler can't recognize it as tail recursive,
+    * but this won't blow the stack.
+    *
+    * @param tarInputStream
+    * @return Lazy stream of tar recordsd
+    */
+  def iter(tarInputStream: TarInputStream): Stream[TarResult] =
+    Option(tarInputStream.getNextEntry) match {
+      case None =>
+        Stream.empty
+
+      case Some(entry) =>
+        val result =
+          if (entry.isDirectory)
+            None
+          else
+            Some(IOUtils.toByteArray(tarInputStream, entry.getSize))
+        TarResult(entry.getName, result) #:: iter(tarInputStream)
+    }
+
+  /**
+    * Holds the output of handleXML
+    */
+  case class XmlResult(id: String, itemXml: String)
+
+  /**
+    * Case class to hold the results of a TarEntry.
+    *
+    * @param entryName Path of the entry in the tarfile
+    * @param data      Holds the data for the entry, or None if it's a directory.
+    */
+  case class TarResult(entryName: String, data: Option[Array[Byte]])
+
+}
+
+class NaraFileHarvestConf(arguments: Seq[String]) extends ScallopConf(arguments) {
+
+  val inputFile: ScallopOption[String] = opt[String](
+    "inputFile",
+    required = true,
+    noshort = true,
+    validate = _.nonEmpty
+  )
+
+  val outputFile: ScallopOption[String] = opt[String](
+    "outputFile",
+    required = true,
+    noshort = true,
+    validate = _.nonEmpty
+  )
+
+  verify()
+}

--- a/src/main/scala/dpla/ingestion3/harvesters/file/tar/DefaultSource.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/tar/DefaultSource.scala
@@ -1,0 +1,216 @@
+package dpla.ingestion3.harvesters.file.tar
+
+import java.io._
+import java.net.URI
+import java.util.zip.GZIPInputStream
+
+import dpla.ingestion3.harvesters.file.tar.DefaultSource.{SerializableConfiguration, _}
+import org.apache.commons.io.IOUtils
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
+import org.apache.hadoop.mapreduce.Job
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.{FileFormat, OutputWriterFactory, PartitionedFile}
+import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
+import org.apache.spark.sql.types.{BinaryType, StringType, StructField, StructType}
+import org.apache.spark.unsafe.types.UTF8String
+import org.apache.tools.bzip2.CBZip2InputStream
+import org.apache.tools.tar.TarInputStream
+
+import scala.util.Try
+
+/**
+  * This is a DataSource that can handle Tar files in a number of formats: tar.gz, tar.bz2, or just .tar.
+  *
+  * It figures out which type it is based on the extension (.tgz and .tbz2 are also valid).
+  *
+  * Use it like:  val df = spark.read.format("dpla.ingestion3.harvesters.file.tar").load(infile)
+  *
+  */
+class DefaultSource extends FileFormat with DataSourceRegister {
+
+  def shortName(): String = "tar"
+
+  /**
+    * Writing not implemented yet. Not sure we need it.
+    *
+    */
+  override def prepareWrite(
+                             sparkSession: SparkSession,
+                             job: Job,
+                             options: Map[String, String],
+                             dataSchema: StructType
+                           ): OutputWriterFactory =
+    throw new UnsupportedOperationException("Writing not implemented.")
+
+
+  /**
+    * Schema is always a tuple of the name of the tarfile, the full path of the entry, and the bytes of the entry.
+    *
+    */
+  override def
+  inferSchema(sparkSession: SparkSession, options: Map[String, String], files: Seq[FileStatus]): Option[StructType] =
+    Some(StructType(Seq(
+      StructField("tarname", StringType, nullable = false),
+      StructField("filename", StringType, nullable = false),
+      StructField("data", BinaryType, nullable = false)
+    )))
+
+  /**
+    * Not even thinking about how to make this data splittable. In many cases this will handle, it's definitely not.
+    *
+    */
+  override def isSplitable(
+                            sparkSession: SparkSession,
+                            options: Map[String, String],
+                            path: Path): Boolean = false
+
+
+  override def buildReader(
+                            spark: SparkSession,
+                            dataSchema: StructType,
+                            partitionSchema: StructType,
+                            requiredSchema: StructType,
+                            filters: Seq[Filter],
+                            options: Map[String, String],
+                            hadoopConf: Configuration): (PartitionedFile) => Iterator[InternalRow] = {
+
+    //We avoid closing over the non-serializable HadoopConf by wrapping it in something serializable and
+    //broadcasting it. Really, Hadoop? It's like, a hashtable. You could save us a lot of trouble by making it
+    //Serializable. But we need a Configuration to laod the data using Hadoop's FileSystem class, which means we
+    //should be able to read files from everywhere Spark can.
+    val broadcastedConf = spark.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
+
+    //this is a function that Spark will call on every file given as input. It's going to be run on a worker node,
+    //not the master, so we have to take a little care not to close over anything that's not serializable.
+    (file: PartitionedFile) => {
+
+      //this contains the stream if it's something we can read, or None if not.
+      val tarInputStreamOption: Option[TarInputStream] = loadStream(broadcastedConf, file)
+      tarInputStreamOption match {
+
+        //we got some data to iterate over
+        case Some(tarInputStream) =>
+          iterateFiles(file.filePath, tarInputStream)
+
+        //The default case cowardly fails. Possibly a directory with
+        //other files was passed, so we don't want to blow up
+        case None =>
+          Iterator.empty
+      }
+    }
+  }
+}
+
+object DefaultSource {
+
+  def iter(tarInputStream: TarInputStream): Stream[TarResult] = {
+    Option(tarInputStream.getNextEntry) match {
+      case None =>
+        Stream.empty
+
+      case Some(entry) =>
+
+        val result =
+          if (entry.isDirectory)
+            TarResult(
+              UTF8String.fromString(entry.getName),
+              None,
+              isDirectory = true
+            )
+          else
+            TarResult(
+              UTF8String.fromString(entry.getName),
+              Some(IOUtils.toByteArray(tarInputStream, entry.getSize)),
+              isDirectory = false
+            )
+
+        result #:: iter(tarInputStream)
+    }
+  }
+
+
+  def iterateFiles(filePath: String, tarInputStream: TarInputStream): Iterator[InternalRow] = {
+
+    /*
+      InternalRow doesn't want a plain old String because that doesn't enforce an encoding on disk. Also, UTF8String
+      models the data as an array of bytes internally, which is probably denser than native Strings.
+
+      InternalRow generally deals in these wrapped, more primitive representations than the standard library. We only
+      happen to be using one of these primative wrappers here, but there are more.
+     */
+    val filePathUTF8 = UTF8String.fromString(filePath)
+
+    /*
+      This helper method lazily traverses the TarInputStream.
+      Can't use @tailrec here because the compiler can't recognize it as tail recursive, but this won't blow the stack.
+     */
+    iter(tarInputStream)
+      .filterNot(_.isDirectory) //we don't care about directories
+      .map((result: TarResult) =>
+      InternalRow(
+        UTF8String.fromString(filePath),
+        result.entryPath,
+        result.data.getOrElse(Array[Byte]())
+      )
+    ).iterator
+  }
+
+  def loadStream(broadcastedConf: Broadcast[SerializableConfiguration], file: PartitionedFile):
+  Option[TarInputStream] = {
+    val hadoopConf = broadcastedConf.value.value
+    val fs = FileSystem.get(hadoopConf)
+    val path = new Path(new URI(file.filePath))
+    file.filePath match {
+      case name if name.endsWith("gz") || name.endsWith("tgz") =>
+        Some(new TarInputStream(new GZIPInputStream(fs.open(path))))
+      case name if name.endsWith("bz2") || name.endsWith("tbz2") =>
+        //skip the "BZ" header added by bzip2.
+        val fileStream = fs.open(path)
+        fileStream.skip(2)
+        Some(new TarInputStream(new CBZip2InputStream(fileStream)))
+      case name if name.endsWith("tar") =>
+        Some(new TarInputStream(fs.open(path)))
+      case _ => None //We don't recognize the extension.
+    }
+  }
+
+
+  /**
+    * This is one of those things that seems to exist in a lot of Hadoop ecosystem projects that Hadoop should just fix.
+    * Basically this is just a wrapper that allows a Hadoop Configuration object to be sent over the wire.
+    * Needed so that workers can find their files on whatever filesystem is passed in (HDFS, S3, etc.)
+    *
+    * @param value the Hadoop Configuration object to be sent.
+    */
+  class SerializableConfiguration(@transient var value: Configuration) extends Serializable {
+    private def writeObject(out: ObjectOutputStream): Unit =
+      Try {
+        out.defaultWriteObject()
+        value.write(out)
+      } getOrElse (
+        (e: Exception) => throw new IOException("Unable to read config from input stream.", e)
+      )
+
+
+    private def readObject(in: ObjectInputStream): Unit =
+      Try {
+        value = new Configuration(false)
+        value.readFields(in)
+      } getOrElse (
+        (e: Exception) => throw new IOException("Unable to read config from input stream.", e)
+      )
+  }
+
+  /**
+    * Case class for holding the result of a single tar entry iteration.
+    *
+    * @param entryPath   Path of the entry in the tar file.
+    * @param data        Binary data in the entry
+    * @param isDirectory If the entry represents a directory.
+    */
+  case class TarResult(entryPath: UTF8String, data: Option[Array[Byte]], isDirectory: Boolean)
+
+}


### PR DESCRIPTION
I built a tar DataSource here. Unfortunately, it requires as much memory per tar file as the uncompressed parts of the tar. I've committed it as part of this pull request in case we think it would be useful to keep around.

The working NARA harvest is a standalone, non-Spark command line invocation that converts their tar files of big XML files to Avros of individual item records.