### PR TITLE
Dt 1474 abstract oai class

### DIFF
--- a/src/main/scala/dpla/ingestion3/OaiHarvesterMain.scala
+++ b/src/main/scala/dpla/ingestion3/OaiHarvesterMain.scala
@@ -15,48 +15,8 @@ import scala.util.{Failure, Success, Try}
 
 /**
   * Entry point for running an OAI harvest.
-  *
-  * For argument options, @see OaiHarvesterConf.
   */
 object OaiHarvesterMain {
-
-  val recordSchemaStr =
-    """{
-        "namespace": "dpla.avro",
-        "type": "record",
-        "name": "OriginalRecord.v1",
-        "doc": "",
-        "fields": [
-          {"name": "id", "type": "string"},
-          {"name": "document", "type": "string"},
-          {"name": "set_id", "type": "string"},
-          ("name": "set_document", "type": "string"},
-          {"name": "provider", "type": "string"},
-          {"name": "mimetype", "type": { "name": "MimeType",
-           "type": "enum", "symbols": ["application_json", "application_xml", "text_turtle"]}
-           }
-        ]
-      }
-    """//.stripMargin // TODO we need to template the document field so we can record info there
-
-  // This schema String is printed to help with debugging.
-  // It is NOT implemented during the write operation b/c sets are written to CSV.
-  val setSchemaStr =
-    """{
-        "namespace": "dpla.avro",
-        "type": "set",
-        "name": "OriginalRecord.v1",
-        "doc": "",
-        "fields": [
-          {"name": "id", "type": "string"},
-          {"name": "document", "type": "string"},
-          {"name": "provider", "type": "string"},
-          {"name": "mimetype", "type": { "name": "MimeType",
-           "type": "enum", "symbols": ["application_json", "application_xml", "text_turtle"]}
-           }
-        ]
-      }
-    """
 
   val logger = LogManager.getLogger(OaiHarvesterMain.getClass)
 
@@ -106,7 +66,7 @@ object OaiHarvesterMain {
     }
 
     runHarvest() match {
-      case Success(results) => {
+      case Success(results) =>
         results.persist(StorageLevel.DISK_ONLY)
 
         val dataframe = results.withColumn("provider", lit(provider))
@@ -115,28 +75,13 @@ object OaiHarvesterMain {
         // Log the results of the harvest
         logger.info(s"Harvested ${dataframe.count()} records")
 
-        readerOptions("verb") match {
-          // Write records to avro.
-          // This task may require a large amount of driver memory.
-          case "ListRecords" => {
-            println(recordSchemaStr)
+        val schema = dataframe.schema
 
-            dataframe.write
-              .format("com.databricks.spark.avro")
-              .option("avroSchema", recordSchemaStr)
-              .avro(outputDir)
-          }
-          // Write sets to csv.
-          case "ListSets" => {
-            println(setSchemaStr)
+        dataframe.write
+          .format("com.databricks.spark.avro")
+          .option("avroSchema", schema.toString)
+          .avro(outputDir)
 
-            dataframe.coalesce(1).write
-              .format("com.databricks.spark.csv")
-              .option("header", true)
-              .csv(outputDir)
-          }
-        }
-      }
       case Failure(f) => logger.fatal(s"Unable to harvest records. ${f.getMessage}")
     }
     // Stop spark session.

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/DefaultSource.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/DefaultSource.scala
@@ -36,12 +36,6 @@ class DefaultSource extends RelationProvider {
     new OaiRelation(endpoint, verb, metadataPrefix, harvestAllSets, setlist, blacklist)(sqlContext)
   }
 
-  def getMetadataPrefix(parameters: Map[String, String]): String = {
-    (parameters.get("metadataPrefix"), parameters.get("verb")) match {
-      case (Some(prefix), Some(verb)) => prefix
-    }
-  }
-
   def getEndpoint(parameters: Map[String, String]): String = {
     val endpoint = parameters.get("endpoint")
     (endpoint, validateUrl(endpoint.getOrElse(""))) match {
@@ -79,13 +73,12 @@ class DefaultSource extends RelationProvider {
 
   def getHarvestAllSets(parameters: Map[String, String]): Boolean = {
     parameters.get("harvestAllSets") match {
-      case Some(x) => {
+      case Some(x) =>
         x.toLowerCase match {
-          case("true") => true
-          case("false") => false
-          case (_) => throwUnrecognizedArgException(x)
+          case "true" => true
+          case "false" => false
+          case _ => throwUnrecognizedArgException(x)
         }
-      }
       case _ => false
     }
   }
@@ -105,9 +98,7 @@ class DefaultSource extends RelationProvider {
   }
 
   // Converts a comma-separated String of sets to an Array of sets.
-  def parseSets(sets: String): Array[String] = {
-    sets.split(",").map(_.trim)
-  }
+  def parseSets(sets: String): Array[String] = sets.split(",").map(_.trim)
 
   def throwMissingArgException(arg: String) = {
     val msg = s"Missing argument: $arg"

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/OaiRecord.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/OaiRecord.scala
@@ -1,4 +1,0 @@
-package dpla.ingestion3.harvesters.oai
-
-// Represents a single record from an OAI Harvest.
-case class OaiRecord(id: String, document: String, set: Option[OaiSet] = None)

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/OaiResponse.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/OaiResponse.scala
@@ -1,0 +1,31 @@
+package dpla.ingestion3.harvesters.oai
+
+// Represents a single page response from an OAI harvest.
+sealed trait OaiResponse
+
+// Url and text are optional b/c there may be errors in formulating the URL or
+// parsing the XML response.
+case class OaiSource(queryParams: Map[String, String],
+                     url: Option[String] = None,
+                     text: Option[String] = None) extends OaiResponse
+
+// A single page of successfully parsed records.
+case class RecordsPage(records: Seq[OaiRecord]) extends OaiResponse
+
+// A single page of successfully parsed sets.
+case class SetsPage(sets: Seq[OaiSet]) extends OaiResponse
+
+// An error that occurs during the harvest, but that does not cause total failure.
+case class OaiError(message: String,
+                    errorSource: OaiSource) extends OaiResponse
+
+// A single record from an OAI Harvest.
+case class OaiRecord(id: String,
+                     document: String,
+                     setIds: Seq[String],
+                     recordSource: OaiSource)
+
+// A single set from an OAI harvest.
+case class OaiSet(id: String,
+                  document: String,
+                  setSource: OaiSource)

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/OaiResponseBuilder.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/OaiResponseBuilder.scala
@@ -2,12 +2,15 @@ package dpla.ingestion3.harvesters.oai
 
 import java.net.URL
 import java.nio.charset.Charset
+
 import dpla.ingestion3.harvesters.OaiQueryUrlBuilder
+
 import org.apache.http.client.fluent.Request
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SQLContext
+
 import scala.annotation.tailrec
-import scala.xml.XML
+import scala.util.{Try, Success, Failure}
 
 /**
  * This class handles requests to the OAI feed.
@@ -21,69 +24,111 @@ class OaiResponseBuilder (endpoint: String)
   val urlBuilder = new OaiQueryUrlBuilder
 
   /**
-    * Get one to many pages of sets.
-    * Results will include all sets.
+    * Get one to many pages of sets, and any errors that occurred in the process
+    * of harvesting said sets.
+    *
+    * @param pageProcessor a parital function that indicates how a response from
+    *                      the OAI feed should be processed, e.g. if sets should
+    *                      be parsed according to a whitelist or blacklist.
+    *
+    * @return RDD of OaiResponses, including SetsPages and OaiErrors.
     */
-  def getSets: RDD[OaiSet] = {
+  def getSets(pageProcessor: PartialFunction[(OaiSource), OaiResponse]): RDD[OaiResponse] = {
     val baseParams = Map("endpoint" -> endpoint, "verb" -> "ListSets")
-    val response = getMultiPageResponse(baseParams)
-    val responseRdd = sqlContext.sparkContext.parallelize(response)
-    responseRdd.flatMap(page => parseSets(page))
+    val multiPageResponse = getMultiPageResponse(baseParams)
+    val responseRdd = sqlContext.sparkContext.parallelize(multiPageResponse)
+
+    responseRdd.map{
+      // Apply partial function to process the OaiSource in some specific way.
+      case page: OaiSource => pageProcessor(page)
+      // Retain other responses (ie. errors) as given.
+      case response: OaiResponse => response
+    }
+  }
+
+  def getAllSets(): RDD[OaiResponse] = {
+    val allSetsPf: PartialFunction[(OaiSource), OaiResponse] = {
+      case page => OaiResponseProcessor.getAllSets(page)
+    }
+    getSets(allSetsPf)
+  }
+
+
+  // Get only those sets included in a given whitelist.
+  def getSetsInclude(setIds: Array[String]) = {
+    val whitelistPf: PartialFunction[(OaiSource), OaiResponse] = {
+      case page => OaiResponseProcessor.getSetsByWhitelist(page, setIds)
+    }
+    getSets(whitelistPf)
+  }
+
+  // Get all sets except those included in a given blacklist.
+  def getSetsExclude(setIds: Array[String]) = {
+    val blacklistPf: PartialFunction[(OaiSource), OaiResponse] = {
+      case page => OaiResponseProcessor.getSetsByBlacklist(page, setIds)
+    }
+    getSets(blacklistPf)
   }
 
   /**
-    * Get one to many pages of records.
+    * Get one to many pages of records, and any errors incurred during the
+    * process of harvesting said records.
     * Results will include all records, regardless of whether or not they belong
     * to a set.
     * @param opts Optional OAI args, eg. metadataPrefix
     */
-  def getRecords(opts: Map[String, String]): RDD[OaiRecord] = {
-    val sets = getSets.collect
+  def getAllRecords(opts: Map[String, String]): RDD[OaiResponse] = {
     val baseParams = Map("endpoint" -> endpoint, "verb" -> "ListRecords")
-    val response = getMultiPageResponse(baseParams, opts)
-    val responseRdd = sqlContext.sparkContext.parallelize(response)
-    val recordsRdd = responseRdd.flatMap(page => parseRecords(page))
-
-    recordsRdd.flatMap(record => {
-      // Get set ids from the record document.
-      // Records may have 0 to many sets ids.
-      val node = XML.loadString(record.document)
-      val setIds = OaiResponseProcessor.getSetIdsFromRecord(node)
-
-      // Map each set id to an OaiSet.
-      // Create a new OaiRecord that contains the OaiSet.
-      val newRecords = setIds.map(id => {
-        val set = sets.filter(s => s.id == id).headOption
-        new OaiRecord(record.id, record.document, set)
-      })
-
-      // If there are any new OaiRecords with sets, return them.
-      // Otherwise, return the original OaiRecord.
-      newRecords.size match {
-        case 0 => Seq(record)
-        case _ => newRecords
-      }
-    })
+    val multiPageResponse = getMultiPageResponse(baseParams, opts)
+    val responseRdd = sqlContext.sparkContext.parallelize(multiPageResponse)
+    val recordsRdd = responseRdd.map(response => parseRecordsResponse(response))
+    recordsRdd.union(getAllSets)
   }
 
   /**
     * Get one to many pages of records from given sets.
-    * @param sets Sets from which to harvest records
+    * @param setResponses Set pages containing sets from which to harvest records
+    *                     or errors incurred during the process of harvesting sets.
     * @param opts Optional OAI args, eg. metadataPrefix
     */
-  def getRecordsBySets(sets: Array[OaiSet],
-                       opts: Map[String, String] = Map()): RDD[OaiRecord] = {
+  def getRecordsBySets(setResponses: RDD[OaiResponse],
+                       opts: Map[String, String] = Map()): RDD[OaiResponse] = {
 
     val baseParams = Map("endpoint" -> endpoint, "verb" -> "ListRecords")
-    val setRdd = sqlContext.sparkContext.parallelize(sets)
 
-    setRdd.flatMap(
-      set => {
-        val options = opts + ("set" -> set.id)
-        val response = getMultiPageResponse(baseParams, options)
-        response.flatMap(page => parseRecords(page, Some(set)))
+    // Get ids for all sets (any any errors incurred in process).
+    val setIds: RDD[String] = setResponses.flatMap {
+      case page: SetsPage => page.sets.map(_.id)
+      // For OaiErrors, etc. return an empty sequence.
+      case _ => Seq()
+    }
+
+    // Repartition ids so they are evenly distributed across clusters.
+    val repartitioned = setIds.repartition(setIds.partitions.size)
+
+    /**
+      * Get all records for each set (and any errors incurred in process).
+      * Any single record may appear in multiple sets.
+      *
+      * @return RDD of OaiResponses, including RecordsPages and OaiErrors.
+      */
+    val records: RDD[OaiResponse] = repartitioned.flatMap(
+      setId => {
+        val options = opts + ("set" -> setId)
+        val multiPageResponse = getMultiPageResponse(baseParams, options)
+        multiPageResponse.map(response => parseRecordsResponse(response))
       }
     )
+
+    // Return all sets, records, and errors.
+    records.union(setResponses)
+  }
+
+  def parseRecordsResponse(response: OaiResponse): OaiResponse = {
+    response match {
+      case page: OaiSource => OaiResponseProcessor.getRecords(page)
+      case _ => response
+    }
   }
 
   /**
@@ -91,25 +136,34 @@ class OaiResponseBuilder (endpoint: String)
     * Makes an initial call to the feed to get the first page of results.
     * For this and all subsequent pages, calls the next page if a resumption
     * token is present.
-    * Returns a single List of single-page responses as Strings.
+    *
+    * @return Un-parsed response page from OAI requests, including OaiSources
+    *         and OaiErrors.
     */
   def getMultiPageResponse(baseParams: Map[String, String],
-                           opts: Map[String, String] = Map()): List[String] = {
+                           opts: Map[String, String] = Map()): List[OaiResponse] = {
 
     @tailrec
-    def loop(data: List[String]): List[String] = {
+    def loop(data: List[OaiResponse]): List[OaiResponse] = {
 
-      val token = OaiResponseProcessor.getResumptionToken(data.head)
+      data.headOption match {
 
-      token match {
-        case None => data
-        case Some(token) => {
-          // Resumption tokens are exclusive, meaning a request with a token
-          // cannot have any additional optional args.
-          val nextParams = baseParams + ("resumptionToken" -> token)
-          val nextResponse = getSinglePageResponse(nextParams)
-          loop(nextResponse :: data)
-        }
+        case Some(previous: OaiSource) =>
+          val text = previous.text.getOrElse("")
+          val token = OaiResponseProcessor.getResumptionToken(text)
+
+          token match {
+            case None => data
+            case Some(token) =>
+              // Resumption tokens are exclusive, meaning a request with a token
+              // cannot have any additional optional args.
+              val nextParams = baseParams + ("resumptionToken" -> token)
+              val nextResponse = getSinglePageResponse(nextParams)
+              loop(nextResponse :: data)
+          }
+        // If there is an error or unexpected response type, return all data
+        // collected up to this point (including the error or unexpected response).
+        case _ => data
       }
     }
 
@@ -119,11 +173,35 @@ class OaiResponseBuilder (endpoint: String)
     loop(List(firstResponse))
   }
 
-  // Returns a single page response as a single String
-  def getSinglePageResponse(queryParams: Map[String, String]): String = {
-    val url = urlBuilder.buildQueryUrl(queryParams)
-    println(url) // for testing purposes, can delete later
-    getStringResponse(url)
+  /**
+    * Get a single-page, unparsed response from the OAI feed, or an error if
+    * one occurs.
+    *
+    * @param queryParams parameters for a single OAI request.
+    * @return OaiSource or OaiError
+    */
+  def getSinglePageResponse(queryParams: Map[String, String]): OaiResponse = {
+
+    getUrl(queryParams) match {
+      // Error building URL
+      case Failure(e) =>
+        val source = OaiSource(queryParams)
+        OaiError(e.toString, source)
+      case Success(url) =>
+        getStringResponse(url) match {
+          // HTTP error
+          case Failure(e) =>
+            val source = OaiSource(queryParams, Some(url.toString))
+            OaiError(e.toString, source)
+          case Success(response) =>
+            OaiSource(queryParams, Some(url.toString), Some(response))
+        }
+    }
+  }
+
+  // Attempts to build a URL based on given query params.
+  def getUrl(queryParams: Map[String, String]): Try[URL] = Try {
+    urlBuilder.buildQueryUrl(queryParams)
   }
 
   /**
@@ -131,29 +209,16 @@ class OaiResponseBuilder (endpoint: String)
     *
     * @param url URL
     *            OAI request URL
-    * @return String
+    * @return Try[String]
     *         String response
     *
     *         OAI-PMH XML responses must be enncoded as UTF-8.
     * @see https://www.openarchives.org/OAI/openarchivesprotocol.html#XMLResponse
-    *
-    *      TODO: Handle failed HTTP request.
     */
-
-  def getStringResponse(url: URL) : String = {
+  def getStringResponse(url: URL) : Try[String] = Try {
     Request.Get(url.toURI)
       .execute()
       .returnContent()
-        .asString(Charset.forName("UTF8"))
-  }
-
-  def parseSets(page: String): Seq[OaiSet] = {
-    val xml = XML.loadString(page)
-    OaiResponseProcessor.getSets(xml)
-  }
-
-  def parseRecords(page: String, set: Option[OaiSet] = None): Seq[OaiRecord] = {
-    val xml = XML.loadString(page)
-    OaiResponseProcessor.getRecords(xml, set)
+      .asString(Charset.forName("UTF8"))
   }
 }

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/OaiSet.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/OaiSet.scala
@@ -1,4 +1,0 @@
-package dpla.ingestion3.harvesters.oai
-
-// Represents a single set from an OAI harvest.
-case class OaiSet(id: String, document: String)

--- a/src/test/scala/dpla/ingestion3/data/TestOaiData.scala
+++ b/src/test/scala/dpla/ingestion3/data/TestOaiData.scala
@@ -18,17 +18,17 @@ object TestOaiData {
         </header>
       </OAI-PMH>"""
 
-    val paOaiErrorRsp: Elem =
-    <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+    val paOaiErrorRsp: String =
+    """<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
       <responseDate>2017-01-27T05:10:17Z</responseDate>
       <request verb="ListRecords">http://localhost:8080/fedora/oai</request>
       <error code="cannotDisseminateFormat">
         Repository does not provide that format in OAI-PMH responses.
       </error>
-    </OAI-PMH>
+    </OAI-PMH>"""
 
-  val paOaiListRecordsRsp: Elem =
-    <OAI-PMH
+  val paOaiListRecordsRsp: String =
+    """<OAI-PMH
     xmlns="http://www.openarchives.org/OAI/2.0/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
       <responseDate>2017-01-21T17:24:56Z</responseDate>
@@ -40,6 +40,7 @@ object TestOaiData {
               oai:libcollab.temple.edu:fedora-system:ContentModel-3.0
             </identifier>
             <datestamp>2008-07-02T05:09:44Z</datestamp>
+            <setSpec>foobar</setSpec>
           </header>
           <metadata>
             <oai_dc:dc
@@ -340,10 +341,10 @@ object TestOaiData {
         </record>
         <resumptionToken expirationDate="2017-01-21T17:33:16Z" cursor="0">90d421891feba6922f57a59868d7bcd1</resumptionToken>
       </ListRecords>
-    </OAI-PMH>
+    </OAI-PMH>"""
 
-  val inOaiListSetsRsp: Elem =
-    <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  val inOaiListSetsRsp: String =
+    """<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
       <responseDate>2017-07-20T19:58:26Z</responseDate>
       <request verb="ListSets">http://dpla.library.in.gov/OAIHandler</request>
       <ListSets>
@@ -368,5 +369,5 @@ object TestOaiData {
           <setName>Shortridge High School Yearbook Collection</setName>
         </set>
     </ListSets>
-  </OAI-PMH>
+  </OAI-PMH>"""
 }


### PR DESCRIPTION
The harvest does not fail completely due to errors with single requests or responses.  Instead, the harvest will complete as much as possible, and return both successful responses, and actionable information about failures.

New case classes allow us to track information about the harvesting process.  Each individual request to the OAI feed begins with the instantiation of an `OaiSource`, which at minimum stores the parameters for that query.  

1. Query is initiated.  `OaiSource` is instantiated with the query params.
2. URL is formed from the query param and stored in the `OaiSource`.
3. HTTP request is made.  Response is stored in `OaiSource` as a String.
4. Response string is parsed into XML.
5. Response XML is checked to see if it contains an error message.  
6. Response XML is parsed into records or sets.

An error can occur during steps 2-5, in which case an `OaiError` is returned with the `OaiSource`.  Otherwise, records and sets are returned, also with their respective `OaiSource`s.

The new schema for the output DataFrame is:

```
root
 |-- set: struct (nullable = true)
 |    |-- id: string (nullable = true)
 |    |-- document: string (nullable = true)
 |    |-- setSource: struct (nullable = true)
 |    |    |-- queryParams: map (nullable = true)
 |    |    |    |-- key: string
 |    |    |    |-- value: string (valueContainsNull = true)
 |    |    |-- url: string (nullable = true)
 |    |    |-- text: string (nullable = true)
 |-- record: struct (nullable = true)
 |    |-- id: string (nullable = true)
 |    |-- document: string (nullable = true)
 |    |-- setIds: array (nullable = true)
 |    |    |-- element: string (containsNull = true)
 |    |-- recordSource: struct (nullable = true)
 |    |    |-- queryParams: map (nullable = true)
 |    |    |    |-- key: string
 |    |    |    |-- value: string (valueContainsNull = true)
 |    |    |-- url: string (nullable = true)
 |    |    |-- text: string (nullable = true)
 |-- error: struct (nullable = true)
 |    |-- message: string (nullable = true)
 |    |-- errorSource: struct (nullable = true)
 |    |    |-- queryParams: map (nullable = true)
 |    |    |    |-- key: string
 |    |    |    |-- value: string (valueContainsNull = true)
 |    |    |-- url: string (nullable = true)
 |    |    |-- text: string (nullable = true)
```

Note: Sets can no longer be persisted as CSV files b/c they have a complex, nested data type.  They are saved as AVRO files.