### PR TITLE
Add PropertyValueReport

### DIFF
--- a/src/main/scala/dpla/ingestion3/ReporterMain.scala
+++ b/src/main/scala/dpla/ingestion3/ReporterMain.scala
@@ -26,10 +26,11 @@ import util.{Try, Failure}
   *
   * @see ReporterTest
   *
-  * @param token            The report name token
+  *
   * @param inputURI         Input URI or file path
   * @param outputURI        Output URI or file path
   * @param sparkMasterName  Spark master name, e.g. "local[1]"
+  * @param token            The report name token
   * @param reportParams     Additional parameters particular to the report
   */
 class Reporter (
@@ -44,6 +45,10 @@ class Reporter (
 
   private def getReport(token: String): Option[Report] = {
     token match {
+      case "propertyDistinctValue" =>
+        Some(new PropertyDistinctValueReport(
+          inputURI, outputURI, sparkMasterName, reportParams
+        ))
       case "propertyValue" =>
         Some(new PropertyValueReport(
           inputURI, outputURI, sparkMasterName, reportParams

--- a/src/main/scala/dpla/ingestion3/reports/PropertyDistinctValueReport.scala
+++ b/src/main/scala/dpla/ingestion3/reports/PropertyDistinctValueReport.scala
@@ -1,0 +1,108 @@
+package dpla.ingestion3.reports
+
+import org.apache.spark.sql.{DataFrame, Row, SparkSession, Dataset}
+import dpla.ingestion3.model._
+
+/**
+  * Property Distinct Value QA report.  Takes one field and gives a count of unique
+  * values.
+  *
+  * Fields currently supported:
+  *   - sourceResource.format
+  *   - sourceResource.rights
+  *   - sourceResource.type
+  *
+  * @example Example invocation:
+  *
+  *   $ sbt "run-main dpla.ingestion3.ReporterMain \
+  *     /path/to/enriched-data.avro /path/to/propvalreport local[2] \
+  *     propertyValue sourceResource.type"
+  *
+  *     ... This produces a directory named 'propvalreport' with a file in it
+  *     named 'part-< ... >.csv', with contents like:
+  *
+  *     value,count
+  *     physicalobject,1
+  *     dataset,13
+  *     [...]
+  *
+  * @param inputURI         Input URI or file path (Avro file / directory)
+  * @param outputURI        Output URI or file path (directory containing CSV
+  *                         file)
+  * @param sparkMasterName  Spark master name, e.g. "local[1]"
+  * @param params           Additional parameters, currently:
+  *                         params(0): The DPLA MAP field to analyze
+  */
+class PropertyDistinctValueReport(
+                            val inputURI: String,
+                            val outputURI: String,
+                            val sparkMasterName: String,
+                            val params: Array[String]
+                          ) extends Report {
+
+  /*
+   * We set instance fields from constructor arguments, and override accessor
+   * methods in order to make the class more amenable to unit testing.
+   * However ...
+   * FIXME: It's not clear how to write unit tests that involve Dataframes
+   * and Datasets, so there are no such tests for this class.
+   *
+   */
+  override val sparkAppName: String = "PropertyDistinctValueReport"
+  override def getInputURI: String = inputURI
+  override def getOutputURI: String = outputURI
+  override def getSparkMasterName: String = sparkMasterName
+  override def getParams: Option[Array[String]] = {
+    if (params.nonEmpty) Some(params) else None
+  }
+
+
+  /**
+    * Process the incoming dataset.
+    *
+    * @see          Report.process()
+    *
+    * @param ds     Dataset of DplaMapData (mapped or enriched records)
+    * @param spark  The Spark session, which contains encoding / parsing info.
+    * @return       DataFrame, typically of Row[value: String, count: Int]
+    */
+  override def process(ds: Dataset[DplaMapData],
+                       spark: SparkSession
+                      ): DataFrame = {
+
+    import spark.implicits._
+
+    val token: String = getParams match {
+      case Some(p) => p.head
+      case _ => throw new RuntimeException(s"No field specified")
+    }
+
+    token match {
+        /*
+         * FIXME: "java.lang.UnsupportedOperationException: No Encoder found
+         * for java.net.URI" for sourceResource.language, subject, and other
+         * fields of classes that have URIs, even if you're not evaluating
+         * one of the URI fields in that dpla.ingestion3.model case class.
+         */
+      case "sourceResource.format" =>
+        ds.map(dplaMapData => dplaMapData.sourceResource.format)
+          .flatMap(x => x)
+          .groupBy("value")
+          .count
+      case "sourceResource.rights" =>
+        ds.map(dplaMapData => dplaMapData.sourceResource.rights)
+          .flatMap(x => x)
+          .groupBy("value")
+          .count
+      case "sourceResource.type" =>
+        ds.map(dplaMapData => dplaMapData.sourceResource.`type`)
+          .flatMap(x => x)
+          .groupBy("value")
+          .count
+      case x =>
+        throw new RuntimeException(s"Unrecognized field name '$x'")
+    }
+
+  }
+
+}

--- a/src/test/scala/dpla/ingestion3/ReporterTest.scala
+++ b/src/test/scala/dpla/ingestion3/ReporterTest.scala
@@ -8,8 +8,19 @@ import dpla.ingestion3.reports._
 class ReporterTest extends FlatSpec
     with MockFactory with PrivateMethodTester {
 
-  "Reporter.getReport" should "return a PropertyValueReport given token " +
-      "'propertyValue'" in {
+  "Reporter.getReport" should "return a PropertyDistinctValueReport given token " +
+      "'propertyDistinctValue'" in {
+    val getReport = PrivateMethod[Option[Report]]('getReport)
+    val reporter = new Reporter("x", "x", "x", "x", Array())
+    val report = reporter invokePrivate getReport("propertyDistinctValue")
+    report match {
+      case Some(r) => assert(r.isInstanceOf[PropertyDistinctValueReport])
+      case _ => fail
+    }
+  }
+
+  it should "return a PropertyValueReport given token " +
+    "'propertyValue'" in {
     val getReport = PrivateMethod[Option[Report]]('getReport)
     val reporter = new Reporter("x", "x", "x", "x", Array())
     val report = reporter invokePrivate getReport("propertyValue")

--- a/src/test/scala/dpla/ingestion3/reports/PropertyDistinctValueReportTest.scala
+++ b/src/test/scala/dpla/ingestion3/reports/PropertyDistinctValueReportTest.scala
@@ -7,9 +7,9 @@ import dpla.ingestion3.model._
 import dpla.ingestion3.reports._
 
 
-class PropertyValueReportTest extends FlatSpec with MockFactory{
+class PropertyDistinctValueReportTest extends FlatSpec with MockFactory{
 
-  "PropertyValueReport.process" should "x" in {
+  "PropertyDistinctValueReport.process" should "x" in {
     // FIXME: How do you mock Dataframes and DataSets??
     true
   }


### PR DESCRIPTION
This report takes a property and builds a Dataset that contains the values of the
property, the provider's local uri and the DPLA uri.

Refactors PropertyValueReport class name to PropertyDistinctValueReport because it is
only returning the unique values. Also to distinguish it from the PropertyValueReport
where all values for a given property are returned. This name change was suggested as
a part of DT-1498 (see Gretchen's comment)