### PR TITLE
Fix for Avro serialization

### DIFF
--- a/src/it/scala/dpla/ingestion3/model/ModelConverterTest.scala
+++ b/src/it/scala/dpla/ingestion3/model/ModelConverterTest.scala
@@ -1,0 +1,306 @@
+package dpla.ingestion3.model
+
+import java.net.URI
+
+import com.databricks.spark.avro.SchemaConverters
+import dpla.ingestion3.data.EnrichedRecordFixture
+import dpla.ingestion3.utils.FlatFileIO
+import org.apache.avro.Schema
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.StructType
+import org.scalatest.{BeforeAndAfter, FlatSpec}
+
+class ModelConverterTest extends FlatSpec with BeforeAndAfter {
+
+  val schema = new Schema.Parser().parse(new FlatFileIO().readFileAsString("/avro/MAPRecord.avsc"))
+  val sqlSchema = SchemaConverters.toSqlType(schema).dataType.asInstanceOf[StructType]
+  val enrichedRecord = EnrichedRecordFixture.enrichedRecord
+
+  val urlString1 = "http://example.com"
+  val urlString2 = "http://google.com"
+  val urlString3 = "http://yahoo.com"
+
+  val testEdmAgent = Row(
+    urlString1,
+    "Sam",
+    "Sam Example",
+    "F#",
+    urlString2,
+    Seq(urlString3, urlString2),
+    Seq(urlString3, urlString1)
+  )
+
+  val testEdmWebResource = Row(urlString1, Seq("foo"), Seq("bar"), "baz")
+
+  val testEdmTimeSpan = Row("2012", "2013", "2014", "2015")
+
+  val testDcmiTypeCollection = Row("Foo", "Bar")
+
+  val testSkosConcept = Row("foo", "bar", "baz", urlString1, Seq(urlString2, urlString3), Seq(urlString1))
+
+  val testDplaPlace = Row("foo", "bar", "baz", "buzz", "Booga", "Wooga", "Oooga")
+
+  val literal = Row("I'm very literal", false)
+  val uri = Row(urlString1, true)
+
+
+  "A ModelConverter" should "work with RowConverter and round trip a DplaMapModel" in {
+    val row = RowConverter.toRow(enrichedRecord, sqlSchema)
+    val roundTripRecord = ModelConverter.toModel(row)
+  }
+
+  it should "extract a sequence of URIs from a Row" in {
+    val data = Row(Seq(urlString1, urlString2, urlString3))
+    val output = ModelConverter.uriSeq(data, 0)
+    assert(output === Seq(urlString1, urlString2, urlString3).map(new URI(_)))
+  }
+
+  it should "extract no URIs from an empty Row" in {
+    val output = ModelConverter.uriSeq(Row(Seq()), 0)
+    assert(output === Seq())
+  }
+
+  it should "extract a sequence of strings from a Row" in {
+    val seq = Seq("eenie", "miney", "moe")
+    val data = Row(seq)
+    val output = ModelConverter.stringSeq(data, 0)
+    assert(output === seq)
+  }
+
+  it should "extract no strings from an empty Row" in {
+    val output = ModelConverter.stringSeq(Row(Seq()), 0)
+    assert(output === Seq())
+  }
+
+  it should "extract an Option[String] from a Row" in {
+    val output = ModelConverter.optionalString(Row("foo"), 0)
+    assert(output === Some("foo"))
+  }
+
+  it should "extract None when no string is present" in {
+    val output = ModelConverter.optionalString(Row(null), 0)
+    assert(output === None)
+  }
+
+  it should "extract a string when one is expected to be present" in {
+    val output = ModelConverter.requiredString(Row("foo"), 0)
+    assert(output === "foo")
+  }
+
+  it should "throw an exception when a required string isn't there" in {
+    assertThrows[RuntimeException](ModelConverter.requiredString(Row(null), 0))
+  }
+
+  it should "extract an Option[URI] from a Row" in {
+    val output = ModelConverter.optionalUri(Row(urlString1), 0)
+    assert(output === Some(new URI(urlString1)))
+  }
+
+  it should "extract None when no uri is present" in {
+    val output = ModelConverter.optionalUri(Row(null), 0)
+    assert(output === None)
+  }
+
+  it should "extract a URI when one is expected to be present" in {
+    val output = ModelConverter.requiredUri(Row(urlString3), 0)
+    assert(output === new URI(urlString3))
+  }
+
+  it should "throw an exception when a required uri isn't there" in {
+    assertThrows[RuntimeException](ModelConverter.requiredUri(Row(null), 0))
+  }
+
+  it should "extract Rows from a subfield" in {
+    val output = ModelConverter.toRows(Row(Seq(Seq("a", "b", "c"), Seq("1", "2", "3"))), 0)
+    assert(output.nonEmpty)
+    assert(output.size === 2)
+    assert(output.headOption.getOrElse(Seq()) === Seq("a", "b", "c"))
+    assert(output(1) === Seq("1", "2", "3"))
+  }
+
+  it should "perform transformations on multivalued fields" in {
+    val testData = Row(Seq(Row(1), Row(2)))
+    val function = (row: Row) => row.get(0).toString
+    val output = ModelConverter.toMulti(testData, 0, function)
+    assert(output.nonEmpty)
+    assert(output.size === 2)
+    assert(output.headOption.getOrElse("") === "1")
+    assert(output(1) === "2")
+  }
+
+  it should "convertRowsToEdmAgent" in {
+    val edmAgent = ModelConverter.toEdmAgent(testEdmAgent)
+    val uri = edmAgent.uri.orNull
+    assert(edmAgent.uri.map(_.toString).orNull === testEdmAgent(0))
+    assert(edmAgent.name.orNull === testEdmAgent(1))
+    assert(edmAgent.providedLabel.orNull === testEdmAgent(2))
+    assert(edmAgent.note.orNull === testEdmAgent(3))
+    assert(edmAgent.scheme.map(_.toString).orNull === testEdmAgent(4))
+    assert(edmAgent.exactMatch.map(_.toString) === testEdmAgent.getSeq[String](5))
+    assert(edmAgent.closeMatch.map(_.toString) === testEdmAgent.getSeq[String](6))
+  }
+
+  it should "handle LiteralOrUri" in {
+    val literalOrUri1 = ModelConverter.toLiteralOrUri(literal)
+    assert(literalOrUri1.isLeft)
+    assert(literalOrUri1.left.getOrElse("") === "I'm very literal")
+
+    val literalOrUri2 = ModelConverter.toLiteralOrUri(uri)
+    assert(literalOrUri2.isRight)
+    assert(literalOrUri2.right.getOrElse(new URI("http://example.com")) === new URI(urlString1))
+  }
+
+  it should "handle optional EdmWebResources" in {
+    ModelConverter.toOptionEdmWebResource(testEdmWebResource) match {
+      case Some(edmWebResource: EdmWebResource) => assert(true)
+      case None => fail("Got a none back for something that should be a Some")
+    }
+
+    assert(ModelConverter.toOptionEdmWebResource(null) === None)
+  }
+
+  it should "convert DcmiTypeCollection" in {
+    val testResult1 = ModelConverter.toDcmiTypeCollection(testDcmiTypeCollection)
+    val testResult2 = ModelConverter.toDcmiTypeCollection(Row(null, null))
+
+    assert(testResult1.title === Some("Foo"))
+    assert(testResult1.description === Some("Bar"))
+    assert(testResult2.title === None)
+    assert(testResult2.description === None)
+  }
+
+  it should "convert EdmTimeSpan" in {
+    val testResult1 = ModelConverter.toEdmTimeSpan(testEdmTimeSpan)
+    val testResult2 = ModelConverter.toEdmTimeSpan(Row(null, null, null, null))
+
+    assert(testResult1.originalSourceDate === Some("2012"))
+    assert(testResult1.prefLabel === Some("2013"))
+    assert(testResult1.begin === Some("2014"))
+    assert(testResult1.end === Some("2015"))
+
+    assert(testResult2.originalSourceDate === None)
+    assert(testResult2.prefLabel === None)
+    assert(testResult2.begin === None)
+    assert(testResult2.end === None)
+  }
+
+  it should "convert SkosConcept" in {
+    val testResult1 = ModelConverter.toSkosConcept(testSkosConcept)
+    val testResult2 = ModelConverter.toSkosConcept(Row(null, null, null, null, Seq(), Seq()))
+
+    assert(testResult1.concept === Some("foo"))
+    assert(testResult1.providedLabel === Some("bar"))
+    assert(testResult1.note === Some("baz"))
+    assert(testResult1.scheme === Some(new URI(urlString1)))
+    assert(testResult1.exactMatch === Seq(new URI(urlString2), new URI(urlString3)))
+    assert(testResult1.closeMatch === Seq(new URI(urlString1)))
+
+    assert(testResult2.concept === None)
+    assert(testResult2.providedLabel === None)
+    assert(testResult2.note === None)
+    assert(testResult2.scheme === None)
+    assert(testResult2.exactMatch === Seq())
+    assert(testResult2.closeMatch === Seq())
+  }
+
+  it should "convert DplaPlace" in {
+    val testResult1 = ModelConverter.toDplaPlace(testDplaPlace)
+    val testResult2 = ModelConverter.toDplaPlace(Row(null, null, null, null, null, null, null))
+
+    assert(testResult1.name === Some("foo"))
+    assert(testResult1.city === Some("bar"))
+    assert(testResult1.county === Some("baz"))
+    assert(testResult1.state === Some("buzz"))
+    assert(testResult1.country === Some("Booga"))
+    assert(testResult1.region === Some("Wooga"))
+    assert(testResult1.coordinates === Some("Oooga"))
+  }
+
+  it should "convert an OreAggregation" in {
+    val testResult1 = ModelConverter.toOreAggregation(
+      Row(
+        urlString1,
+        testEdmAgent,
+        "an original record",
+        Seq(testEdmWebResource, testEdmWebResource),
+        testEdmAgent,
+        testEdmWebResource,
+        testEdmWebResource,
+        testEdmAgent,
+        urlString1
+      )
+    )
+
+    val edmAgent = ModelConverter.toEdmAgent(testEdmAgent)
+    val edmWebResource = ModelConverter.toEdmWebResource(testEdmWebResource)
+
+    assert(testResult1.uri === new URI(urlString1))
+    assert(testResult1.dataProvider === edmAgent)
+    assert(testResult1.originalRecord === "an original record" )
+    assert(testResult1.hasView === Seq(edmWebResource, edmWebResource))
+    assert(testResult1.intermediateProvider === Some(edmAgent))
+    assert(testResult1.`object` === Some(edmWebResource))
+    assert(testResult1.preview === Some(edmWebResource))
+    assert(testResult1.provider === edmAgent)
+    assert(testResult1.edmRights === Some(new URI(urlString1)))
+  }
+
+  it should "convert an EdmWebResource" in {
+    val testResult = ModelConverter.toEdmWebResource(testEdmWebResource)
+    assert(testResult.uri === new URI(urlString1))
+    assert(testResult.fileFormat === Seq("foo"))
+    assert(testResult.dcRights === Seq("bar"))
+    assert(testResult.edmRights === Some("baz"))
+  }
+
+  it should "convert a SourceResource" in {
+    val stringSeq = Seq("booga", "wooga", "oooga")
+    val testRow = Row(
+      stringSeq,                                          //alternateTitle
+      Seq(testDcmiTypeCollection, testDcmiTypeCollection),//collection
+      Seq(testEdmAgent, testEdmAgent),                    //contributor
+      Seq(testEdmAgent, testEdmAgent),                    //creator
+      Seq(testEdmTimeSpan, testEdmTimeSpan),              //date
+      stringSeq,                                          //description
+      stringSeq,                                          //extent
+      stringSeq,                                          //format
+      Seq(testSkosConcept, testSkosConcept),              //genre
+      stringSeq,                                          //identifier
+      Seq(testSkosConcept, testSkosConcept),              //language
+      Seq(testDplaPlace, testDplaPlace),                  //place,
+      Seq(testEdmAgent, testEdmAgent),                    //publisher
+      Seq(literal, literal, uri),                         //relation
+      stringSeq,                                          //replacedBy
+      stringSeq,                                          //replaces
+      stringSeq,                                          //rights
+      Seq(testEdmAgent, testEdmAgent),                    //rightsHolder
+      Seq(testSkosConcept, testSkosConcept),              //subject
+      Seq(testEdmTimeSpan, testEdmTimeSpan),              //temporal
+      stringSeq,                                          //title
+      stringSeq                                           //type
+    )
+    val output = ModelConverter.toSourceResource(testRow)
+    assert(ModelConverter.stringSeq(testRow, 0) === output.alternateTitle)
+    assert(testRow.getSeq[Row](1).map(ModelConverter.toDcmiTypeCollection) === output.collection)
+    assert(testRow.getSeq[Row](2).map(ModelConverter.toEdmAgent) === output.contributor)
+    assert(testRow.getSeq[Row](3).map(ModelConverter.toEdmAgent) === output.creator)
+    assert(testRow.getSeq[Row](4).map(ModelConverter.toEdmTimeSpan) === output.date)
+    assert(ModelConverter.stringSeq(testRow, 5) === output.description)
+    assert(ModelConverter.stringSeq(testRow, 6) === output.extent)
+    assert(ModelConverter.stringSeq(testRow, 7) === output.format)
+    assert(testRow.getSeq[Row](8).map(ModelConverter.toSkosConcept) === output.genre)
+    assert(ModelConverter.stringSeq(testRow, 9) === output.identifier)
+    assert(testRow.getSeq[Row](10).map(ModelConverter.toSkosConcept) === output.language)
+    assert(testRow.getSeq[Row](11).map(ModelConverter.toDplaPlace) === output.place)
+    assert(testRow.getSeq[Row](12).map(ModelConverter.toEdmAgent) === output.publisher)
+    assert(testRow.getSeq[Row](13).map(ModelConverter.toLiteralOrUri) === output.relation)
+    assert(ModelConverter.stringSeq(testRow, 14) === output.replacedBy)
+    assert(ModelConverter.stringSeq(testRow, 15) === output.replaces)
+    assert(ModelConverter.stringSeq(testRow, 16) === output.rights)
+    assert(testRow.getSeq[Row](17).map(ModelConverter.toEdmAgent) === output.rightsHolder)
+    assert(testRow.getSeq[Row](18).map(ModelConverter.toSkosConcept) === output.subject)
+    assert(testRow.getSeq[Row](19).map(ModelConverter.toEdmTimeSpan) === output.temporal)
+    assert(ModelConverter.stringSeq(testRow, 20) === output.title)
+    assert(ModelConverter.stringSeq(testRow, 21) === output.`type`)
+  }
+}

--- a/src/it/scala/dpla/ingestion3/model/RowConverterTest.scala
+++ b/src/it/scala/dpla/ingestion3/model/RowConverterTest.scala
@@ -1,0 +1,272 @@
+package dpla.ingestion3.model
+
+import java.net.URI
+
+import com.databricks.spark.avro.SchemaConverters
+import dpla.ingestion3.data.EnrichedRecordFixture
+import dpla.ingestion3.utils.FlatFileIO
+import org.apache.avro.Schema
+import org.apache.spark.sql.types.StructType
+import org.scalatest.{BeforeAndAfter, FlatSpec}
+
+class RowConverterTest extends FlatSpec with BeforeAndAfter {
+
+  val uri1 = new URI("http://hampsterdance.com")
+  val uri2 = new URI("http://zombo.com")
+  val uri3 = new URI("http://realultimatepower.net")
+  val uri4 = new URI("http://timecube.com")
+  val uri5 = new URI("http://ytmnd.com")
+
+  val schema = new Schema.Parser().parse(new FlatFileIO().readFileAsString("/avro/MAPRecord.avsc"))
+  val sqlSchema = SchemaConverters.toSqlType(schema).dataType.asInstanceOf[StructType]
+  val enrichedRecord = EnrichedRecordFixture.enrichedRecord
+
+  val dcmiTypeCollection = enrichedRecord.sourceResource.collection
+    .headOption.getOrElse(throw new RuntimeException("You cut off my head"))
+  val emptyDcmiTypeCollection = DcmiTypeCollection()
+
+  val edmTimeSpan = enrichedRecord.sourceResource.date
+    .headOption.getOrElse(throw new RuntimeException("You cut off my head"))
+  val emptyEdmTimeSpan = EdmTimeSpan()
+
+  val dplaPlace = DplaPlace(
+    name = Some("Boston"),
+    city = Some("Boston"),
+    county = Some("Suffolk County"),
+    state = Some("Massachusetts"),
+    country = Some("United States of America"),
+    region = Some("North America"),
+    coordinates = Some("42.358333,71.059722")
+  )
+  val emptyDplaPlace = DplaPlace()
+
+  val skosConcept = SkosConcept(
+    concept = Some("Food"),
+    providedLabel = Some("Food label"),
+    note = Some("Food notes"),
+    scheme = Some(uri1),
+    exactMatch = Seq(uri2, uri3),
+    closeMatch = Seq(uri4, uri5)
+  )
+  val emtpySkosConcept = SkosConcept()
+
+  val stringLiteralOrUri = Left("String")
+  val uriLiteralOrUri = Right(uri1)
+
+  val edmAgent = EdmAgent(
+    uri = Some(uri1),
+    name = Some("Michael Scott"),
+    providedLabel = Some("Michael Scarn"),
+    note = Some("C#"),
+    scheme = Some(uri5),
+    exactMatch = Seq(uri1, uri2),
+    closeMatch = Seq(uri3, uri4)
+  )
+  val emptyEdmAgent = EdmAgent()
+
+  val edmWebResource = EdmWebResource(
+    uri = uri1,
+    fileFormat = Seq("image/gif", "image/jpeg"),
+    dcRights = Seq("free speech", "peaceful assembly"),
+    edmRights = Some("trial by jury")
+  )
+
+  val emptyEdmWebResource = EdmWebResource(uri = uri1)
+
+  "A RowConverter" should "convert a DplaMapModel to a Row with a schema" in {
+    val row = RowConverter.toRow(enrichedRecord, sqlSchema)
+  }
+
+  it should "convert a DcmiTypeCollection" in {
+    val row = RowConverter.dcmiTypeCollection(dcmiTypeCollection)
+    assert(row(0) === dcmiTypeCollection.title.orNull)
+    assert(row(1) === dcmiTypeCollection.description.orNull)
+  }
+
+  it should "convert an empty DcmiTypeCollection" in {
+    val row = RowConverter.dcmiTypeCollection(emptyDcmiTypeCollection)
+    assert(row(0) === null)
+    assert(row(1) === null)
+  }
+
+  it should "convert an EdmTimeSpan" in {
+    val row = RowConverter.edmTimeSpan(edmTimeSpan)
+    assert(row(0) === edmTimeSpan.originalSourceDate.orNull)
+    assert(row(1) === edmTimeSpan.prefLabel.orNull)
+    assert(row(2) === edmTimeSpan.begin.orNull)
+    assert(row(3) === edmTimeSpan.end.orNull)
+  }
+
+  it should "convert an empty EdmTimeSpan" in {
+    val row = RowConverter.edmTimeSpan(emptyEdmTimeSpan)
+    assert(row(0) === null)
+    assert(row(1) === null)
+    assert(row(2) === null)
+    assert(row(3) === null)
+  }
+
+  it should "convert a SkosConcept" in {
+    val row = RowConverter.skosConcept(skosConcept)
+    assert(row(0) === skosConcept.concept.orNull)
+    assert(row(1) === skosConcept.providedLabel.orNull)
+    assert(row(2) === skosConcept.note.orNull)
+    assert(row(3) === skosConcept.scheme.map(_.toString).orNull)
+    assert(row(4) === skosConcept.exactMatch.map(_.toString))
+    assert(row(5) === skosConcept.closeMatch.map(_.toString))
+  }
+
+  it should "convert an empty SkosConcpet" in {
+    val row = RowConverter.skosConcept(emtpySkosConcept)
+    assert(row(0) === null)
+    assert(row(1) === null)
+    assert(row(2) === null)
+    assert(row(3) === null)
+    assert(row(4) === Seq())
+    assert(row(5) === Seq())
+  }
+
+  it should "convert a DplaPlace" in {
+    val row = RowConverter.dplaPlace(dplaPlace)
+    assert(row(0) === dplaPlace.name.orNull)
+    assert(row(1) === dplaPlace.city.orNull)
+    assert(row(2) === dplaPlace.county.orNull)
+    assert(row(3) === dplaPlace.state.orNull)
+    assert(row(4) === dplaPlace.country.orNull)
+    assert(row(5) === dplaPlace.region.orNull)
+    assert(row(6) === dplaPlace.coordinates.orNull)
+  }
+
+  it should "convert an empty DplaPlace" in {
+    val row = RowConverter.dplaPlace(emptyDplaPlace)
+    assert(row(0) === null)
+    assert(row(1) === null)
+    assert(row(2) === null)
+    assert(row(3) === null)
+    assert(row(4) === null)
+    assert(row(5) === null)
+    assert(row(6) === null)
+  }
+
+  it should "convert a LiteralOrUri" in {
+    val stringRow = RowConverter.literalOrUri(stringLiteralOrUri)
+    assert(stringRow(0) === "String")
+    assert(stringRow(1) === false)
+
+    val uriRow = RowConverter.literalOrUri(uriLiteralOrUri)
+    assert(uriRow(0) === uri1.toString)
+    assert(uriRow(1) === true)
+  }
+
+  it should "convert an EdmAgent" in {
+    val row = RowConverter.edmAgent(edmAgent)
+    assert(row(0) === edmAgent.uri.map(_.toString).orNull)
+    assert(row(1) === edmAgent.name.orNull)
+    assert(row(2) === edmAgent.providedLabel.orNull)
+    assert(row(3) === edmAgent.note.orNull)
+    assert(row(4) === edmAgent.scheme.map(_.toString).orNull)
+    assert(row(5) === edmAgent.exactMatch.map(_.toString))
+    assert(row(6) === edmAgent.closeMatch.map(_.toString))
+  }
+
+  it should "convert an empty EdmAgent" in {
+    val row = RowConverter.edmAgent(emptyEdmAgent)
+    assert(row(0) === null)
+    assert(row(1) === null)
+    assert(row(2) === null)
+    assert(row(3) === null)
+    assert(row(4) === null)
+    assert(row(5) === Seq())
+    assert(row(6) === Seq())
+  }
+
+  it should "convert an EdmWebResource" in {
+    val row = RowConverter.edmWebResource(edmWebResource)
+    assert(row(0) === edmWebResource.uri.toString)
+    assert(row(1) === edmWebResource.fileFormat)
+    assert(row(2) === edmWebResource.dcRights)
+    assert(row(3) === edmWebResource.edmRights.orNull)
+  }
+
+  it should "convert an empty EdmWebResource" in {
+    val row = RowConverter.edmWebResource(emptyEdmWebResource)
+    assert(row(0) === emptyEdmWebResource.uri.toString)
+    assert(row(1) === Seq())
+    assert(row(2) === Seq())
+    assert(row(3) === null)
+  }
+
+  it should "convert an OreAggregation" in {
+    val oreAggregation = OreAggregation(
+      uri = uri3,
+      dataProvider = edmAgent,
+      originalRecord = "I'm very original",
+      hasView = Seq(edmWebResource, edmWebResource),
+      intermediateProvider = Some(edmAgent),
+      `object` = Some(edmWebResource),
+      preview = Some(edmWebResource),
+      provider = edmAgent,
+      edmRights = Some(uri1)
+    )
+    val row = RowConverter.oreAggregation(oreAggregation)
+    assert(row(0) === oreAggregation.uri.toString)
+    assert(row(1) === RowConverter.edmAgent(oreAggregation.dataProvider))
+    assert(row(2) === oreAggregation.originalRecord)
+    assert(row(3) === oreAggregation.hasView.map(RowConverter.edmWebResource))
+    assert(row(4) === oreAggregation.intermediateProvider.map(RowConverter.edmAgent).orNull)
+    assert(row(5) === oreAggregation.`object`.map(RowConverter.edmWebResource).orNull)
+    assert(row(6) === oreAggregation.preview.map(RowConverter.edmWebResource).orNull)
+    assert(row(7) === RowConverter.edmAgent(oreAggregation.provider))
+    assert(row(8) === oreAggregation.edmRights.map(_.toString).orNull)
+  }
+
+  it should "convert a SourceResource" in {
+    val sourceResource = DplaSourceResource(
+      alternateTitle = Seq("fee", "fie", "fo"),
+      collection = Seq(dcmiTypeCollection, dcmiTypeCollection, dcmiTypeCollection),
+      contributor = Seq(edmAgent, edmAgent),
+      creator = Seq(edmAgent, edmAgent, edmAgent),
+      date = Seq(edmTimeSpan, edmTimeSpan, edmTimeSpan),
+      description = Seq("this", "is", "description"),
+      extent = Seq("very", "extensive"),
+      format = Seq("hfs+", "fat32"),
+      genre = Seq(skosConcept, skosConcept, skosConcept),
+      identifier = Seq("can", "I", "see", "some", "id"),
+      language = Seq(skosConcept, skosConcept, skosConcept),
+      place = Seq(dplaPlace, dplaPlace, dplaPlace),
+      publisher = Seq(edmAgent, edmAgent, edmAgent),
+      relation = Seq(Right(uri1), Left("foobar"), Right(uri2), Left("snozzbuzz")),
+      replacedBy = Seq("someone's", "taken", "my", "place"),
+      replaces = Seq("we're", "the", "replacmements"),
+      rights = Seq("some", "rights"),
+      rightsHolder = Seq(edmAgent, edmAgent),
+      subject = Seq(skosConcept, skosConcept),
+      temporal = Seq(edmTimeSpan, edmTimeSpan),
+      title = Seq("some", "title"),
+      `type` = Seq("rock", "magic", "grass")
+    )
+    val row = RowConverter.dplaSourceResource(sourceResource)
+    assert(row(0) === sourceResource.alternateTitle)
+    assert(row(1) === sourceResource.collection.map(RowConverter.dcmiTypeCollection))
+    assert(row(2) === sourceResource.contributor.map(RowConverter.edmAgent))
+    assert(row(3) === sourceResource.creator.map(RowConverter.edmAgent))
+    assert(row(4) === sourceResource.date.map(RowConverter.edmTimeSpan))
+    assert(row(5) === sourceResource.description)
+    assert(row(6) === sourceResource.extent)
+    assert(row(7) === sourceResource.format)
+    assert(row(8) === sourceResource.genre.map(RowConverter.skosConcept))
+    assert(row(9) === sourceResource.identifier)
+    assert(row(10) === sourceResource.language.map(RowConverter.skosConcept))
+    assert(row(11) === sourceResource.place.map(RowConverter.dplaPlace))
+    assert(row(12) === sourceResource.publisher.map(RowConverter.edmAgent))
+    assert(row(13) === sourceResource.relation.map(RowConverter.literalOrUri))
+    assert(row(14) === sourceResource.replacedBy)
+    assert(row(15) === sourceResource.replaces)
+    assert(row(16) === sourceResource.rights)
+    assert(row(17) === sourceResource.rightsHolder.map(RowConverter.edmAgent))
+    assert(row(18) === sourceResource.subject.map(RowConverter.skosConcept))
+    assert(row(19) === sourceResource.temporal.map(RowConverter.edmTimeSpan))
+    assert(row(20) === sourceResource.title)
+    assert(row(21) === sourceResource.`type`)
+
+  }
+}

--- a/src/main/resources/avro/MAPRecord.avsc
+++ b/src/main/resources/avro/MAPRecord.avsc
@@ -11,376 +11,1061 @@
   "type": "record",
   "name": "MAPRecord",
   "doc": "",
-
-  "types": [
-  {"name": "StringArray", "type": "array", "items": "string"},
-  {
-    "name": "Collection",  // dcmitype:Collection
-    "type": "record",
-    "fields": [
-    {   // 0-1
-      "name": "title",
-      "type": ["null", "string"],
-      "default": null
-    },
-    {   // 0-1
-      "name": "description",
-      "type": ["null", "string"],
-      "default": null
-    }
-    ]
-  },
-  {
-    "name": "Agent",  // edm:Agent
-    "type": "record",
-    "fields": [
-    { // 0-1
-      "name": "name",
-      "type": ["null", "string"],
-      "default": null
-    },
-    { // 0-1
-      "name": "providedLabel",
-      "type": ["null", "string"],
-      "default": null
-    },
-    { // 0-1
-      "name": "note",
-      "type": ["null", "string"],
-      "default": null
-    },
-    { // 0-1
-      "name": "inScheme",
-      "type": ["null", "string"],
-      "default": null
-    },
-    { // 0-1
-      "name": "exactMatch",
-      "type": ["null", "StringArray"],
-      "default": null
-    },
-    {
-      // 0-n
-      "name": "closeMatch",
-      "type": ["null", "StringArray"],
-      "default": null
-    }
-    ]
-  },
-  {"name": "AgentArray", "type": "array", "items": "Agent"},
-  {
-    "name": "Concept",  // skos:Concept
-    "type": "record",
-    "fields": [
-    {
-      // 0-1
-      "name": "name",  // skos:prefLabel
-      "type": ["null", "string"],
-      "default": null
-    },
-    {
-      // 0-1
-      "name": "providedLabel",
-      "type": ["null", "string"],
-      "default": null
-    },
-    {
-      // 0-1
-      "name": "note",
-      "type": ["null", "string"],
-      "default": null
-    },
-    {
-      // 0-1
-      "name": "inScheme",
-      "type": ["null", "string"],
-      "default": null
-    },
-    {
-      // 0-n
-      "name": "exactMatch",
-      "type": ["null", "StringArray"],
-      "default": null
-    },
-    {
-      // 0-n
-      "name": "closeMatch",
-      "type": ["null", "StringArray"],
-      "default": null
-    }
-    ]
-  },
-  {"name": "ConceptArray", "type": "array", "items": "Concept"},
-  {
-    "name": "Place",  // dpla:Place from MAP 3.1 spec
-    "type": "record",
-    "fields": [
-    {"name": "name", "type": "string"}, // 1
-    {   // 0-1
-      "name": "city",
-      "type": ["null", "string"],
-      "default": null
-    },
-    {   // 0-1
-      "name": "county",
-      "type": ["null", "string"],
-      "default": null
-    },
-    {   // 0-1
-      "name": "state",
-      "type": ["null", "string"],
-      "default": null
-    },
-    {   // 0-1
-      "name": "country",
-      "type": ["null", "string"],
-      "default": null
-    },
-    {   // 0-1
-      "name": "region",
-      "type": ["null", "string"],
-      "default": null
-    },
-    {   // 0-1
-      "name": "coordinates",
-      "type": ["null", "string"],
-      "default": null
-    }
-    ]
-  },
-  {"name": "PlaceArray", "type": "array", "items": "Place"},
-  {
-    "name": "TimeSpan",  // edm:TimeSpan
-    "type": "record",
-    "fields": [
-    {   // 0-n
-      "name": "providedLabel",
-      "type": ["null", "StringArray"],
-      "default": null
-    },
-    {
-      // 0-1
-      "name": "begin",
-      "type": ["null", "string"],
-      "default": null
-    },
-    {
-      // 0-1
-      "name": "end",
-      "type": ["null", "string"],
-      "default": null
-    }
-    ]
-  },
-  {"name": "TimeSpanArray", "type": "array", "items": "TimeSpan"}
-  ],  // types
-
   "fields": [
-
-  // 1
-  {"name": "id", "type": "string", "doc": "DPLA record ID"},
-
-  // 1
-  {
-    "name": "ingestType",
-    "type": {
-      "name": "IngestType",
-      "type": "enum",
-      "symbols": ["item", "collection"]
-    }
-  },
-
-  // 1
-  {
-    "name": "ingestDate",
-    "type": "long",
-    "doc": "UNIX timestamp"
-  },
-
-  // 1
-  {"name": "dataProvider", "type": "string"},
-
-  // 0-n
-  {
-    "name": "hasView",
-    "type": ["null", "StringArray"],
-    "default": null
-  },
-
-  // 0-n
-  {
-    "name": "intermediateProvider",
-    "type": ["null", "StringArray"],
-    "default": null
-  },
-
-  // 1
-  {"name": "isShownAt", "type": "string"},
-
-  // 0-1
-  {
-    "name": "object",
-    "type": ["null", "string"],
-    "default": null
-  },
-
-  // 1
-  {"name": "originalRecord", "type": "string"},
-
-  // 1
-  {"name": "preview", "type": "string"},
-
-  // 1
-  {"name": "provider", "type": "string"},
-
-  // 0-1
-  {
-    "name": "rightsStatement",
-    "type": ["null", "string"],
-    "default": null
-  },
-
-  // 1
-  {
-    "name": "sourceResource",
-    "type": {
-      "type": "record",
+    {
       "name": "SourceResource",
-      "fields": [
-
-    {   // 0-n
-      "name": "alternative",
-      "type": ["null", "StringArray"],
-      "default": null
-    },
-    {   // 0-n
-      "name": "collection",
-      "type": ["null", "CollectionArray"],
-      "default": null
-    },
-    {   // 0-n
-      "name": "contributor",
-      "type": ["null", "AgentArray"],
-      "default": null
-    },
-    {   // 0-n
-      "name": "creator",
-      "type": ["null", "AgentArray"],
-      "default": null
-    },
-    {   // 0-n
-      "name": "date",
-      "type": ["null", "TimeSpanArray"],
-      "default": null
+      "type": {
+        "type": "record",
+        "name": "SourceResource",
+        "fields": [
+          {
+            "name": "alternateTitle",
+            "type": {
+              "type": "array",
+              "items": "string"
+            }
+          },
+          {
+            "name": "collection",
+            "type": {
+              "name": "DcmiTypeCollectionArray",
+              "type": "array",
+              "items": {
+                "name": "DcmiTypeCollection",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "title",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "description",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "contributor",
+            "type": {
+              "name": "ContributorEdmAgentArray",
+              "type": "array",
+              "items": {
+                "name": "ContributorEdmAgent",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "uri",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "name",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "providedLabel",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "note",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "scheme",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "exactMatch",
+                    "type": {
+                      "name": "exactMatchArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  },
+                  {
+                    "name": "closeMatch",
+                    "type": {
+                      "name": "closeMatchArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "creator",
+            "type": {
+              "name": "CreatorEdmAgentArray",
+              "type": "array",
+              "items": {
+                "name": "CreatorEdmAgent",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "uri",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "name",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "providedLabel",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "note",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "scheme",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "exactMatch",
+                    "type": {
+                      "name": "exactMatchArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  },
+                  {
+                    "name": "closeMatch",
+                    "type": {
+                      "name": "closeMatchArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "date",
+            "type": {
+              "name": "DateEdmTimeSpanArray",
+              "type": "array",
+              "items": {
+                "name": "DateEdmTimeSpan",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "originalSourceDate",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "prefLabel",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "begin",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "end",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "description",
+            "type": {
+              "name": "descriptionArray",
+              "type": "array",
+              "items": "string"
+            }
+          },
+          {
+            "name": "extent",
+            "type": {
+              "name": "extentArray",
+              "type": "array",
+              "items": "string"
+            }
+          },
+          {
+            "name": "format",
+            "type": {
+              "name": "formatArray",
+              "type": "array",
+              "items": "string"
+            }
+          },
+          {
+            "name": "genre",
+            "type": {
+              "name": "GenreSkosConceptArray",
+              "type": "array",
+              "items": {
+                "name": "GenreSkosConcept",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "concept",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "providedLabel",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "note",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "scheme",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "exactMatch",
+                    "type": {
+                      "name": "exactMatchArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  },
+                  {
+                    "name": "closeMatch",
+                    "type": {
+                      "name": "closeMatchArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "identifier",
+            "type": {
+              "name": "identifierArray",
+              "type": "array",
+              "items": "string"
+            }
+          },
+          {
+            "name": "language",
+            "type": {
+              "name": "LanguageSkosConceptArray",
+              "type": "array",
+              "items": {
+                "name": "LanguageSkosConcept",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "concept",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "providedLabel",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "note",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "scheme",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "exactMatch",
+                    "type": {
+                      "name": "exactMatchArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  },
+                  {
+                    "name": "closeMatch",
+                    "type": {
+                      "name": "closeMatchArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "place",
+            "type": {
+              "type": "array",
+              "name": "DplaPlaceArray",
+              "items": {
+                "name": "DplaPlace",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "name",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "city",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "county",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "state",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "country",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "coordinates",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "publisher",
+            "type": {
+              "name": "PublisherEdmAgentArray",
+              "type": "array",
+              "items": {
+                "name": "PublisherEdmAgent",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "uri",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "name",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "providedLabel",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "note",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "scheme",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "exactMatch",
+                    "type": {
+                      "name": "exactMatchArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  },
+                  {
+                    "name": "closeMatch",
+                    "type": {
+                      "name": "closeMatchArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "relation",
+            "type": {
+              "name": "LiteralOrUriRelationArray",
+              "type": "array",
+              "items": {
+                "name": "LiteralOrUriRelation",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "value",
+                    "type": "string"
+                  },
+                  {
+                    "name": "isUri",
+                    "type": "boolean"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "replacedBy",
+            "type": {
+              "name": "replacedByArray",
+              "type": "array",
+              "items": "string"
+            }
+          },
+          {
+            "name": "replaces",
+            "type": {
+              "name": "replacesArray",
+              "type": "array",
+              "items": "string"
+            }
+          },
+          {
+            "name": "rights",
+            "type": {
+              "name": "rightsArray",
+              "type": "array",
+              "items": "string"
+            }
+          },
+          {
+            "name": "rightsHolder",
+            "type": {
+              "name": "RightsHolderEdmAgentArray",
+              "type": "array",
+              "items" : {
+                "name": "RightsHolderEdmAgent",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "uri",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "name",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "providedLabel",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "note",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "scheme",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "exactMatch",
+                    "type": {
+                      "name": "exactMatchArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  },
+                  {
+                    "name": "closeMatch",
+                    "type": {
+                      "name": "closeMatchArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "subject",
+            "type": {
+              "name": "SubjectSkosConceptArray",
+              "type": "array",
+              "items": {
+                "name": "SubjectSkosConcept",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "concept",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "providedLabel",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "note",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "scheme",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "exactMatch",
+                    "type": {
+                      "name": "exactMatchArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  },
+                  {
+                    "name": "closeMatch",
+                    "type": {
+                      "name": "closeMatchArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "temporal",
+            "type": {
+              "name": "TemporalEdmTimeSpanArray",
+              "type": "array",
+              "items" : {
+                "name": "TemporalEdmTimeSpan",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "originalSourceDate",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "prefLabel",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "begin",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "end",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "title",
+            "type": {
+              "name": "titleArray",
+              "type": "array",
+              "items": "string"
+            }
+          },
+          {
+            "name": "type",
+            "type": {
+              "name": "typeArray",
+              "type": "array",
+              "items": "string"
+            }
+          }
+        ]
+      }
     },
     {
-      // 0-n
-      "name": "description",
-      "type": ["null", "StringArray"],
-      "default": null
+      "name": "EdmWebResource",
+      "type": {
+        "name": "EdmWebResource",
+        "type": "record",
+        "fields": [
+          {
+            "name": "uri",
+            "type": "string"
+          },
+          {
+            "name": "fileFormat",
+            "type": {
+              "name": "fileFormatsArray",
+              "type": "array",
+              "items": "string"
+            }
+          },
+          {
+            "name": "dcRights",
+            "type": {
+              "name": "dcRightsArray",
+              "type": "array",
+              "items": "string"
+            }
+          },
+          {
+            "name": "edmRights",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        ]
+      }
     },
     {
-      // 0-n
-      "name": "extent",
-      "type": ["null", "StringArray"],
-      "default": null
-    },
-    {
-      // 0-n
-      "name": "format",
-      "type": ["null", "StringArray"],
-      "default": null
-    },
-    {
-      // 0-n
-      "name": "genre",
-      "type": ["null", "ConceptArray"],
-      "default": null
-    },
-    {
-      // 0-n
-      "name": "identifier",
-      "type": ["null", "StringArray"],
-      "default": null
-    },
-    {
-      // 0-n
-      "name": "language",
-      "type": ["null", "StringArray"],
-      "default": null
-    },
-    {
-      // 0-n
-      "name": "spatial",
-      "type": ["null", "PlaceArray"],
-      "default": null
-    },
-    {   // 0-n
-      "name": "publisher",
-      "type": ["null", "AgentArray"],
-      "default": null
-    },
-    {
-      // 0-n
-      "name": "relation",
-      "type": ["null", "StringArray"],
-      "default": null
-    },
-    {
-      // 0-n
-      "name": "isReplacedBy",
-      "type": ["null", "StringArray"],
-      "default": null
-    },
-    {
-      // 0-n
-      "name": "replaces",
-      "type": ["null", "StringArray"],
-      "default": null
-    },
-    {
-      // 1-n
-      "name": "rights",
-      "type": "StringArray"
-    },
-    {   // 0-n
-      "name": "rightsHolder",
-      "type": ["null", "AgentArray"],
-      "default": null
-    },
-    {
-      // 0-n
-      "name": "subject",
-      "type": ["null", "ConceptArray"],
-      "default": null
-    },
-    {   // 0-n
-      "name": "temporal",
-      "type": ["null", "TimeSpanArray"],
-      "default": null
-    },
-    {
-      // 1-n
-      "name": "title",
-      "type": "StringArray"
-    },
-    {
-      // 0-n
-      "name": "type",
-      "type": ["null", "StringArray"],
-      "default": null
+      "name": "OreAggregation",
+      "type": {
+        "name": "OreAggregation",
+        "type": "record",
+        "fields": [
+          {
+            "name": "uri",
+            "type": "string"
+          },
+          {
+            "name": "dataProvider",
+            "type": {
+              "name": "DataProviderEdmAgent",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "uri",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                {
+                  "name": "name",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                {
+                  "name": "providedLabel",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                {
+                  "name": "note",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                {
+                  "name": "scheme",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                {
+                  "name": "exactMatch",
+                  "type": {
+                    "name": "exactMatchArray",
+                    "type": "array",
+                    "items": "string"
+                  }
+                },
+                {
+                  "name": "closeMatch",
+                  "type": {
+                    "name": "closeMatchArray",
+                    "type": "array",
+                    "items": "string"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "originalRecord",
+            "type": "string"
+          },
+          {
+            "name": "hasView",
+            "type": {
+              "name": "HasViewEdmWebResourceArray",
+              "type": "array",
+              "items": {
+                "name": "HasViewEdmWebResource",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "uri",
+                    "type": "string"
+                  },
+                  {
+                    "name": "fileFormat",
+                    "type": {
+                      "name": "fileFormatsArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  },
+                  {
+                    "name": "dcRights",
+                    "type": {
+                      "name": "dcRightsArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  },
+                  {
+                    "name": "edmRights",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "intermediateProvider",
+            "type": [
+              "null",
+              {
+                "name": "IntermediateProviderEdmAgent",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "uri",
+                    "type": ["null", "string"]
+                  },
+                  {
+                    "name": "name",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "providedLabel",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "note",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "scheme",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "exactMatch",
+                    "type": {
+                      "name": "exactMatchArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  },
+                  {
+                    "name": "closeMatch",
+                    "type": {
+                      "name": "closeMatchArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "object",
+            "type": {
+              "name": "ObjectEdmWebResource",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "uri",
+                  "type": "string"
+                },
+                {
+                  "name": "fileFormat",
+                  "type": {
+                    "name": "fileFormatsArray",
+                    "type": "array",
+                    "items": "string"
+                  }
+                },
+                {
+                  "name": "dcRights",
+                  "type": {
+                    "name": "dcRightsArray",
+                    "type": "array",
+                    "items": "string"
+                  }
+                },
+                {
+                  "name": "edmRights",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "preview",
+            "type": [
+              "null",
+              {
+                "name": "PreviewEdmWebResource",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "uri",
+                    "type": "string"
+                  },
+                  {
+                    "name": "fileFormat",
+                    "type": {
+                      "name": "fileFormatsArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  },
+                  {
+                    "name": "dcRights",
+                    "type": {
+                      "name": "dcRightsArray",
+                      "type": "array",
+                      "items": "string"
+                    }
+                  },
+                  {
+                    "name": "edmRights",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "provider",
+            "type": {
+              "name": "ProviderEdmAgent",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "uri",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                {
+                  "name": "name",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                {
+                  "name": "providedLabel",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                {
+                  "name": "note",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                {
+                  "name": "scheme",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                {
+                  "name": "exactMatch",
+                  "type": {
+                    "name": "exactMatchArray",
+                    "type": "array",
+                    "items": "string"
+                  }
+                },
+                {
+                  "name": "closeMatch",
+                  "type": {
+                    "name": "closeMatchArray",
+                    "type": "array",
+                    "items": "string"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "edmRights",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        ]
+      }
     }
-      ] // fields
-    }  // type
-
-  }, // sourceResource
-
-  {
-    "name": "title",
-    "type": ["null", "string"],
-    "doc": "Only for collection records"
-  }
-
-  ]  // fields
-
+  ]
 }

--- a/src/main/scala/dpla/ingestion3/enrichments/SpatialEnrichment.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/SpatialEnrichment.scala
@@ -154,9 +154,9 @@ class SpatialEnrichment(geocoder: Twofisher) extends Serializable {
     * @return The query term: either the name or coordinates, or None
     */
   private def queryTerm(place: DplaPlace): Option[String] = place match {
-    case DplaPlace(_, _, _, _, _, Some(coordinates)) =>
+    case DplaPlace(_, _, _, _, _, _, Some(coordinates)) =>
       Some(coordinates)
-    case DplaPlace(Some(name), _, _, _, _, _) =>
+    case DplaPlace(Some(name), _, _, _, _, _, _) =>
       name match {
         case s if s matches """^United States(?!\-\-)""" => None
         case s if s matches "^USA" => None

--- a/src/main/scala/dpla/ingestion3/model/DplaMapData.scala
+++ b/src/main/scala/dpla/ingestion3/model/DplaMapData.scala
@@ -16,7 +16,6 @@ object DplaMapData {
   type ZeroToOne[T] = Option[T]
   type ExactlyOne[T] = T
   type LiteralOrUri = Either[String,URI]
-  type LiteralOrSkos = Either[String,SkosConcept]
 }
 
 sealed trait DplaMap
@@ -150,8 +149,7 @@ case class DplaPlace(
                      county: ZeroToOne[String] = None,
                      state: ZeroToOne[String] = None,
                      country: ZeroToOne[String] = None,
-                     // Region or equivalent is not returned by Twofishes
-                     // region: ZeroToOne[String] = None,
+                     region: ZeroToOne[String] = None,
                      coordinates: ZeroToOne[String] = None
                     )
 

--- a/src/main/scala/dpla/ingestion3/model/ModelConverter.scala
+++ b/src/main/scala/dpla/ingestion3/model/ModelConverter.scala
@@ -1,0 +1,149 @@
+package dpla.ingestion3.model
+
+import java.net.URI
+
+import dpla.ingestion3.model.DplaMapData.LiteralOrUri
+import org.apache.spark.sql.Row
+
+/**
+  * Responsible for taking a Row representing a structure of fields that represents a DplaMapData in Avro or other
+  * lower-level Spark output formats and turning it back into a DplaMapData.
+  *
+  * PLEASE NOTE: The field index values represented here are significant and cannot be changed without a concurrent
+  * effort to rewrite all the existing data stored in our master dataset, and a matching change to RowConverter, which
+  * is responsible for converting a DplaMapData to a Row and represents the opposite of this transformation.
+  */
+
+
+object ModelConverter {
+
+  def toModel(row: Row): DplaMapData = DplaMapData(
+    sourceResource = toSourceResource(row.getStruct(0)),
+    edmWebResource = toEdmWebResource(row.getStruct(1)),
+    oreAggregation = toOreAggregation(row.getStruct(2))
+  )
+
+  private[model] def toSourceResource(row: Row): DplaSourceResource = DplaSourceResource(
+    alternateTitle = stringSeq(row, 0),
+    collection = toMulti(row, 1, toDcmiTypeCollection),
+    contributor = toMulti(row, 2, toEdmAgent),
+    creator = toMulti(row, 3, toEdmAgent),
+    date = toMulti(row, 4, toEdmTimeSpan),
+    description = stringSeq(row, 5),
+    extent = stringSeq(row, 6),
+    format = stringSeq(row, 7),
+    genre = toMulti(row, 8, toSkosConcept),
+    identifier = stringSeq(row, 9),
+    language = toMulti(row, 10, toSkosConcept),
+    place = toMulti(row, 11, toDplaPlace),
+    publisher = toMulti(row, 12, toEdmAgent),
+    relation = toMulti(row, 13, toLiteralOrUri),
+    replacedBy = stringSeq(row, 14),
+    replaces = stringSeq(row, 15),
+    rights = stringSeq(row, 16),
+    rightsHolder = toMulti(row, 17, toEdmAgent),
+    subject = toMulti(row, 18, toSkosConcept),
+    temporal = toMulti(row, 19, toEdmTimeSpan),
+    title = stringSeq(row, 20),
+    `type` = stringSeq(row, 21)
+  )
+
+  private[model] def toEdmWebResource(row: Row): EdmWebResource = EdmWebResource(
+    uri = requiredUri(row, 0),
+    fileFormat = stringSeq(row, 1),
+    dcRights = stringSeq(row, 2),
+    edmRights = optionalString(row, 3)
+  )
+
+  private[model] def toOreAggregation(row: Row): OreAggregation = OreAggregation(
+    uri = requiredUri(row, 0),
+    dataProvider = toEdmAgent(row.getStruct(1)),
+    originalRecord = requiredString(row, 2),
+    hasView = toRows(row, 3).map(toEdmWebResource),
+    intermediateProvider = Option(row.getStruct(4)).map(toEdmAgent),
+    `object` = toOptionEdmWebResource(row.getStruct(5)),
+    preview = toOptionEdmWebResource(row.getStruct(6)),
+    provider = toEdmAgent(row.getStruct(7)),
+    edmRights = optionalUri(row, 8)
+  )
+
+  private[model] def toDplaPlace(row: Row): DplaPlace = DplaPlace(
+    name = optionalString(row, 0),
+    city = optionalString(row, 1),
+    county = optionalString(row, 2),
+    state = optionalString(row, 3),
+    country = optionalString(row, 4),
+    region = optionalString(row, 5),
+    coordinates = optionalString(row, 6)
+  )
+
+  private[model] def toSkosConcept(row: Row): SkosConcept = SkosConcept(
+    concept = optionalString(row, 0),
+    providedLabel = optionalString(row, 1),
+    note = optionalString(row, 2),
+    scheme = optionalUri(row, 3),
+    exactMatch = uriSeq(row, 4),
+    closeMatch = uriSeq(row, 5)
+  )
+
+  private[model] def toEdmTimeSpan(row: Row): EdmTimeSpan = EdmTimeSpan(
+    originalSourceDate = optionalString(row, 0),
+    prefLabel = optionalString(row, 1),
+    begin = optionalString(row, 2),
+    end = optionalString(row, 3)
+  )
+
+  private[model] def toDcmiTypeCollection(row: Row): DcmiTypeCollection = DcmiTypeCollection(
+    title = optionalString(row, 0),
+    description = optionalString(row, 1)
+  )
+
+  private[model] def toOptionEdmWebResource(row: Row): Option[EdmWebResource] =
+    Option(row) match {
+      case None => None
+      case Some(row) => Some(toEdmWebResource(row))
+    }
+
+  private[model] def toLiteralOrUri(row: Row): LiteralOrUri =
+    if (row.getBoolean(1)) Right(new URI(row.getString(0)))
+    else Left(row.getString(0))
+
+  private[model] def toEdmAgent(row: Row): EdmAgent = EdmAgent(
+    uri = optionalUri(row, 0),
+    name = optionalString(row, 1),
+    providedLabel = optionalString(row, 2),
+    note = optionalString(row, 3),
+    scheme = optionalUri(row, 4),
+    exactMatch = uriSeq(row, 5),
+    closeMatch = uriSeq(row, 6)
+  )
+
+  private[model] def toMulti[T](row: Row, fieldPosition: Integer, f: (Row) => T): Seq[T] = {
+    toRows(row, fieldPosition).map(f)
+  }
+
+  private[model] def toRows(row: Row, fieldPosition: Integer): Seq[Row] = {
+    row.getSeq[Row](fieldPosition)
+  }
+
+  private[model] def requiredUri(row: Row, fieldPosition: Integer): URI =
+    optionalUri(row, fieldPosition)
+      .getOrElse(throw new RuntimeException(s"Couldn't parse URI in row $row, field position $fieldPosition"))
+
+  private[model] def optionalUri(row: Row, fieldPosition: Integer): Option[URI] =
+    Option(row.getString(fieldPosition)).map(new URI(_))
+
+  private[model] def requiredString(row: Row, fieldPosition: Integer): String =
+    optionalString(row, fieldPosition)
+      .getOrElse(throw new RuntimeException(s"Couldn't retrieve string in row $row, field position $fieldPosition"))
+
+  private[model] def optionalString(row: Row, fieldPosition: Integer): Option[String] =
+    Option(row.getString(fieldPosition))
+
+  private[model] def stringSeq(row: Row, fieldPosition: Integer): Seq[String] =
+    row.getSeq[String](fieldPosition)
+
+  private[model] def uriSeq(row: Row, fieldPosition: Integer): Seq[URI] =
+    stringSeq(row, fieldPosition).map(new URI(_))
+
+}

--- a/src/main/scala/dpla/ingestion3/model/RowConverter.scala
+++ b/src/main/scala/dpla/ingestion3/model/RowConverter.scala
@@ -1,0 +1,118 @@
+package dpla.ingestion3.model
+
+import dpla.ingestion3.model.DplaMapData.LiteralOrUri
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.types.{ArrayType, StringType, StructField, StructType}
+
+/**
+  * Responsible for desugaring a DplaMapModel and converting it to a Spark-native Row-based structure.
+  *
+  * PLEASE NOTE: The *ordering* of the parameters to each call to the Row() constructor is significant, and
+  * cannot be changed without a concurrent effort to rewrite all the data in the master dataset, and a matching
+  * edit to ModelConverter which is responsible for creating sugared instances of DplaMapData from the output of this
+  * code, and represents the opposite of this transformation.
+  */
+
+object RowConverter {
+
+  def toRow(dplaMapData: DplaMapData, sqlSchema: StructType): Row =
+    new GenericRowWithSchema(
+      Array(dplaSourceResource(dplaMapData.sourceResource),
+        edmWebResource(dplaMapData.edmWebResource),
+        oreAggregation(dplaMapData.oreAggregation)),
+      sqlSchema
+    )
+
+  private[model] def oreAggregation(oa: OreAggregation): Row = Row(
+    oa.uri.toString,
+    edmAgent(oa.dataProvider),
+    oa.originalRecord,
+    oa.hasView.map(edmWebResource),
+    oa.intermediateProvider.map(edmAgent).orNull,
+    oa.`object`.map(edmWebResource).orNull,
+    oa.preview.map(edmWebResource).orNull,
+    edmAgent(oa.provider),
+    oa.edmRights.map(_.toString).orNull
+  )
+
+  private[model] def dplaSourceResource(sr: DplaSourceResource): Row = Row(
+    sr.alternateTitle,
+    sr.collection.map(dcmiTypeCollection),
+    sr.contributor.map(edmAgent),
+    sr.creator.map(edmAgent),
+    sr.date.map(edmTimeSpan),
+    sr.description,
+    sr.extent,
+    sr.format,
+    sr.genre.map(skosConcept),
+    sr.identifier,
+    sr.language.map(skosConcept),
+    sr.place.map(dplaPlace),
+    sr.publisher.map(edmAgent),
+    sr.relation.map(literalOrUri),
+    sr.replacedBy,
+    sr.replaces,
+    sr.rights,
+    sr.rightsHolder.map(edmAgent),
+    sr.subject.map(skosConcept),
+    sr.temporal.map(edmTimeSpan),
+    sr.title,
+    sr.`type`
+  )
+
+  private[model]def edmWebResource(wr: EdmWebResource): Row = Row(
+    wr.uri.toString,
+    wr.fileFormat,
+    wr.dcRights,
+    wr.edmRights.orNull
+  )
+
+  private[model] def edmAgent(ea: EdmAgent): Row = Row(
+    ea.uri.map(_.toString).orNull,
+    ea.name.orNull,
+    ea.providedLabel.orNull,
+    ea.note.orNull,
+    ea.scheme.map(_.toString).orNull,
+    ea.exactMatch.map(_.toString),
+    ea.closeMatch.map(_.toString)
+  )
+
+
+  private[model] def literalOrUri(literalOrUri: LiteralOrUri): Row = Row(
+    literalOrUri.merge.toString, //both types turn into strings with toString
+    literalOrUri.isRight //right is URI, isRight is true when it's a uri
+  )
+
+  private[model] def dplaPlace(dplaPlace: DplaPlace): Row = Row(
+    dplaPlace.name.orNull,
+    dplaPlace.city.orNull,
+    dplaPlace.county.orNull,
+    dplaPlace.state.orNull,
+    dplaPlace.country.orNull,
+    dplaPlace.region.orNull,
+    dplaPlace.coordinates.orNull
+  )
+
+  private[model] def skosConcept(skosConcept: SkosConcept): Row = Row(
+    skosConcept.concept.orNull,
+    skosConcept.providedLabel.orNull,
+    skosConcept.note.orNull,
+    skosConcept.scheme.map(_.toString).orNull,
+    skosConcept.exactMatch.map(_.toString),
+    skosConcept.closeMatch.map(_.toString)
+  )
+
+  private[model] def edmTimeSpan(edmTimeSpan: EdmTimeSpan): Row = Row(
+    edmTimeSpan.originalSourceDate.orNull,
+    edmTimeSpan.prefLabel.orNull,
+    edmTimeSpan.begin.orNull,
+    edmTimeSpan.end.orNull
+  )
+
+  private[model] def dcmiTypeCollection(dcmiTypeCollection: DcmiTypeCollection): Row = Row(
+    dcmiTypeCollection.title.orNull,
+    dcmiTypeCollection.description.orNull
+  )
+
+}

--- a/src/test/scala/dpla/ingestion3/avro/AvroSchemaTest.scala
+++ b/src/test/scala/dpla/ingestion3/avro/AvroSchemaTest.scala
@@ -1,0 +1,17 @@
+package dpla.ingestion3.avro
+
+import dpla.ingestion3.utils.FlatFileIO
+import org.apache.avro.Schema
+import org.scalatest.{BeforeAndAfter, FlatSpec}
+
+class AvroSchemaTest  extends FlatSpec with BeforeAndAfter {
+
+  val schemaFiles = Seq("/avro/IndexRecord_MAP3.avsc", "/avro/IndexRecord_MAP4.avsc", "/avro/MAPRecord.avsc", "/avro/OriginalRecord.avsc")
+
+  "an Avro schema file" should "parse" in {
+    for (file <- schemaFiles) {
+      val schemaString = new FlatFileIO().readFileAsString(file)
+      val schema = new Schema.Parser().parse(schemaString)
+    }
+  }
+}


### PR DESCRIPTION
This PR contains two functions, one to convert a DplaMapModel to a Row, and one to convert a Row into a DplaMapModel. These can be used at the point when we need to write to Avro and  to subsequently read from those Avro files. Additionally, we can in theory use these to serialize to any other format Spark supports (e.g., Parquet), and we can work with the data in desugared, primitive format in SparkSQL if needed.