### PR TITLE
PA Extractor

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/Extractor.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/Extractor.scala
@@ -2,9 +2,11 @@ package dpla.ingestion3.mappers.providers
 
 import java.net.URI
 
-import dpla.ingestion3.model.{DplaMapData, EdmAgent}
+import dpla.ingestion3.model.{DplaMap, DplaMapData, DplaMapError, EdmAgent}
 import dpla.ingestion3.utils.Utils
 import org.apache.pig.data.utils.MethodHelper.NotImplemented
+
+import scala.util.{Failure, Success, Try}
 
 /**
   * Interface that all provider extractors implement.
@@ -14,7 +16,7 @@ trait Extractor {
   // Base item uri
   private val baseItemUri = "http://dp.la/api/items/"
 
-  def build(): DplaMapData
+  def build(): DplaMap
   def agent: EdmAgent
   /**
     * Build the base ID to be hashed. Implemented per provider
@@ -37,4 +39,19 @@ trait Extractor {
     * @return URI
     */
   protected def mintDplaItemUri(): URI = new URI(s"${baseItemUri}${mintDplaId()}")
+
+  /**
+    * Implicit method used to convert Try[DplaMap] objects to either
+    * DplaMapData or DplaMapError objects depending on whether the mapping
+    * task was performed without errors.
+    *
+    * @param data The result from Extractor.build()
+    * @return DplaMapData or DplaMapError
+    */
+  implicit def DplaDataToDataOrError(data: Try[DplaMap]) = data match {
+    case Success(s) => s
+      // TODO If the record ID is not available it would be helpful to dump the original record out here
+    case Failure(f) => DplaMapError(f.getMessage + s" for record " +
+      s"${getProviderBaseId().getOrElse(s"ID not available! !! TODO !! Dumping record...\n")}")
+  }
 }

--- a/src/main/scala/dpla/ingestion3/model/DplaMapData.scala
+++ b/src/main/scala/dpla/ingestion3/model/DplaMapData.scala
@@ -9,6 +9,7 @@ import dpla.ingestion3.model.DplaMapData._
   * and a union type for fields that can be literals or uris.
   */
 
+
 object DplaMapData {
   type ZeroToMany[T] = Seq[T]
   type AtLeastOne[T] = Seq[T]
@@ -18,6 +19,16 @@ object DplaMapData {
   type LiteralOrSkos = Either[String,SkosConcept]
 }
 
+sealed trait DplaMap
+
+/**
+  * Class for describing mapping errors
+  * @param errorMessage
+  */
+// TODO Work out additional useful properties and useful error reporting
+case class DplaMapError (
+                          errorMessage: String
+                         ) extends DplaMap
 /**
   * Container for the classes that represent an item in DPLA MAP.
   *
@@ -27,11 +38,11 @@ object DplaMapData {
   * @param edmWebResource Metadata about the item's representation on the provider's site.
   * @param oreAggregation Metadata about the aggretation of the item across it's source and representations.
   */
-case class DplaMapData(
+case class DplaMapData (
                          sourceResource: DplaSourceResource,
                          edmWebResource: EdmWebResource,
                          oreAggregation: OreAggregation
-                       )
+                       ) extends DplaMap
 
 //Core Classes
 
@@ -161,5 +172,4 @@ case class EdmTimeSpan(
                         begin: ZeroToOne[String] = None,
                         end: ZeroToOne[String] = None
                       )
-
 

--- a/src/main/scala/dpla/ingestion3/utils/Utils.scala
+++ b/src/main/scala/dpla/ingestion3/utils/Utils.scala
@@ -60,7 +60,8 @@ object Utils {
     id match {
       case Some(i) => DigestUtils.md5Hex(i)
       // TODO: Is more information required in this error message?
-      case _ => throw new IllegalArgumentException("Unable to mint an MD5 ID for record.")
+      case _ => throw new IllegalArgumentException(s"Unable to mint an MD5 ID given local " +
+        s"ID of ${id.getOrElse("**No ID provided**")}")
     }
   }
 


### PR DESCRIPTION
Adds the Pennsylvania extractor.  There are a lot of TODOs and follow-up points here but the core requirement of DT-1309 is addressed in this PR.

The Extractor class was rewritten so that #build() returns a DplaMap class which is inclusive of DplaMapData (success) and DplaMapError (failed mapping).

Additionally, this work may require a revision after reviewing changes to `DplaMapData`. 