### PR TITLE
Generalized file configuration for harvests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,5 +34,6 @@ libraryDependencies ++= Seq(
   "org.eclipse.rdf4j" % "rdf4j-rio-turtle" % "2.2",
   "org.scalaj" % "scalaj-http_2.11" % "2.3.0",
   "org.rogach" % "scallop_2.11" % "3.0.3",
-  "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0" % "test"
+  "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0" % "test",
+  "com.typesafe" % "config" % "1.3.1"
 )

--- a/src/main/resources/profiles/digital-commonwealth.conf
+++ b/src/main/resources/profiles/digital-commonwealth.conf
@@ -1,0 +1,16 @@
+"""
+Digital Commonwealth ingestion profile
+
+See https://digitalpubliclibraryofamerica.atlassian.net/wiki/spaces/HUBS/pages/70025245/Digital+Commonwealth
+for additional hub details.
+"""
+
+# Harvest configuration
+blacklist = "commonwealth,commonwealth-oai"
+endpoint = "http://fedora.digitalcommonwealth.org/oaiprovider/"
+metadataPrefix = "mods"
+outputDir = "" # TODO This should be an S3:// bucket that i3 has write access to
+provider = "Digital Commonwealth"
+type = "oai" # Which harvester to invoke
+verb = "ListRecords"
+

--- a/src/main/resources/profiles/oaiSample.conf
+++ b/src/main/resources/profiles/oaiSample.conf
@@ -1,0 +1,10 @@
+
+# Sample OAI harvest configuration
+type = "oai"
+outputDir = "/Users/scott/dpla/bulk_data/dig_comm_sets_test-2"
+endpoint = "http://fedora.digitalcommonwealth.org/oaiprovider/"
+metadataPrefix = "mods"
+provider = "digital commonwealth"
+blacklist = "commonwealth,commonwealth-oai"
+verb = "ListRecords"
+

--- a/src/main/scala/dpla/ingestion3/confs/OaiHarvesterConf.scala
+++ b/src/main/scala/dpla/ingestion3/confs/OaiHarvesterConf.scala
@@ -1,13 +1,11 @@
 package dpla.ingestion3.confs
 
-import org.rogach.scallop.{ScallopConf, ScallopOption}
-import dpla.ingestion3.utils.Utils.validateUrl
+import com.typesafe.config.ConfigFactory
 
 /**
-  * https://github.com/scallop/scallop/wiki
   *
   * Arguments to be passed into the OAI-PMH harvester
-  *
+  * 
   * Output directory: String
   * Endpoint: String the OAI URL
   * Verb: String ListRecords || ListSets
@@ -22,43 +20,53 @@ import dpla.ingestion3.utils.Utils.validateUrl
   * sparkMaster (Optional): If omitted the defaults to local[*]
   */
 
-class OaiHarvesterConf(arguments: Seq[String]) extends ScallopConf(arguments) {
-  // Required parameters
-  val outputDir: ScallopOption[String] = opt[String]("outputDir",
-    required = true,
-    noshort = true,
-    validate = _.nonEmpty)
-  val endpoint: ScallopOption[String] = opt[String]("endpoint",
-    required = true,
-    noshort = true)
-  val verb: ScallopOption[String] = opt[String]("verb",
-    required = true,
-    noshort = true)
-  val provider: ScallopOption[String] = opt[String]("provider",
-    required = true,
-    noshort = true)
-  // Optional parameters
-  val prefix: ScallopOption[String] = opt[String]("prefix",
-    required = false,
-    noshort = true,
-    validate = _.nonEmpty)
-  val harvestAllSets: ScallopOption[String] = opt[String]("harvestAllSets",
-    required = false,
-    noshort = true,
-    default = Some("false"))
-  val setlist: ScallopOption[String] = opt[String]("setlist",
-    required = false,
-    noshort = true,
-    validate = _.nonEmpty)
-  val blacklist: ScallopOption[String] = opt[String]("blacklist",
-    required = false,
-    noshort = true,
-    validate = _.nonEmpty)
-  // If a master URL is not provider then default to local[*]
-  val sparkMaster: ScallopOption[String] = opt[String]("sparkMaster",
-    required = false,
-    noshort = true,
-    default = Some("local[*]"))
+class OaiHarvesterConf(arguments: Seq[String]) {
+  def load(): OaiConfig = {
+    // Loads config file for more information about loading hierarchy please read
+    // https://github.com/typesafehub/config#standard-behavior
+    ConfigFactory.invalidateCaches()
+    val oaiConf = ConfigFactory.load()
 
-  verify()
+    def getProp(prop: String, default: Option[String] = None): Option[String] = {
+      oaiConf.hasPath(prop) match {
+        case true => Some(oaiConf.getString(prop))
+        case false => default
+      }
+    }
+
+    OaiConfig(
+      // Validate outputDir parameter here since it is not validated in DefaultSource
+      outputDir = getProp("outputDir") match {
+        case Some(d) => Some(d)
+        case None => throw new IllegalArgumentException("Output directory is not " +
+          "specified in config. Cannot harvest.")
+      },
+      endpoint = getProp("endpoint"),
+      verb = getProp("verb"),
+      // Validate provider parameter here since it is not validated in DefaultSource
+      provider = getProp("provider") match {
+        case Some(d) => Some(d)
+        case None => throw new IllegalArgumentException("Provider is not " +
+          "specified in config. Cannot harvest.")
+      },
+      metadataPrefix = getProp("metadataPrefix"),
+      harvestAllSets = getProp("harvestAllSets"),
+      setList = getProp("setList"),
+      blacklist = getProp("blacklist"),
+      // Default spark master is to run on local
+      sparkMaster = getProp("sparkMaster", Some("local[*]"))
+    )
+  }
 }
+
+case class OaiConfig (
+                       outputDir: Option[String],
+                       endpoint: Option[String],
+                       verb: Option[String],
+                       provider: Option[String],
+                       metadataPrefix: Option[String],
+                       harvestAllSets: Option[String],
+                       setList: Option[String],
+                       blacklist: Option[String],
+                       sparkMaster: Option[String]
+                     )


### PR DESCRIPTION
Refactor the extraction of OAI parameters from command line arguments to configuration files. The OaiHarvster requires one command line argument to a file that contains the configuration values for the a given provider (e.g. `--Dconfig.{file,url,resource}=<path to config>`). This file will include all configurations for a provider and is not limited to harvest properties.

This PR includes a sample OAI configuration file and a complete harvest profile for Digital Commonwealth. The profile includes an additional property,`type`, which will be used to specify the type of harvester to invoke (OAI, API, Primo, File etc.)

Examples:
* By default it will use application.{conf,properties,json} on the classpath but that can be overridden by specifying these system properties, `config.{url, file, resource}`.
* To use an external config file from S3 when running from IntelliJ or other IDE
`-Dconfig.url=https://s3.amazonaws.com/dpla-sw/application.conf` as a VM option
* To use an external configuration file on the filesystem when running from IntelliJ or other IDE
`-Dconfig.file=/home/scott/i3/profiles/provider-cdl.conf`

TODO: 
* Figure out why invocation using SBT and spark-shell is not respecting `config.{url,file,resource}` when passed in at runtime. ee


