### PR TITLE
Fix error handling

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/oai/OaiResponseProcessor.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/OaiResponseProcessor.scala
@@ -40,7 +40,9 @@ object OaiResponseProcessor {
           case Some(node) =>
             val id = getRecordIdentifier(node)
             val setIds = getSetIdsFromRecord(node)
-            Some(OaiRecord(id, node.toString, setIds, source))
+            // Drop the entire page text from source when returning OaiRecord. Embedding the entire
+            // page text was triggering Out of Memory exceptions even on small harvests (200,000 records)
+            Some(OaiRecord(id, node.toString, setIds, source.copy(text = None) ))
           case _ => None
       })
     }


### PR DESCRIPTION
Rewrite error handling to quit on errors that are unparsable (XML parsing, OAI error, HTTP error). Previously, these errors were being swallowed and leading to an infinite loop where the first page was being requested over and over despite being an error.

No longer embeds entire response page in every single extracted item. This was causing OOM exceptions.