### PR TITLE
fix oai harvester invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,24 +61,21 @@ To use SBT you need to specify the path to the config file you just created when
 
 ```
 # Example when the path is stored locally. This should address 95% of all use cases
--Dconfig.file=/loca/path/to/config.conf
+/local/path/to/config.conf
 
-# Exmple when the profile is stored remotely
--Dconfig.url=https://s3.amazonaws.com/dpla-i3-oai-profiles/sample_provider.conf
-
-# Example when the config file is on the project classpath
--Dconfig.resource=profiles/sample_provider.conf
+# Example when the profile is stored remotely
+https://s3.amazonaws.com/dpla-i3-oai-profiles/sample_provider.conf
 ``` 
 
 *Example invocation with local config file*
 
-`sbt "run -Dconfig.file=/loca/path/to/oai.conf /path/to/ingestion3.jar"`
+`sbt "run /local/path/to/oai.conf /path/to/ingestion3.jar"`
 
 ### Running using IntelliJ
 Specify the config file parameter as a VM Option argument.
 
 ```text
--Dconfig.url=https://s3.amazonaws.com/dpla-i3-oai-profiles/sample_provider.conf
+https://s3.amazonaws.com/dpla-i3-oai-profiles/sample_provider.conf
 ``` 
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/6a9dfda51ad04ce3acfb7fcb441af846)](https://www.codacy.com/app/mdellabitta/ingestion3?utm_source=github.com&utm_medium=referral&utm_content=dpla/ingestion3&utm_campaign=badger)

--- a/src/main/scala/dpla/ingestion3/confs/OaiHarvesterConf.scala
+++ b/src/main/scala/dpla/ingestion3/confs/OaiHarvesterConf.scala
@@ -1,6 +1,8 @@
 package dpla.ingestion3.confs
 
+import java.net.URL
 import com.typesafe.config.ConfigFactory
+import scala.util.Try
 
 /**
   *
@@ -25,7 +27,22 @@ class OaiHarvesterConf(arguments: Seq[String]) {
     // Loads config file for more information about loading hierarchy please read
     // https://github.com/typesafehub/config#standard-behavior
     ConfigFactory.invalidateCaches()
-    val oaiConf = ConfigFactory.load()
+
+    val filePath = arguments.headOption.getOrElse("")
+
+    if (filePath.isEmpty) throw new IllegalArgumentException("Missing path to conf file")
+
+    // Check if filePath is a URL.
+    def validateUrl(string: String): Boolean = Try{ new URL(string) }.isSuccess
+
+    val property = validateUrl(filePath) match {
+      case true => "config.url"
+      case false => "config.file"
+    }
+
+    System.setProperty(property, filePath)
+    val oaiConf = ConfigFactory.load
+
 
     def getProp(prop: String, default: Option[String] = None): Option[String] = {
       oaiConf.hasPath(prop) match {


### PR DESCRIPTION
This fixes the OAI harvester invocation (at least for me).  

The OAI harvester invocation was not working on my local machine.  Using `-Dconfig` in the SBT command line did not seem to be successfully setting the system properties, so when `ConfigFactory.load()` was called, my `.conf` file was not being read in.  I don't know _why_ this was happening, but this PR fixes it.  The same bug was reported by one of our users in the tech channel.  Scott was _not_ having trouble with the previous implementation.

Instead of using `-Dconfig` in the command line, this new PR reads in a file locally or from a URL, and sets the system property in `OaiHarvesterConf`.

The user does not need to specify whether a file is local or a URL; the application checks this.  The upside of having the application check for a URL is that it's a simpler command-line interface.  The downside is that there is no way to specify reading a file from a classpath, as there was before.  I'm not sure if we need to account for this use case - if so, we could add a command line arg specifying "file", "url", or "classpath".

I have tested this using a local `.conf` file, and one in S3.  It would be good to get at least one more test from someone on the team (and maybe the person from the tech channel).