### PR TITLE
Update Avro schemas to match specs, load from files

### DIFF
--- a/src/main/resources/avro/IndexRecord_MAP3.avsc
+++ b/src/main/resources/avro/IndexRecord_MAP3.avsc
@@ -1,0 +1,11 @@
+
+{
+  "namespace": "dpla.avro.v1.MAP3_1",
+  "type": "record",
+  "name": "IndexRecord",
+  "doc": "",
+  "fields": [
+  {"name": "id", "type": "string"},
+  {"name": "document", "type": "string"}
+  ]
+}

--- a/src/main/resources/avro/IndexRecord_MAP4.avsc
+++ b/src/main/resources/avro/IndexRecord_MAP4.avsc
@@ -1,0 +1,10 @@
+{
+  "namespace": "dpla.avro.v1.MAP4_x",
+  "type": "record",
+  "name": "IndexRecord.v1",
+  "doc": "",
+  "fields": [
+  {"name": "id", "type": "string"},
+  {"name": "document", "type": "string"}
+  ]
+}

--- a/src/main/resources/avro/MAPRecord.avsc
+++ b/src/main/resources/avro/MAPRecord.avsc
@@ -1,0 +1,386 @@
+// See http://dp.la/info/wp-content/uploads/2015/03/MAPv4.pdf
+// and https://dp.la/info/wp-content/uploads/2013/04/DPLA-MAP-V3.1-2.pdf
+//
+// Figures below like "1" or "0-1" indicate field obligations specified in those
+// documents.
+//
+// Fields are mostly taken from the MAPv4 document, except for Place, which is
+// pulled from the MAPv3.1 document.
+{
+  "namespace": "dpla.avro.v1.MAP4_x",
+  "type": "record",
+  "name": "MAPRecord",
+  "doc": "",
+
+  "types": [
+  {"name": "StringArray", "type": "array", "items": "string"},
+  {
+    "name": "Collection",  // dcmitype:Collection
+    "type": "record",
+    "fields": [
+    {   // 0-1
+      "name": "title",
+      "type": ["null", "string"],
+      "default": null
+    },
+    {   // 0-1
+      "name": "description",
+      "type": ["null", "string"],
+      "default": null
+    }
+    ]
+  },
+  {
+    "name": "Agent",  // edm:Agent
+    "type": "record",
+    "fields": [
+    { // 0-1
+      "name": "name",
+      "type": ["null", "string"],
+      "default": null
+    },
+    { // 0-1
+      "name": "providedLabel",
+      "type": ["null", "string"],
+      "default": null
+    },
+    { // 0-1
+      "name": "note",
+      "type": ["null", "string"],
+      "default": null
+    },
+    { // 0-1
+      "name": "inScheme",
+      "type": ["null", "string"],
+      "default": null
+    },
+    { // 0-1
+      "name": "exactMatch",
+      "type": ["null", "StringArray"],
+      "default": null
+    },
+    {
+      // 0-n
+      "name": "closeMatch",
+      "type": ["null", "StringArray"],
+      "default": null
+    }
+    ]
+  },
+  {"name": "AgentArray", "type": "array", "items": "Agent"},
+  {
+    "name": "Concept",  // skos:Concept
+    "type": "record",
+    "fields": [
+    {
+      // 0-1
+      "name": "name",  // skos:prefLabel
+      "type": ["null", "string"],
+      "default": null
+    },
+    {
+      // 0-1
+      "name": "providedLabel",
+      "type": ["null", "string"],
+      "default": null
+    },
+    {
+      // 0-1
+      "name": "note",
+      "type": ["null", "string"],
+      "default": null
+    },
+    {
+      // 0-1
+      "name": "inScheme",
+      "type": ["null", "string"],
+      "default": null
+    },
+    {
+      // 0-n
+      "name": "exactMatch",
+      "type": ["null", "StringArray"],
+      "default": null
+    },
+    {
+      // 0-n
+      "name": "closeMatch",
+      "type": ["null", "StringArray"],
+      "default": null
+    }
+    ]
+  },
+  {"name": "ConceptArray", "type": "array", "items": "Concept"},
+  {
+    "name": "Place",  // dpla:Place from MAP 3.1 spec
+    "type": "record",
+    "fields": [
+    {"name": "name", "type": "string"}, // 1
+    {   // 0-1
+      "name": "city",
+      "type": ["null", "string"],
+      "default": null
+    },
+    {   // 0-1
+      "name": "county",
+      "type": ["null", "string"],
+      "default": null
+    },
+    {   // 0-1
+      "name": "state",
+      "type": ["null", "string"],
+      "default": null
+    },
+    {   // 0-1
+      "name": "country",
+      "type": ["null", "string"],
+      "default": null
+    },
+    {   // 0-1
+      "name": "region",
+      "type": ["null", "string"],
+      "default": null
+    },
+    {   // 0-1
+      "name": "coordinates",
+      "type": ["null", "string"],
+      "default": null
+    }
+    ]
+  },
+  {"name": "PlaceArray", "type": "array", "items": "Place"},
+  {
+    "name": "TimeSpan",  // edm:TimeSpan
+    "type": "record",
+    "fields": [
+    {   // 0-n
+      "name": "providedLabel",
+      "type": ["null", "StringArray"],
+      "default": null
+    },
+    {
+      // 0-1
+      "name": "begin",
+      "type": ["null", "string"],
+      "default": null
+    },
+    {
+      // 0-1
+      "name": "end",
+      "type": ["null", "string"],
+      "default": null
+    }
+    ]
+  },
+  {"name": "TimeSpanArray", "type": "array", "items": "TimeSpan"}
+  ],  // types
+
+  "fields": [
+
+  // 1
+  {"name": "id", "type": "string", "doc": "DPLA record ID"},
+
+  // 1
+  {
+    "name": "ingestType",
+    "type": {
+      "name": "IngestType",
+      "type": "enum",
+      "symbols": ["item", "collection"]
+    }
+  },
+
+  // 1
+  {
+    "name": "ingestDate",
+    "type": "long",
+    "doc": "UNIX timestamp"
+  },
+
+  // 1
+  {"name": "dataProvider", "type": "string"},
+
+  // 0-n
+  {
+    "name": "hasView",
+    "type": ["null", "StringArray"],
+    "default": null
+  },
+
+  // 0-n
+  {
+    "name": "intermediateProvider",
+    "type": ["null", "StringArray"],
+    "default": null
+  },
+
+  // 1
+  {"name": "isShownAt", "type": "string"},
+
+  // 0-1
+  {
+    "name": "object",
+    "type": ["null", "string"],
+    "default": null
+  },
+
+  // 1
+  {"name": "originalRecord", "type": "string"},
+
+  // 1
+  {"name": "preview", "type": "string"},
+
+  // 1
+  {"name": "provider", "type": "string"},
+
+  // 0-1
+  {
+    "name": "rightsStatement",
+    "type": ["null", "string"],
+    "default": null
+  },
+
+  // 1
+  {
+    "name": "sourceResource",
+    "type": {
+      "type": "record",
+      "name": "SourceResource",
+      "fields": [
+
+    {   // 0-n
+      "name": "alternative",
+      "type": ["null", "StringArray"],
+      "default": null
+    },
+    {   // 0-n
+      "name": "collection",
+      "type": ["null", "CollectionArray"],
+      "default": null
+    },
+    {   // 0-n
+      "name": "contributor",
+      "type": ["null", "AgentArray"],
+      "default": null
+    },
+    {   // 0-n
+      "name": "creator",
+      "type": ["null", "AgentArray"],
+      "default": null
+    },
+    {   // 0-n
+      "name": "date",
+      "type": ["null", "TimeSpanArray"],
+      "default": null
+    },
+    {
+      // 0-n
+      "name": "description",
+      "type": ["null", "StringArray"],
+      "default": null
+    },
+    {
+      // 0-n
+      "name": "extent",
+      "type": ["null", "StringArray"],
+      "default": null
+    },
+    {
+      // 0-n
+      "name": "format",
+      "type": ["null", "StringArray"],
+      "default": null
+    },
+    {
+      // 0-n
+      "name": "genre",
+      "type": ["null", "ConceptArray"],
+      "default": null
+    },
+    {
+      // 0-n
+      "name": "identifier",
+      "type": ["null", "StringArray"],
+      "default": null
+    },
+    {
+      // 0-n
+      "name": "language",
+      "type": ["null", "StringArray"],
+      "default": null
+    },
+    {
+      // 0-n
+      "name": "spatial",
+      "type": ["null", "PlaceArray"],
+      "default": null
+    },
+    {   // 0-n
+      "name": "publisher",
+      "type": ["null", "AgentArray"],
+      "default": null
+    },
+    {
+      // 0-n
+      "name": "relation",
+      "type": ["null", "StringArray"],
+      "default": null
+    },
+    {
+      // 0-n
+      "name": "isReplacedBy",
+      "type": ["null", "StringArray"],
+      "default": null
+    },
+    {
+      // 0-n
+      "name": "replaces",
+      "type": ["null", "StringArray"],
+      "default": null
+    },
+    {
+      // 1-n
+      "name": "rights",
+      "type": "StringArray"
+    },
+    {   // 0-n
+      "name": "rightsHolder",
+      "type": ["null", "AgentArray"],
+      "default": null
+    },
+    {
+      // 0-n
+      "name": "subject",
+      "type": ["null", "ConceptArray"],
+      "default": null
+    },
+    {   // 0-n
+      "name": "temporal",
+      "type": ["null", "TimeSpanArray"],
+      "default": null
+    },
+    {
+      // 1-n
+      "name": "title",
+      "type": "StringArray"
+    },
+    {
+      // 0-n
+      "name": "type",
+      "type": ["null", "StringArray"],
+      "default": null
+    }
+      ] // fields
+    }  // type
+
+  }, // sourceResource
+
+  {
+    "name": "title",
+    "type": ["null", "string"],
+    "doc": "Only for collection records"
+  }
+
+  ]  // fields
+
+}

--- a/src/main/resources/avro/OriginalRecord.avsc
+++ b/src/main/resources/avro/OriginalRecord.avsc
@@ -1,12 +1,16 @@
 {
-  "namespace": "dpla.avro.MAP_3.1",
+  "namespace": "dpla.avro.v1",
   "type": "record",
   "name": "OriginalRecord",
   "doc": "",
   "fields": [
-    {"name": "or_document", "type": "string", "default": ""},
-    {"name": "or_mimetype", "type": "string", "default": ""},
-    {"name": "id",          "type": "string"},
-    {"name": "rdf_document","type": "string", "default": ""}
+  {"name": "id", "type": "string"},
+  {"name": "ingestDate", "type": "long", "doc": "UNIX timestamp"},
+  {"name": "provider", "type": "string"},
+  {"name": "document", "type": "string"},
+  {"name": "mimetype",
+    "type": {"name": "MimeType",
+      "type": "enum",
+      "symbols": ["application_json", "application_xml", "text_turtle"]}}
   ]
 }

--- a/src/main/scala/dpla/ingestion3/EnricherMain.scala
+++ b/src/main/scala/dpla/ingestion3/EnricherMain.scala
@@ -13,7 +13,7 @@ import org.apache.spark.storage.StorageLevel
 import org.eclipse.rdf4j.model.Model
 import org.eclipse.rdf4j.model.util.ModelBuilder
 import org.eclipse.rdf4j.rio._
-import dpla.ingestion3.utils.Utils
+import dpla.ingestion3.utils.{FlatFileIO, Utils}
 import dpla.ingestion3.enrichments.Spatial
 
 /**
@@ -33,20 +33,6 @@ import dpla.ingestion3.enrichments.Spatial
  */
 object EnricherMain {
 
-  // Avro schema for our output
-  val schemaStr: String =
-    """
-    {
-      "namespace": "dpla.avro",
-      "type": "record",
-      "name": "MAPRecord.v1",
-      "doc": "Prototype enriched record",
-      "fields": [
-        {"name": "id", "type": "string"},
-        {"name": "document", "type": "string"}
-      ]
-    }
-    """
   val logger = LogManager.getLogger(EnricherMain.getClass)
 
   /*
@@ -64,6 +50,7 @@ object EnricherMain {
     val sparkMaster = args(0)
     val inputURI = args(1)
     val outputURI = args(2)
+    val schema = new FlatFileIO().readFileAsString("/avro/MapRecord.avsc")
 
     val start_time = System.currentTimeMillis()
 
@@ -75,7 +62,7 @@ object EnricherMain {
 
     val rdd: RDD[Row] = spark.read
       .format("com.databricks.spark.avro")
-      .option("avroSchema", schemaStr)
+      .option("avroSchema", schema)
       .load(inputURI)
       .rdd
 

--- a/src/main/scala/dpla/ingestion3/indexer/IndexerMain.scala
+++ b/src/main/scala/dpla/ingestion3/indexer/IndexerMain.scala
@@ -1,5 +1,6 @@
 package dpla.ingestion3.indexer
 
+import dpla.ingestion3.utils.FlatFileIO
 import org.apache.hadoop.mapred.JobConf
 import org.apache.spark.SparkConf
 import org.apache.spark.rdd.RDD
@@ -10,27 +11,14 @@ import org.elasticsearch.hadoop.mr.EsOutputFormat.EsOldAPIOutputCommitter
 
 object IndexerMain {
 
-  // See https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Ingestion+3+Storage+Specification
-  val schema: String = """
-  | {
-  |   "namespace": "dpla.avro.MAP_3.1",
-  |   "type": "record",
-  |   "name": "IndexRecord.v1",
-  |   "doc": "",
-  |   "fields": [
-  |     { "name": "id", "type": "string" },
-  |     { "name": "document", "type": "string" }
-  |   ]
-  | }
-  """.stripMargin //todo retrieve this from S3
-
   def main(args:Array[String]): Unit = {
 
     val input = args(0)
     val esCluster = args(1)
     val esPort = args(2)
     val index = args(3)
-    
+    val schema = new FlatFileIO().readFileAsString("/avro/IndexRecord_MAP3.avsc")
+
     val filter: Option[String] = if (args.isDefinedAt(4)) Some(args(4)) else None
 
     val conf = new SparkConf()

--- a/src/main/scala/dpla/ingestion3/utils/FileIO.scala
+++ b/src/main/scala/dpla/ingestion3/utils/FileIO.scala
@@ -7,6 +7,9 @@ import java.nio.file.StandardOpenOption.{CREATE, TRUNCATE_EXISTING}
 import org.apache.avro.Schema
 import org.apache.avro.file.{CodecFactory, DataFileWriter}
 import org.apache.avro.generic.{GenericDatumWriter, GenericRecordBuilder}
+import org.apache.commons.io.IOUtils
+
+import scala.io.Source
 
 /**
   * Basic FileIO ops
@@ -22,6 +25,16 @@ class FlatFileIO extends FileIO {
   def writeFile(record: String, outputFile: String): Unit = {
     val outFile = new File(outputFile).toPath
     Files.write(outFile, record.getBytes("utf8"), CREATE, TRUNCATE_EXISTING)
+  }
+
+  /**
+    * Reads a file and returns it as a single string
+    * @param name
+    * @return
+    */
+  def readFileAsString(name: String): String = {
+    val stream = getClass.getResourceAsStream(name)
+    try Source.fromInputStream(stream).mkString finally IOUtils.closeQuietly(stream)
   }
 }
 


### PR DESCRIPTION
Update Avro schema files to match the specification at
https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Ingestion+3+Storage+Specification

Remove hard coded schemas from driver classes.

Add a basic file reader method to FlatFileIO which returns the file
contents as a String.