### PR TITLE
Add mapping and enrichment entry points

### DIFF
--- a/src/main/scala/dpla/ingestion3/EnrichEntry.scala
+++ b/src/main/scala/dpla/ingestion3/EnrichEntry.scala
@@ -1,0 +1,89 @@
+package dpla.ingestion3
+
+import java.io.File
+
+import dpla.ingestion3.enrichments.EnrichmentDriver
+import dpla.ingestion3.model.DplaMapData
+import dpla.ingestion3.utils.Utils
+import org.apache.log4j.LogManager
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+
+/**
+  * Expects two parameters:
+  *   1) a path to the harvested data
+  *   2) a path to output the mapped data
+  *
+  *   Usage
+  *   -----
+  *   To invoke via sbt:
+  *     sbt "run-main dpla.ingestion3.EnrichEntry /input/path/to/mapped.avro /output/path/to/enriched.avro"
+  *
+  */
+
+object EnrichEntry {
+
+  def main(args: Array[String]): Unit = {
+
+    val logger = LogManager.getLogger(EnrichEntry.getClass)
+
+    if (args.length != 2)
+      logger.error("Incorrect number of parameters provided. Expected <input> <output>")
+
+    // Get files
+    val dataIn = args(0)
+    val dataOut = args(1)
+
+    val sparkConf = new SparkConf()
+      .setAppName("Enrichment")
+      // TODO there should be a central place to store the sparkMaster
+      .setMaster("local[*]")
+      // TODO: This spark.serializer is a kludge to get around serialization issues. Will be fixed in future ticket
+      .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+
+    implicit val dplaMapDataEncoder = org.apache.spark.sql.Encoders.kryo[DplaMapData]
+
+    val spark = SparkSession.builder()
+      .config(sparkConf)
+      .getOrCreate()
+
+    val sc = spark.sparkContext
+
+    // Need to keep this here despite what IntelliJ and Codacy say
+    import spark.implicits._
+
+    // Load the mapped records
+    val mappedRecords = spark.read
+      .format("com.databricks.spark.avro")
+      .load(dataIn)
+      .as[DplaMapData]
+
+    // Create a broadcast enrichment driver
+    val enrichment = sc.broadcast(new EnrichmentDriver)
+
+    // Run the enrichments over the Dataframe
+    val enrichedRecords = mappedRecords.map(
+      record => {
+        enrichment.value.enrich(record)
+      }
+    )
+
+    // Delete the output location if it exists
+    Utils.deleteRecursively(new File(dataOut))
+
+    // Save mapped records out to Avro file
+    enrichedRecords.toDF("document").write
+      .format("com.databricks.spark.avro")
+      .save(dataOut)
+
+
+    // Gather some stats
+    val mappedRecordCount = mappedRecords.count()
+    val enrichedRecordCount = enrichedRecords.count()
+
+    sc.stop()
+
+    logger.debug(s"Mapped ${mappedRecordCount} records and enriched ${enrichedRecordCount} records")
+    logger.debug(s"${mappedRecordCount-enrichedRecordCount} enrichment errors")
+  }
+}

--- a/src/main/scala/dpla/ingestion3/MappingEntry.scala
+++ b/src/main/scala/dpla/ingestion3/MappingEntry.scala
@@ -1,0 +1,89 @@
+package dpla.ingestion3
+
+import java.io.File
+
+import dpla.ingestion3.mappers.providers.{CdlExtractor, NaraExtractor}
+import dpla.ingestion3.model.DplaMapData
+import dpla.ingestion3.utils.Utils
+import org.apache.log4j.LogManager
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+
+/**
+  * Expects two parameters:
+  *   1) a path to the harvested data
+  *   2) a path to output the mapped data
+  *
+  *   Usage
+  *   -----
+  *   To invoke via sbt:
+  *     sbt "run-main dpla.ingestion3.MappingEntry /input/path/to/harvested.avro /output/path/to/mapped.avro"
+  */
+
+object MappingEntry {
+
+  def main(args: Array[String]): Unit = {
+    val logger = LogManager.getLogger(MappingEntry.getClass)
+
+    if (args.length != 2)
+      logger.error("Incorrect number of parameters provided. Expected <input> <output>")
+
+    // Get files
+    val dataIn = args(0)
+    val dataOut = args(1)
+
+    val sparkConf = new SparkConf()
+      .setAppName("Mapper")
+      // TODO there should be a central place to store the sparkMaster
+      .setMaster("local[*]")
+      // TODO: This spark.serializer is a kludge to get around serialization issues. Will be fixed in future ticket
+      .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+
+    implicit val dplaMapDataEncoder = org.apache.spark.sql.Encoders.kryo[DplaMapData]
+
+    val spark = SparkSession.builder()
+      .config(sparkConf)
+      .getOrCreate()
+
+    // Need to keep this here despite what IntelliJ and Codacy say
+    import spark.implicits._
+
+    // Load the harvested record dataframe
+    val harvestedRecords = spark.read
+      .format("com.databricks.spark.avro")
+      .load(dataIn)
+
+    // Take the first harvested record in the dataFrame and get the provider value
+    val shortName = harvestedRecords.take(1)(0).getAs[String]("provider").toLowerCase
+
+    // Match on the shortName to select the correct Extractor
+    val extractorClass = shortName match {
+      case "cdl" => classOf[CdlExtractor]
+      case "nara" => classOf[NaraExtractor]
+    }
+
+    // Run the mapping over the Dataframe
+    val mappedRecords = harvestedRecords.map(
+      record => {
+        extractorClass.getConstructor(classOf[String])
+          .newInstance(record.getAs[String]("document"))
+          .build
+      }
+    )
+
+    // Delete the output location if it exists
+    Utils.deleteRecursively(new File(dataOut))
+
+    // Save mapped records out to Avro file
+    mappedRecords.toDF("document").write
+      .format("com.databricks.spark.avro")
+      .save(dataOut)
+
+    // Gather some stats
+    val harvestedRecordCount = harvestedRecords.count()
+    val mappedRecordCount = mappedRecords.count()
+
+    logger.debug(s"Harvested ${harvestedRecordCount} records and mapped ${mappedRecordCount} records")
+    logger.debug(s"${harvestedRecordCount-mappedRecordCount} mapping errors")
+  }
+}

--- a/src/main/scala/dpla/ingestion3/confs/OaiHarvesterConf.scala
+++ b/src/main/scala/dpla/ingestion3/confs/OaiHarvesterConf.scala
@@ -21,7 +21,7 @@ import com.typesafe.config.ConfigFactory
   */
 
 class OaiHarvesterConf(arguments: Seq[String]) {
-  def load(): OaiConfig = {
+  def load(): OaiConf = {
     // Loads config file for more information about loading hierarchy please read
     // https://github.com/typesafehub/config#standard-behavior
     ConfigFactory.invalidateCaches()
@@ -34,7 +34,7 @@ class OaiHarvesterConf(arguments: Seq[String]) {
       }
     }
 
-    OaiConfig(
+    OaiConf(
       // Validate outputDir parameter here since it is not validated in DefaultSource
       outputDir = getProp("outputDir") match {
         case Some(d) => Some(d)
@@ -59,7 +59,7 @@ class OaiHarvesterConf(arguments: Seq[String]) {
   }
 }
 
-case class OaiConfig (
+case class OaiConf(
                        outputDir: Option[String],
                        endpoint: Option[String],
                        verb: Option[String],

--- a/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
@@ -17,10 +17,11 @@ object Geocoder extends Twofisher {
   }
 }
 
-class EnrichmentDriver {
+class EnrichmentDriver extends Serializable {
   val stringEnrichment = new StringEnrichments()
   val dateEnrichment = new ParseDateEnrichment()
   val spatialEnrichment = new SpatialEnrichment(Geocoder)
+  val langEnrichment = LanguageMapper
 
   /**
     * Applies a set of common enrichments that need to be run for all providers
@@ -36,9 +37,8 @@ class EnrichmentDriver {
     record.copy(
       DplaSourceResource(
         date = record.sourceResource.date.map(d => dateEnrichment.parse(d)),
-        language = record.sourceResource.language.map(LanguageMapper.mapLanguage),
-        place = record.sourceResource.place
-                      .map(p => spatialEnrichment.enrich(p))
+        language = record.sourceResource.language.map(l => LanguageMapper.mapLanguage(l)),
+        place = record.sourceResource.place.map(p => spatialEnrichment.enrich(p))
     ))
   }
 }

--- a/src/main/scala/dpla/ingestion3/enrichments/ParseDateEnrichment.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/ParseDateEnrichment.scala
@@ -8,7 +8,7 @@ import dpla.ingestion3.model.EdmTimeSpan
 
 import scala.annotation.tailrec
 
-class ParseDateEnrichment {
+class ParseDateEnrichment extends Serializable {
 
   //TODO ranges
   def parse(edtfOriginalDate: EdmTimeSpan, allowInterval: Boolean = false): EdmTimeSpan = {


### PR DESCRIPTION
Adds entry points for invoking mapping (a.k.a. `Extractors`) and enrichment jobs. Both entries accept only two parameters, the source data and output destination. 

The mapping entry point determines the correct mapper extractor to invoke by inspecting the `provider` property stored with the harvested data. 

The enrichment entry point only invokes the enrichments which are applied to all providers (see EnrichmentDriver for a complete list). Make all enrichment classes `Serailizable` to allow distribution over nodes.

**Running via sbt** 
`sbt "run-main dpla.ingestion3.MappingEntry /input/path/to/harvestedData.avro /output/path/to/mappedData.avro"`

`sbt "run-main dpla.ingestion3.EnrichEntry /input/path/to/mappedData.avro /output/path/to/enrichedData.avro"`

This also adds a retry() method to support geocodeResponse(). Tests showed that a single failed request to Twofishes, such as a timeout,  would fail the entire enrichment job. The geocodeResponse() method will now attempt to retry a failed request. If it does not succeed it will return a JNothing object which will cause the original value to be returned by #enrich(). 

