### PR TITLE
do not use elasticsearch reserve chars in xml shredder

### DIFF
--- a/src/main/scala/dpla/ingestion3/preMappingReports/PreMappingReport.scala
+++ b/src/main/scala/dpla/ingestion3/preMappingReports/PreMappingReport.scala
@@ -49,7 +49,7 @@ trait PreMappingReport {
 
     Utils.deleteRecursively(new File(getOutputURI))
 
-    output.saveAsTextFile(getOutputURI)
+    output.coalesce(1).saveAsTextFile(getOutputURI)
 
     sc.stop()
   }

--- a/src/main/scala/dpla/ingestion3/preMappingReports/XmlShredder.scala
+++ b/src/main/scala/dpla/ingestion3/preMappingReports/XmlShredder.scala
@@ -148,7 +148,7 @@ object XmlShredder {
 
     // Map text nodes Triples.
     val text: List[Triple] = textNodes.map(t => {
-      val attribute = s"${label}.text()"
+      val attribute = s"${label}.text"
       Triple(id, attribute, t.text.toString)
     })
 
@@ -168,7 +168,7 @@ object XmlShredder {
   def labelWithPrefix(node: Node): String =
     // We have to use null here b/c it can be returned by scala.xml.Node
     if(node.prefix == null) node.label
-    else s"${node.prefix}:${node.label}"
+    else s"${node.prefix}_${node.label}"
 }
 
 // An XML node plus its label


### PR DESCRIPTION
Remove Elastic Search reserve characters from concatenated field labels.  Previously, we were adding `: ( )` to field labels for legibility.  Now we are adding `_` instead.

All of the ES reserve chars are: `+ - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /`  XML's reserve chars are `"  ' < > &`  I don't know if it's worth writing in escapes for all the other ES reserve chars at this point, b/c I don't anticipate that we will likely see them coming through as field labels - perhaps someone more familiar with our provider's XML streams could weigh in.

I also added back in coalescing the output before writing so we only get one JSON file instead of many.  I don't know if this will be desired in the long term, but for now it makes it easier to index things with elastic dump.

This addresses [DT-1577](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1577).  It has been tested locally and indexed to http://ec2-52-87-236-197.compute-1.amazonaws.com:9200/xml-shredder-test/