### PR TITLE
Add method to export a JSONL string for a record

### DIFF
--- a/src/main/scala/dpla/ingestion3/model/DplaMapData.scala
+++ b/src/main/scala/dpla/ingestion3/model/DplaMapData.scala
@@ -85,6 +85,11 @@ case class EdmWebResource(
   */
 
 case class OreAggregation(
+                           /*
+                            * FIXME: it's not clear what `uri' corresponds to
+                            * in Section 4.1.C of
+                            * http://dp.la/info/wp-content/uploads/2015/03/MAPv4.pdf
+                            */
                            uri: ExactlyOne[URI], //uri of the record on our site
                            dataProvider: ExactlyOne[EdmAgent],
                            originalRecord: ExactlyOne[String], //map v4 specifies this as a ref, but that's LDP maybe?

--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -3,6 +3,11 @@ package dpla.ingestion3
 import java.net.URI
 
 import dpla.ingestion3.model.DplaMapData.LiteralOrUri
+import org.json4s.JsonAST.JObject
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+import dpla.ingestion3.utils.Utils.generateMd5
+
 
 package object model {
 
@@ -26,5 +31,73 @@ package object model {
   def eitherStringOrUri(string: String): LiteralOrUri = new Left(string)
 
   def eitherStringOrUri(uri: URI): LiteralOrUri = new Right(uri)
+
+  def jsonlRecord(record: DplaMapData): String = {
+    val recordID: String = generateMd5(Some(record.oreAggregation.uri.toString))
+    val jobj: JObject =
+      ("id" -> recordID) ~
+      ("@context" -> "http://dp.la/api/items/context") ~
+      ("@id" -> ("http://dp.la/api/items/" + recordID)) ~
+      ("admin" ->
+        ("sourceResource" -> ("title" -> record.sourceResource.title))) ~
+      ("aggregatedCHO" -> "#sourceResource") ~
+      ("dataProvider" -> record.oreAggregation.dataProvider.name) ~
+      ("ingestDate" -> "FIXME") ~  // FIXME: no place in MAPv4 schema for this
+      ("ingestType" -> "item") ~
+      ("isShownAt" -> record.edmWebResource.uri.toString) ~
+      ("object" -> record.oreAggregation.`object`
+                         .map{o => o.uri.toString}) ~
+      ("originalRecord" -> record.oreAggregation.originalRecord) ~
+      ("provider" -> record.oreAggregation.provider.name) ~
+      ("sourceResource" ->
+        ("@id" ->
+          ("http://dp.la/api/items/" + recordID + "#SourceResource")) ~
+        ("collection" ->
+          record.sourceResource.collection.map {c => "title" -> c.title}) ~
+        ("contributor" -> record.sourceResource.contributor.map{c => c.name}) ~
+        ("creator" -> record.sourceResource.creator.map{c => c.name}) ~
+        ("date" ->
+          record.sourceResource.date.map { d =>
+            ("displayDate" -> d.originalSourceDate) ~
+              ("begin" -> d.begin) ~
+              ("end" -> d.end)
+          }) ~
+        ("description" -> record.sourceResource.description) ~
+        ("extent" -> record.sourceResource.extent) ~
+        ("format" -> record.sourceResource.format) ~
+        ("identifier" -> record.sourceResource.identifier) ~
+        ("language" ->
+          record.sourceResource.language.map { lang =>
+            ("name" -> lang.providedLabel) ~ ("iso639_3" -> lang.concept)
+          }) ~
+        ("publisher" -> record.sourceResource.publisher.map{p => p.name}) ~
+        ("relation" ->
+          record.sourceResource.relation.map { r =>
+            r.merge.toString
+          })  ~
+        ("rights" -> record.sourceResource.rights) ~
+        // FIXME: Wait til open PR for geo enrichments gets merged before
+        // implementing Spatial.
+        ("spatial" -> "FIXME") ~
+        /*
+         * FIXME: specType is unaccounted for in MAPv4 and DplaMapData.
+         * It was edm:hasType in MAPv3.1.  It was optional. Shall we omit it?
+         */
+        ("specType" -> "FIXME") ~
+        // stateLocatedIn is being omitted here ...
+        ("subject" -> record.sourceResource.subject.map{s => s.providedLabel}) ~
+        ("temporal" ->
+          record.sourceResource.temporal.map{ t =>
+            ("displayDate" -> t.originalSourceDate) ~
+              ("begin" -> t.begin) ~
+              ("end" -> t.end)
+          }) ~
+        ("title" -> record.sourceResource.title) ~
+        ("type" -> record.sourceResource.`type`)
+      ) ~
+      ("type" -> "ore:Aggregation")
+
+    compact(render(jobj))
+  }
 
 }

--- a/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
+++ b/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
@@ -1,0 +1,120 @@
+package dpla.ingestion3.data
+
+import java.net.URI
+
+import dpla.ingestion3.model._
+
+object EnrichedRecordFixture {
+
+  val enrichedRecord = DplaMapData(
+    DplaSourceResource(
+      collection = Seq(DcmiTypeCollection(
+        title = Some("The Collection"),
+        description = Some("The Archives of Some Department, U. of X")
+      )),
+      contributor = Seq(EdmAgent(
+        name = Some("J Doe")
+      )),
+      creator = Seq(EdmAgent(
+        name = Some("J Doe")
+      )),
+      date = Seq(EdmTimeSpan(
+        originalSourceDate=Some("5.7.2012"),
+        prefLabel = Some("2012-05-07"),
+        begin = Some("2012-05-07"),
+        end = Some("2012-05-07")
+      )),
+      description = Seq("The description"),
+      extent = Seq("200 pp.", "8 x 10 in."),
+      format = Seq("handwritten letter", "gelatin silver print"),
+      identifier = Seq("us-history-13243", "j-doe-archives-2343"),
+      language = Seq(SkosConcept(
+        providedLabel = Some("English"),
+        concept = Some("eng"),
+        note = None,
+        scheme = None,
+        exactMatch= Seq(),
+        closeMatch = Seq())
+      ),
+      publisher = Seq(EdmAgent(
+        name = Some("The Publisher")
+      )),
+      relation = Seq("x", "https://example.org/x").map(eitherStringOrUri),
+      rights = Seq("Public Domain"),
+      subject = Seq(SkosConcept(
+        providedLabel = Some("Birds")
+      )),
+      temporal = Seq(
+        EdmTimeSpan(
+          originalSourceDate = Some("1920s"),
+          begin = Some("1920-01-01"),
+          end = Some("1929-12-31")
+        ),
+        EdmTimeSpan(
+          originalSourceDate = Some("1930s"),
+          begin = Some("1930-01-01"),
+          end = Some("1939-12-31")
+        )
+      ),
+      title = Seq("The Title"),
+      `type` = Seq("image", "text")
+    ),
+    EdmWebResource(
+      uri = new URI("https://example.org/record/123")
+    ),
+    OreAggregation(
+      dataProvider = EdmAgent(
+        name = Some("The Data Provider")
+      ),
+      uri = new URI("https://example.org/record/123"),
+      originalRecord = "The Original Record",
+      provider = EdmAgent(
+        name = Some("The Provider")
+      ),
+      hasView = Seq(EdmWebResource(uri = new URI("https://example.org/"))),
+      intermediateProvider = Some(
+        EdmAgent(name = Some("The Intermediate Provider"))
+      ),
+      `object` = Some(
+        EdmWebResource(uri = new URI("https://example.org/record/123.html"))
+      ),
+      preview = Some(
+        EdmWebResource(uri = new URI("https://example.org/thumbnail/123.jpg"))
+      ),
+      edmRights = Some(new URI("https://example.org/rights/public_domain.html"))
+    )
+  )
+
+  val minimalEnrichedRecord = DplaMapData(
+    DplaSourceResource(
+      rights = Seq("Public Domain"),
+      title = Seq("The Title"),
+      `type` = Seq("image", "text")
+    ),
+    EdmWebResource(
+      uri = new URI("https://example.org/record/123")
+    ),
+    OreAggregation(
+      dataProvider = EdmAgent(
+        name = Some("The Data Provider")
+      ),
+      uri = new URI(""),
+      originalRecord = "The Original Record",
+      provider = EdmAgent(
+        name = Some("The Provider")
+      ),
+      hasView = Seq(EdmWebResource(uri = new URI("https://example.org/"))),
+      intermediateProvider = Some(
+        EdmAgent(name = Some("The Intermediate Provider"))
+      ),
+      `object` = Some(
+        EdmWebResource(uri = new URI("https://example.org/record/123.html"))
+      ),
+      preview = Some(
+        EdmWebResource(uri = new URI("https://example.org/thumbnail/123.jpg"))
+      ),
+      edmRights = Some(new URI("https://example.org/rights/public_domain.html"))
+    )
+  )
+
+}

--- a/src/test/scala/dpla/ingestion3/data/MappedRecordsFixture.scala
+++ b/src/test/scala/dpla/ingestion3/data/MappedRecordsFixture.scala
@@ -1,0 +1,34 @@
+package dpla.ingestion3.data
+
+import java.net.URI
+
+import dpla.ingestion3.model._
+
+object MappedRecordsFixture {
+  val mappedRecord = DplaMapData(
+    new DplaSourceResource(
+      date = Seq(EdmTimeSpan(
+        originalSourceDate=Some("5.7.2012"),
+        prefLabel = None,
+        begin = None,
+        end = None
+      )),
+      language = Seq(SkosConcept(
+        providedLabel = Some("eng"),
+        note = None,
+        scheme = None,
+        exactMatch= Seq(),
+        closeMatch = Seq())
+      )
+    ),
+    EdmWebResource(
+      uri = new URI("")
+    ),
+    new OreAggregation(
+      dataProvider = new EdmAgent(),
+      uri = new URI(""), //uri of the record on our site
+      originalRecord = "", //map v4 specifies this as a ref, but that's LDP maybe?
+      provider = new EdmAgent()
+    )
+  )
+}

--- a/src/test/scala/dpla/ingestion3/enrichments/EnrichmentDriverTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/EnrichmentDriverTest.scala
@@ -8,6 +8,7 @@ import dpla.ingestion3.data.MappedRecordsFixture
 import dpla.ingestion3.model.{DplaSourceResource, EdmTimeSpan, SkosConcept}
 import org.scalatest.{BeforeAndAfter, FlatSpec}
 
+
 class EnrichmentDriverTest extends FlatSpec with BeforeAndAfter {
 
   val driver = new EnrichmentDriver
@@ -33,7 +34,7 @@ class EnrichmentDriverTest extends FlatSpec with BeforeAndAfter {
     ),
     OreAggregation(
       dataProvider = EdmAgent(),
-      uri = new URI(""), //uri of the record on our site
+      uri = new URI("https://example.org/item/123"), //uri of the record on our site
       originalRecord = "", //map v4 specifies this as a ref, but that's LDP maybe?
       provider = EdmAgent()
     )
@@ -46,9 +47,20 @@ class EnrichmentDriverTest extends FlatSpec with BeforeAndAfter {
           originalSourceDate = Some("5.7.2012")
         )),
       language = Seq(SkosConcept(
+
+        /*
+         * FIXME: I think that providedLabel and concept are reversed.
+         * Concept is supposed to be the "The preferred form of the name of the
+         * concept," per
+         * http://dp.la/info/wp-content/uploads/2015/03/MAPv4.pdf
+         * Provided label is what the provider gave us. The language code is
+         * not "English", it's "eng", according to
+         * http://www.lexvo.org/page/term/eng/English
+         */
         providedLabel = Some("eng"),
         concept = Some("English"),
         scheme = Some(new URI("http://lexvo.org/id/iso639-3/")))
+
       )
     ))
 

--- a/src/test/scala/dpla/ingestion3/enrichments/EnrichmentDriverTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/EnrichmentDriverTest.scala
@@ -4,6 +4,8 @@ import java.net.URI
 
 
 import dpla.ingestion3.model._
+import dpla.ingestion3.data.MappedRecordsFixture
+import dpla.ingestion3.model.{DplaSourceResource, EdmTimeSpan, SkosConcept}
 import org.scalatest.{BeforeAndAfter, FlatSpec}
 
 class EnrichmentDriverTest extends FlatSpec with BeforeAndAfter {
@@ -38,10 +40,10 @@ class EnrichmentDriverTest extends FlatSpec with BeforeAndAfter {
   )
 
   "EnrichmentDriver" should " enrich both language and date" in {
-    val expectedValue = mappedRecord.copy(DplaSourceResource(
-      date = Seq(EdmTimeSpan(
-          prefLabel = Some("2015-04-03"),
-          originalSourceDate = Some("4.3.2015")
+    val expectedValue = MappedRecordsFixture.mappedRecord.copy(new DplaSourceResource(
+      date = Seq(new EdmTimeSpan(
+          prefLabel = Some("2012-05-07"),
+          originalSourceDate = Some("5.7.2012")
         )),
       language = Seq(SkosConcept(
         providedLabel = Some("eng"),
@@ -50,7 +52,7 @@ class EnrichmentDriverTest extends FlatSpec with BeforeAndAfter {
       )
     ))
 
-    val enrichedRecord = driver.enrich(mappedRecord)
+    val enrichedRecord = driver.enrich(MappedRecordsFixture.mappedRecord)
 
     assert(enrichedRecord === expectedValue)
   }

--- a/src/test/scala/dpla/ingestion3/model/JsonlStringTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/JsonlStringTest.scala
@@ -1,0 +1,53 @@
+package dpla.ingestion3.model
+
+
+import org.scalatest.FlatSpec
+import dpla.ingestion3.data.EnrichedRecordFixture
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+
+
+class JsonlStringTest extends FlatSpec {
+
+  "jsonlRecord" should "print a valid JSON string" in {
+    val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord)
+    val jvalue = parse(s)
+    assert(jvalue.isInstanceOf[JValue])
+  }
+
+  it should "render a field that's a String" in {
+    val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord)
+    val jvalue = parse(s)
+    assert(
+      compact(render(jvalue \ "id")) == "\"7738a840caff15224f50cf17eade27e6\""
+    )
+  }
+
+  it should "render a field that's a sequence" in {
+    val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord)
+    val jvalue = parse(s)
+    val title = jvalue \ "sourceResource" \ "title"
+    assert(title.isInstanceOf[JArray])
+    assert(compact(render(title(0))) == "\"The Title\"")
+  }
+
+  it should "render a field that requires a map() on a sequence" in {
+    val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord)
+    val jvalue = parse(s)
+    val collection = jvalue \ "sourceResource" \ "collection"
+    assert(collection.isInstanceOf[JArray])
+    assert(
+      compact(render(collection(0))) == "{\"title\":\"The Collection\"}"
+    )
+  }
+
+  it should "have empty arrays for fields that have no data" in {
+    // Those fields that are optional are 0-n, so they will be arrays.
+    val s: String = jsonlRecord(EnrichedRecordFixture.minimalEnrichedRecord)
+    val jvalue = parse(s)
+    assert(
+      compact(render(jvalue \ "sourceResource" \ "collection")) == "[]"
+    )
+  }
+
+}


### PR DESCRIPTION
See https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1479

This adds a package method to `dpla.ingestion3.model` that returns a string for a single JSON object for a DPLA item record, in such a way that will be suitable for JSONL output.

The application now has a lot of FIXME comments for fields that don't translate between MAPv4 and MAPv3, and others that I wasn't sure how to fill in. There are also some FIXMEs for things I think need to be changed, but are outside the scope of DT-1479. It's possible that new stories need to be generated to take care of some of these, or some may already be slated for change.

A `println(s)` statement can be added to JsonStringTest to print out the JSON
for inspection.  Here is what I am getting:
```
{"id":"e9de22c337ebacb4a7f8da8ce90043d2","@context":"http://dp.la/api/items/context","@id":"http://dp.la/api/items/e9de22c337ebacb4a7f8da8ce90043d2","admin":{"sourceResource":{"title":["The Title"]}},"aggregatedCHO":"#sourceResource","dataProvider":"The Data Provider","ingestDate":"FIXME","ingestType":"item","isShownAt":"https://example.org/record/123","object":"https://example.org/record/123.html","originalRecord":"https://dp.la/TODO","provider":"The Provider","sourceResource":{"@id":"http://dp.la/api/items/e9de22c337ebacb4a7f8da8ce90043d2#SourceResource","collection":[{"title":"The Collection"}],"contributor":["J Doe"],"creator":["J Doe"],"date":[{"displayDate":"5.7.2012","begin":"2012-05-07","end":"2012-05-07"}],"description":["The description"],"extent":["200 pp.","8 x 10 in."],"format":["handwritten letter","gelatin silver print"],"identifier":["us-history-13243","j-doe-archives-2343"],"language":[{"name":"English","iso639_3":"eng"}],"publisher":["The Publisher"],"relation":"FIXME","rights":["Public Domain"],"spatial":"FIXME","specType":"FIXME","subject":["Birds"],"temporal":[{"displayDate":"1920s","begin":"1920-01-01","end":"1929-12-31"},{"displayDate":"1930s","begin":"1930-01-01","end":"1939-12-31"}],"title":["The Title"],"type":["image","text"]},"type":"ore:Aggregation"}
```

This PR's commits should be squashed manually before being merged, because some of them should remain distinct.
