### PR TITLE
xml shredder json output for elastic search

### DIFF
--- a/src/main/scala/dpla/ingestion3/preMappingReports/XmlShredderReport.scala
+++ b/src/main/scala/dpla/ingestion3/preMappingReports/XmlShredderReport.scala
@@ -1,7 +1,10 @@
 package dpla.ingestion3.premappingreports
 
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
-import org.apache.spark.sql.functions.{udf, explode}
+import org.apache.spark.sql.functions._
+
+import scala.util.parsing.json._
 
 class XmlShredderReport(val inputURI: String,
                         val outputURI: String,
@@ -19,16 +22,15 @@ class XmlShredderReport(val inputURI: String,
   /**
     * Process the incoming DataFrame.
     *
-    * The resulting DataFrame has the following columns:
-    *   - id: String
-    *   - attribute: String
-    *   - value: String
+    * The resulting RDD contains JSONType object.
+    * Each JSONType object represents a single record, in a format that will
+    * work with elastidump.
     *
     * @see PreMappingReport.process()
     * @param df DataFrame (harvested records)
-    * @return DataFrame
+    * @return RDD[JSONType]
     */
-  override def process(df: DataFrame): DataFrame = {
+  override def process(df: DataFrame): RDD[JSONType] = {
 
     val records: DataFrame = df.select("document", "id")
       .where("document is not null")
@@ -43,7 +45,29 @@ class XmlShredderReport(val inputURI: String,
     val flattened = triples.withColumn("triples", explode(triples.col("triples")))
       .where("triples is not null")
 
-    flattened.select("triples.id", "triples.attribute", "triples.value")
+    // Each row in `flattenedAgain' has three columns: "id", "attribute", "value"
+    val flattenedAgain = flattened
+      .select("triples.id", "triples.attribute", "triples.value")
+
+    // Each row in the returned DataFrame has columns for "id" and for each
+    // attribute.  If there is more than one value for any attribute, it is
+    // concatenated with ",".
+    val grouped = flattenedAgain.groupBy("id")
+      .pivot("attribute")
+      .agg(concat_ws(",", collect_list(col("value"))))
+
+    // Change each row to a JSON String.
+    val json: Dataset[String] = grouped.toJSON
+
+    // Covert Dataset to RDD.  Datasets run into encoder errors when you try to
+    // parse their Rows to JSON.
+    json.rdd.flatMap(x => {
+      // Create proper nested JSON format to work with elasticdump.
+      val string = """{"_source": """ + x + """}"""
+      // Convert Strings into JSONType objects so they can be written out to
+      // JSON files.
+      JSON.parseRaw(string)
+    })
   }
 
   /**


### PR DESCRIPTION
This changes the output of the XML shredder from a CSV file to a JSON file that is formatted correctly to work with elasticdump.

To generate JSON from a harvest:

```
sbt "run-main dpla.ingestion3.PreMappingReporterMain [PATH TO HARVESTED DATA] [PATH TO JSON OUTPUT] [SPARK MASTER] xmlShredder"
```

To index the JSON to ElasticSearch, I did:

```
./bin/elasticdump --input [PATH-TO-JSON] --output http://ec2-52-87-236-197.compute-1.amazonaws.com:9200/xml-shredder-test/item --headers '{"Content-Type": "application/json"}'
```

To see this indexed: `http://ec2-52-87-236-197.compute-1.amazonaws.com:9200/xml-shredder-test/_search?pretty=true&q=*:*`

This addresses [ticket DT-1555](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1555).  It has been tested locally.