### PR TITLE
fix case of setlist var

### DIFF
--- a/src/main/scala/dpla/ingestion3/OaiHarvesterMain.scala
+++ b/src/main/scala/dpla/ingestion3/OaiHarvesterMain.scala
@@ -41,7 +41,7 @@ object OaiHarvesterMain {
       "verb" -> oaiParams.verb,
       "metadataPrefix" -> oaiParams.metadataPrefix,
       "harvestAllSets" -> oaiParams.harvestAllSets,
-      "setlist" -> oaiParams.setList,
+      "setlist" -> oaiParams.setlist,
       "blacklist" -> oaiParams.blacklist,
       "endpoint" -> oaiParams.endpoint
     ).collect{ case (key, Some(value)) => key -> value } // remove None values

--- a/src/main/scala/dpla/ingestion3/confs/OaiHarvesterConf.scala
+++ b/src/main/scala/dpla/ingestion3/confs/OaiHarvesterConf.scala
@@ -51,7 +51,7 @@ class OaiHarvesterConf(arguments: Seq[String]) {
       },
       metadataPrefix = getProp("metadataPrefix"),
       harvestAllSets = getProp("harvestAllSets"),
-      setList = getProp("setList"),
+      setlist = getProp("setlist"),
       blacklist = getProp("blacklist"),
       // Default spark master is to run on local
       sparkMaster = getProp("sparkMaster", Some("local[*]"))
@@ -66,7 +66,7 @@ case class OaiConf(
                        provider: Option[String],
                        metadataPrefix: Option[String],
                        harvestAllSets: Option[String],
-                       setList: Option[String],
+                       setlist: Option[String],
                        blacklist: Option[String],
                        sparkMaster: Option[String]
                      )


### PR DESCRIPTION
This fixes the case of the `setlist` var so that it is always lowercase (as opposed to camel-case).  This brings it in line with the documentation in the `README.md` and also makes it consistent throughout the app.