### PR TITLE
FIX: Include empty/missing values to all reports and add support for all fields

### DIFF
--- a/src/main/scala/dpla/ingestion3/reports/PropertyValueReport.scala
+++ b/src/main/scala/dpla/ingestion3/reports/PropertyValueReport.scala
@@ -1,12 +1,17 @@
 package dpla.ingestion3.reports
-import dpla.ingestion3.model.DplaMapData
+import dpla.ingestion3.model._
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
+import org.apache.spark.sql.functions.{col, explode}
+
+case class PropertyValueRpt(dplaUri: String,
+                            localUri: String,
+                            value: Seq[String])
 
 class PropertyValueReport (
                             val inputURI: String,
                             val outputURI: String,
                             val sparkMasterName: String,
-                            val params: Array[String]) extends Report {
+                            val params: Array[String]) extends Report with Serializable {
 
   override val sparkAppName: String = "PropertyValueReport"
   override def getInputURI: String = inputURI
@@ -18,6 +23,8 @@ class PropertyValueReport (
       case _ => None
     }
   }
+  val dplaUriCol = "dpla uri"
+  val localUriCol = "local uri"
 
   def splitOnPipe(str: String) = str.split("|")
 
@@ -50,40 +57,224 @@ class PropertyValueReport (
     implicit val dplaMapDataEncoder =
       org.apache.spark.sql.Encoders.kryo[DplaMapData]
 
-    token match {
-        // TODO Is there a cleaner way of including the local and dpla uris
-        // so they aren't repeated for every single case block?
+    val rptDataset: Dataset[PropertyValueRpt] = token match {
+      case "sourceResource.alternateTitle" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.alternateTitle)
+          )
+        })
+      case "sourceResource.contributor.name" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.contributor)
+          )
+        })
+      case "sourceResource.collection.title" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.collection)
+          )
+        })
+      case "sourceResource.creator.name" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.creator)
+          )
+        })
+      case "sourceResource.date.originalSourceDate" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.date)
+          )
+        })
+      case "sourceResource.description" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.description)
+          )
+        })
+      case "sourceResource.extent" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.extent)
+          )
+        })
       case "sourceResource.format" =>
-          ds.map(dplaMapData => ( dplaMapData.edmWebResource.uri.toString,
-                                dplaMapData.sourceResource.format,
-                                dplaMapData.oreAggregation.uri.toString))
-            .withColumnRenamed("_1", "local uri")
-            .withColumnRenamed("_3", "dpla uri")
-            .withColumn("format", org.apache.spark.sql.functions.explode($"_2"))
-            .drop("_2")
-
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.format)
+          )
+        })
+      case "sourceResource.genre" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.genre)
+          )
+        })
+      case "sourceResource.identifier" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.identifier)
+          )
+        })
+      case "sourceResource.language.providedLabel" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.language)
+          )
+        })
+      case "sourceResource.place.name" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.place)
+          )
+        })
+      case "sourceResource.place.name" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.place)
+          )
+        })
+      case "sourceResource.publisher.name" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.publisher)
+          )
+        })
+      case "sourceResource.relation" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.relation)
+          )
+        })
+      case "sourceResource.replacedBy" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.replacedBy)
+          )
+        })
+      case "sourceResource.replacedBy" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.replacedBy)
+          )
+        })
+      case "sourceResource.replaces" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.replaces)
+          )
+        })
       case "sourceResource.rights" =>
-        ds.map(dplaMapData => ( dplaMapData.edmWebResource.uri.toString,
-                                dplaMapData.sourceResource.rights,
-                                dplaMapData.oreAggregation.uri.toString))
-          .withColumnRenamed("_1", "local uri")
-          .withColumnRenamed("_3", "dpla uri")
-          .withColumn("rights", org.apache.spark.sql.functions.explode($"_2"))
-          .drop("_2")
-
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.rights)
+          )
+        })
+      case "sourceResource.rightsHolder.name" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.rightsHolder)
+          )
+        })
+      case "sourceResource.subject.providedLabel" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.subject)
+          )
+        })
+      case "sourceResource.temporal.originalSourceDate" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.temporal)
+          )
+        })
+      case "sourceResource.title" =>
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.title)
+          )
+        })
       case "sourceResource.type" =>
-        ds.map(dplaMapData => ( dplaMapData.edmWebResource.uri.toString,
-                                dplaMapData.sourceResource.`type`,
-                                dplaMapData.oreAggregation.uri.toString))
-          .withColumnRenamed("_1", "local uri")
-          .withColumnRenamed("_3", "dpla uri")
-          .withColumn("type", org.apache.spark.sql.functions.explode($"_2"))
-          .drop("_2")
-
+        ds.map(dplaMapData => {
+          PropertyValueRpt(
+            dplaUri = dplaMapData.edmWebResource.uri.toString,
+            localUri = dplaMapData.oreAggregation.uri.toString,
+            value = extractValue(dplaMapData.sourceResource.`type`)
+          )
+        })
       case x =>
         throw new RuntimeException(s"Unrecognized field name '${x}'")
     }
+
+    makeTable(rptDataset, spark, token)
   }
 
+  /**
+    * Responsible for exploding the value column of the
+    * DataFrame so that multiple values occur on separate
+    * rows.
+    *
+    * @param rptDataset Report dataset
+    * @param spark Spark Session
+    * @param token The name of the column being reported on
+    * @return
+    */
+  def makeTable(rptDataset: Dataset[PropertyValueRpt],
+                spark: SparkSession,
+                token: String): DataFrame = {
+    val sqlContext = spark.sqlContext
+    rptDataset.createOrReplaceTempView("tmpPropValRpt")
 
+    sqlContext.sql("""SELECT * FROM tmpPropValRpt""")
+      .withColumn(token, explode(col("value")))
+      .drop(col("value"))
+  }
 }


### PR DESCRIPTION
This PR addresses both DT-1546 and DT-1545. 

All sourceResource fields were added to the PropertyValueReport and PropertyDistinctValueReport. Case classes were also added to both report classes to tighten up the code. Adds an extraction method for the report values. This method is also used to extract the correct field from all the context case classes. 