### PR TITLE
EnrichmentDriver Data Copy Fix

### DIFF
--- a/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
@@ -35,7 +35,7 @@ class EnrichmentDriver extends Serializable {
     */
   def enrich(record: DplaMapData): DplaMapData = {
     record.copy(
-      DplaSourceResource(
+      record.sourceResource.copy(
         date = record.sourceResource.date.map(d => dateEnrichment.parse(d)),
         language = record.sourceResource.language.map(l => LanguageMapper.mapLanguage(l)),
         place = record.sourceResource.place.map(p => spatialEnrichment.enrich(p))


### PR DESCRIPTION
Fix to EnrichmentDriver that wasn't calling copy constructor
of DplaSourceResource, so was losing data not explicitly mutated.