### PR TITLE
Xml Shredder

### DIFF
--- a/src/main/scala/dpla/ingestion3/PreMappingReporterMain.scala
+++ b/src/main/scala/dpla/ingestion3/PreMappingReporterMain.scala
@@ -1,0 +1,89 @@
+package dpla.ingestion3
+
+import dpla.ingestion3.premappingreports._
+import org.apache.log4j.{LogManager, Logger}
+import scala.util.{Failure, Try}
+
+/**
+  * PreMappingReporterMain and PreMappingReporter, for generating QA reports
+  * on harvested documents.
+  *
+  * Example invocation:
+  *
+  *   $ sbt "run-main dpla.ingestion3.PreMappingReporterMain \
+  *     /path/to/harvested-data.avro /path/to/pre-mapping-report local[2] \
+  *     xmlShredder"
+ */
+
+/**
+  * PreMappingReporter, the driver class.
+  *
+  * The design patters for PreMappingReporter are the same as those for Reporter.
+  *
+  * @param inputURI         Input URI or file path
+  * @param outputURI        Output URI or file path
+  * @param sparkMasterName  Spark master name, e.g. "local[1]"
+  * @param token            The report name token
+  */
+class PreMappingReporter (token: String,
+                          inputURI: String,
+                          outputURI: String,
+                          sparkMasterName: String) {
+
+  val logger: Logger = LogManager.getLogger(this.getClass)
+
+  private def getPreMappingReport(token: String): Option[PreMappingReport] = {
+    token match {
+      case "xmlShredder" =>
+        Some(new XmlShredderReport(inputURI, outputURI, sparkMasterName))
+      case _ => None
+    }
+  }
+
+  def main(): Unit = {
+    val result: Try[Unit] = getPreMappingReport(token) match {
+      case Some(shreds) => shreds.run()
+      case None => Failure(
+        new RuntimeException(s"Pre-mapping report type $token is unknown")
+      )
+    }
+    result match {
+      case Failure(ex) =>
+        logger.error(ex.toString)
+        logger.error("\n" + ex.getStackTrace.mkString("\n"))
+      case _ => Unit
+    }
+  }
+}
+
+/**
+  * Entry point for running a pre-mapping report.
+  */
+object PreMappingReporterMain {
+
+  def usage(): Unit = {
+    println(
+      """
+        |Usage:
+        |
+        |PreMappingReporterMain <input> <output> <spark master> <report token>
+      """.stripMargin)
+  }
+
+  def main(args: Array[String]): Unit = {
+    if (args.length < 4) {
+      usage()
+      System.err.println("Incorrect invocation arguments")
+      sys.exit(1)
+    }
+    val inputURI = args(0)
+    val outputURI = args(1)
+    val sparkMasterName = args(2)
+    val token = args(3)
+
+    new PreMappingReporter(
+      token, inputURI, outputURI, sparkMasterName
+    ).main()
+  }
+}
+

--- a/src/main/scala/dpla/ingestion3/preMappingReports/PreMappingReport.scala
+++ b/src/main/scala/dpla/ingestion3/preMappingReports/PreMappingReport.scala
@@ -1,0 +1,69 @@
+package dpla.ingestion3.premappingreports
+
+import java.io.File
+
+import com.databricks.spark.avro._
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import dpla.ingestion3.utils.Utils
+
+import util.Try
+
+/**
+  * PreMappingReport: trait with common fields and methods for pre-mapping reports.
+  *
+  * The PreMappingReport trait follow the design patterns of the Report trait.
+  */
+trait PreMappingReport {
+
+  val sparkAppName: String = "PreMappingReport"  // Usually overridden
+
+  /**
+    * Accessor methods are used to make the trait and its extending classes
+    * more amenable to unit testing.
+    */
+  def getInputURI: String
+  def getOutputURI: String
+  def getSparkMasterName: String
+
+  /**
+    * Run the shredder, opening the input and output and invoking the process()
+    * function in the extending class.
+    *
+    * @see PreMappingReporter.main()
+    * @return Try object representing success or failure, for PreMappingReporter.main()
+    */
+  def run(): Try[Unit] = Try {
+
+    val sparkConf: SparkConf =
+      new SparkConf().setAppName(sparkAppName).setMaster(getSparkMasterName)
+    val spark: SparkSession =
+      SparkSession.builder().config(sparkConf).getOrCreate()
+    val sc = spark.sparkContext
+
+    val input: DataFrame = spark.read.avro(getInputURI)
+
+    val output: DataFrame = process(input)
+
+    Utils.deleteRecursively(new File(getOutputURI))
+    output
+      .repartition(1)  // Otherwise multiple CSV files
+      .write
+      .format("com.databricks.spark.csv")
+      .option("header", "true")
+      .save(getOutputURI)
+
+    sc.stop()
+  }
+
+  /**
+    * Process the incoming DataFrame (harvested records) and return a
+    * DataFrame of computed results.
+    *
+    * Overridden by classes in dpla.ingestion3.premappingreports
+    *
+    * @param df     DataFrame of harvested records
+    * @return       DataFrame
+    */
+  def process(df: DataFrame): DataFrame
+}

--- a/src/main/scala/dpla/ingestion3/preMappingReports/XmlShredder.scala
+++ b/src/main/scala/dpla/ingestion3/preMappingReports/XmlShredder.scala
@@ -1,0 +1,180 @@
+package dpla.ingestion3.premappingreports
+
+import scala.annotation.tailrec
+import scala.util.{Try, Failure, Success}
+import scala.xml._
+
+/**
+  * XML shredder for pre-mapping QA.
+  */
+object XmlShredder {
+
+  /**
+    * Entry point for XmlShredder.
+    * Shred a single record into Triples.
+    *
+    * A Triple is a id-attribute-value grouping.
+    * It is terminal, meaning that the value is a String (rather than another
+    * XML node).
+    * Attributes, xml namespaces, and text make triples.
+    * Examples:
+    *   <a id='foo'/>
+    *   id: [ID of record being shredded]
+    *   attribute: a.@id
+    *   value:     foo
+    *
+    *   <a>foo</a>
+    *   id: [ID of record being shredded]
+    *   attribute: a.text()
+    *   value:     foo
+    *
+    *   <a><b><c>foo</c></b></a>
+    *   id: [ID of record being shredded]
+    *   attribute: a.b.c.text()
+    *   value:     foo
+    *
+    * Any XML parsing errors fail silently. This is based on these assumptions:
+    *   1. Parse errors are unlikely since invalid XML causes failure during harvest.
+    *   2. It is not the job of this pre-mapping report to identify invalid XML.
+    *
+    * @param id String ID of the record being shredded
+    * @param record String the record being shredded
+    * @return List[Triple]
+    */
+  def getXmlTriples(id: String, record: String): List[Triple] = {
+    loadXml(record) match {
+      case Success(xml) => shredRecord(id, xml)
+      // Return empty list in case of XML parsing error.
+      case Failure(_) => List()
+    }
+  }
+
+  // Try to parse a string into valid XML.
+  private def loadXml(string: String): Try[Node] = Try { XML.loadString(string) }
+
+  /**
+    * Parse Triples from a root node of an XML record.
+    *
+    * Child nodes are mapped to a case class called NodeWithLabel.
+    * The label is actually the concatenated labels of a node and all its ancestors.
+    * For example, given this xml:
+    *   <a><b><c>foo</c></b></a>
+    *   The label for the c node is "a.b.c"
+    * The case class stores the label so that it doesn't have to be constructed
+    * for each triple via another traversal of the XML record.
+    *
+    * This method uses tail recursion to traverse the XML document.
+    * Starting with the root node, all attributes, xmlns, and text of the root are
+    * mapped to Triples and put in one "bucket."  All child nodes are put into
+    * another "bucket".
+    *
+    * Example:
+    *   <root id='foo'><a>bar</a></root>
+    *   Parsing the root would yield one triple and one node.
+    *
+    * Both "buckets" are passed back through the loop.  All nodes in the
+    * bucket are parsed.  Any new triples are added to the  triples bucket,
+    * and any new nodes are put into the nodes bucket.
+    * This repeats until the nodes bucket is empty.
+    *
+    * @param id String The id of the record being shredded.
+    * @param root The root XML node for a single record.
+    * @return List[Triples] All of the parsed triples from the record.
+    */
+  private def shredRecord(id: String, root: Node): List[Triple] = {
+
+    /**
+      * @param triples List[Triples] Accumulates all triples as xml doc is
+      *                traversed.
+      * @param nodes   List[NodeWithLabel] Contains all nodes to be parsed in a
+      *                single loop cycle.
+      * @return        List[Triple] All accumulated triples.
+      */
+    @tailrec
+    def loop(triples: List[Triple], nodes: List[NodeWithLabel]): List[Triple] = {
+      // Terminate loop if there are no more XML nodes to parse.
+      if (nodes.isEmpty) triples
+      else {
+        // Otherwise, continue parsing nodes.
+
+        // Parse all current nodes into new triples and new nodes.
+        val shreds: List[(List[Triple], List[NodeWithLabel])] =
+          nodes.map(n => shredNode(id, n))
+
+        val newTriples: List[Triple] = shreds.flatMap{ case (triple, _) => triple }
+        val newNodes: List[NodeWithLabel] = shreds.flatMap{ case (_, node) => node }
+
+        loop(triples ::: newTriples, newNodes)
+      }
+    }
+
+    val firstFragment = NodeWithLabel(labelWithPrefix(root), root)
+    loop(List(), List(firstFragment))
+  }
+
+  /**
+    * Shred a single XML node.
+    *
+    * Attribute and text values are forced into String types.
+    *
+    * @param id String The id of the record being shredded.
+    * @param nodeWithLabel The XML node to be shredded.
+    * @return (List[Triple], List[NodeWithLabels]  The complete triples and XML
+    *         child nodes that are derived from the given node.
+    */
+  private def shredNode(id: String, nodeWithLabel: NodeWithLabel):
+    (List[Triple], List[NodeWithLabel]) = {
+
+    val node = nodeWithLabel.node
+    val label = nodeWithLabel.label
+
+    // Map attributes to Triples.
+    val attributes: List[Triple] = node.attributes.flatMap(attr => {
+      val attrLabel = s"${label}.@${attr.key}"
+      attr.value.map(v => Triple(id, attrLabel, v.text.toString))
+    }).toList
+
+    // Map xmlns to Triple.
+    val namespaces: List[Triple] =
+      if(node.namespace.isEmpty) List()
+      else {
+        val attribute = s"${label}.@xmlns"
+        List(Triple(id, attribute, node.namespace))
+      }
+
+    // Separate children into text nodes and xml (i.e. non-text) nodes.
+    val (textNodes: List[Text], xmlNodes: List[Node]) =
+      node.child.partition(_.isInstanceOf[Text])
+
+    // Map text nodes Triples.
+    val text: List[Triple] = textNodes.map(t => {
+      val attribute = s"${label}.text()"
+      Triple(id, attribute, t.text.toString)
+    })
+
+    // Map xml nodes to NodeWithLabels.
+    val newNodes: List[NodeWithLabel] = xmlNodes.map(child => {
+      val childLabel = s"${label}.${labelWithPrefix(child)}"
+      NodeWithLabel(childLabel, child)
+    })
+
+    // Combine attributes and text, which are both complete triples.
+    val newTriples = attributes ::: namespaces ::: text
+
+    (newTriples, newNodes)
+  }
+
+  // Get the XML label. Include prefix if one is present.
+  def labelWithPrefix(node: Node): String =
+    // We have to use null here b/c it can be returned by scala.xml.Node
+    if(node.prefix == null) node.label
+    else s"${node.prefix}:${node.label}"
+}
+
+// An XML node plus its label
+case class NodeWithLabel(label: String,
+                         node: Node)
+
+case class Triple(id: String,
+                  attribute: String,
+                  value: String)

--- a/src/main/scala/dpla/ingestion3/preMappingReports/XmlShredderReport.scala
+++ b/src/main/scala/dpla/ingestion3/preMappingReports/XmlShredderReport.scala
@@ -1,0 +1,56 @@
+package dpla.ingestion3.premappingreports
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions.{udf, explode}
+
+class XmlShredderReport(val inputURI: String,
+                        val outputURI: String,
+                        val sparkMasterName: String
+                       ) extends PreMappingReport with Serializable {
+
+  override val sparkAppName: String = "XmlShredder"
+
+  override def getInputURI: String = inputURI
+
+  override def getOutputURI: String = outputURI
+
+  override def getSparkMasterName: String = sparkMasterName
+
+  /**
+    * Process the incoming DataFrame.
+    *
+    * The resulting DataFrame has the following columns:
+    *   - id: String
+    *   - attribute: String
+    *   - value: String
+    *
+    * @see PreMappingReport.process()
+    * @param df DataFrame (harvested records)
+    * @return DataFrame
+    */
+  override def process(df: DataFrame): DataFrame = {
+
+    val records: DataFrame = df.select("document", "id")
+      .where("document is not null")
+      .distinct
+
+    // Each row in `triples' contains a List of Triples.
+    val triples = records
+      .withColumn("triples", docToTriplesFunc(records.col("id"), records.col("document")))
+      .drop("document", "id")
+
+    // Each row in `flattened' contains a Triple.
+    val flattened = triples.withColumn("triples", explode(triples.col("triples")))
+      .where("triples is not null")
+
+    flattened.select("triples.id", "triples.attribute", "triples.value")
+  }
+
+  /**
+    * Create a UDF to convert a document String into a List of parsed Triples.
+    */
+  private val docToTriples: ((String, String) => List[Triple]) =
+    (id: String, record: String) => XmlShredder.getXmlTriples(id, record)
+
+  private val docToTriplesFunc = udf(docToTriples)
+}

--- a/src/test/scala/dpla/ingestion3/PreMappingReporterTest.scala
+++ b/src/test/scala/dpla/ingestion3/PreMappingReporterTest.scala
@@ -1,0 +1,20 @@
+package dpla.ingestion3
+
+import org.scalatest.{FlatSpec, PrivateMethodTester}
+import org.scalamock.scalatest.MockFactory
+import dpla.ingestion3.premappingreports._
+
+class PreMappingReporterTest extends FlatSpec
+    with MockFactory with PrivateMethodTester {
+
+  "PreMappingReporter.getPreMappingReport" should "return a XmlShredder given token " +
+      "'xmlShredder'" in {
+    val getPreMappingReport = PrivateMethod[Option[PreMappingReport]]('getPreMappingReport)
+    val preMappingReporter = new PreMappingReporter("x", "x", "x", "x")
+    val preMappingReport = preMappingReporter invokePrivate getPreMappingReport("xmlShredder")
+    preMappingReport match {
+      case Some(r) => assert(r.isInstanceOf[XmlShredderReport])
+      case _ => fail
+    }
+  }
+}


### PR DESCRIPTION
This adds a pre-mapping report to shred harvested XML docs.  It addresses [ticket DT-1488](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1488).

The report includes both `xmlns` data and prefixes for labels (ie. a label will be `record.about.oaiProvenance:provenance` instead of `record.about.provenance`.  This can be easily changed if it's too overwhelming for QA workflows.

I tried to write tests for `XmlShredder` but was running into some serialization issues within the test environment that I did not know how to solve.  I did test this locally with a sample of harvested data.