### PR TITLE
Improve json export for Ingestion 1 index.

### DIFF
--- a/src/main/scala/dpla/ingestion3/JsonlEntry.scala
+++ b/src/main/scala/dpla/ingestion3/JsonlEntry.scala
@@ -1,0 +1,61 @@
+package dpla.ingestion3
+
+import dpla.ingestion3.model.{DplaMapData, ModelConverter, jsonlRecord}
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{Dataset, SparkSession}
+
+/**
+  * Driver for reading DplaMapData records (mapped or enriched) and generating
+  * JSONL text, which can be bulk loaded into a DPLA Ingestion1 index, in
+  * Elasticsearch 0.90
+  *
+  * Arguments:
+  *   1) The path or URL to the mapped / enriched data (file, directory, or s3
+  *      URI)
+  *   2) The path or URL to the output (directory or s3 "folder")
+  *
+  * The output directory will contain one file named "part-*" that constitutes
+  * the JSONL.
+  *
+  *   Usage
+  *   -----
+  *   To invoke via sbt:
+  *     sbt "run-main dpla.ingestion3.JsonlEntry /input/path /output/path"
+  *
+  */
+object JsonlEntry {
+
+  def main(args: Array[String]): Unit = {
+
+    val inputName = args(0)
+    val outputName = args(1)
+
+    val sparkConf =
+      new SparkConf()
+      .setAppName("jsonl")
+      .setMaster("local[*]")
+
+    val spark = SparkSession.builder().config(sparkConf).getOrCreate()
+    import spark.implicits._
+    val sc = spark.sparkContext
+
+    val enrichedRows =
+      spark.read
+      .format("com.databricks.spark.avro")
+      .load(inputName)
+
+
+    val indexRecords: Dataset[String] = enrichedRows.map(
+      row => {
+        val record = ModelConverter.toModel(row)
+        jsonlRecord(record)
+      }
+    )
+
+    indexRecords.coalesce(1).write.text(outputName)
+
+    sc.stop()
+
+  }
+
+}

--- a/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
+++ b/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
@@ -56,6 +56,21 @@ object EnrichedRecordFixture {
           end = Some("1939-12-31")
         )
       ),
+      place = Seq(
+        DplaPlace(
+          name = Some("Somerville, MA, United States"),
+          city = Some("Somerville"),
+          county = Some("Middlesex County"),
+          country = Some("United States"),
+          coordinates = Some("42.3876,-71.0995")
+        ),
+        DplaPlace(
+          name = Some("California"),
+          country = Some("United States")
+          // Unspecified fields verify serialization of places without optional
+          // fields.
+        )
+      ),
       title = Seq("The Title"),
       `type` = Seq("image", "text")
     ),
@@ -69,6 +84,7 @@ object EnrichedRecordFixture {
       uri = new URI("https://example.org/record/123"),
       originalRecord = "The Original Record",
       provider = EdmAgent(
+        uri = Some(new URI("http://dp.la/api/contributor/thedataprovider")),
         name = Some("The Provider")
       ),
       hasView = Seq(EdmWebResource(uri = new URI("https://example.org/"))),
@@ -101,7 +117,8 @@ object EnrichedRecordFixture {
       uri = new URI(""),
       originalRecord = "The Original Record",
       provider = EdmAgent(
-        name = Some("The Provider")
+        name = Some("The Provider"),
+        uri = Some(new URI("http://dp.la/api/contributor/thedataprovider"))
       ),
       hasView = Seq(EdmWebResource(uri = new URI("https://example.org/"))),
       intermediateProvider = Some(

--- a/src/test/scala/dpla/ingestion3/model/JsonlStringTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/JsonlStringTest.scala
@@ -19,14 +19,15 @@ class JsonlStringTest extends FlatSpec {
     val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord)
     val jvalue = parse(s)
     assert(
-      compact(render(jvalue \ "id")) == "\"7738a840caff15224f50cf17eade27e6\""
+      compact(render(jvalue \ "_source" \ "id")) ==
+        "\"7738a840caff15224f50cf17eade27e6\""
     )
   }
 
   it should "render a field that's a sequence" in {
     val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord)
     val jvalue = parse(s)
-    val title = jvalue \ "sourceResource" \ "title"
+    val title = jvalue \ "_source" \ "sourceResource" \ "title"
     assert(title.isInstanceOf[JArray])
     assert(compact(render(title(0))) == "\"The Title\"")
   }
@@ -34,7 +35,7 @@ class JsonlStringTest extends FlatSpec {
   it should "render a field that requires a map() on a sequence" in {
     val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord)
     val jvalue = parse(s)
-    val collection = jvalue \ "sourceResource" \ "collection"
+    val collection = jvalue \ "_source" \ "sourceResource" \ "collection"
     assert(collection.isInstanceOf[JArray])
     assert(
       compact(render(collection(0))) == "{\"title\":\"The Collection\"}"
@@ -46,8 +47,21 @@ class JsonlStringTest extends FlatSpec {
     val s: String = jsonlRecord(EnrichedRecordFixture.minimalEnrichedRecord)
     val jvalue = parse(s)
     assert(
-      compact(render(jvalue \ "sourceResource" \ "collection")) == "[]"
+      compact(render(jvalue \ "_source" \ "sourceResource" \ "collection")) ==
+        "[]"
     )
+  }
+
+  it should "use the same ingestDate across multiple calls" in {
+    val s1: String = ingestDate
+    Thread.sleep(100)
+    val s2: String = ingestDate
+    assert(s1 == s2)
+  }
+
+  "ingestDate" should "return a string in the correct format" in {
+    assert(ingestDate matches
+           """^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$""")
   }
 
 }


### PR DESCRIPTION
Improve our JSONL export feature by correcting the format of the output so that it loads into our Ingestion 1 Elasticsearch index, which is for Elasticsearch 0.90 and uses the DPLA MAPv3.1 schema.

* Correct the JSON format (ES wants fields `_source` and `_id`, for example).
* Correct `provider` by writing it as an object with the necessary properties
* Add methods `ingestDate` and `providerToken` to help fill in some of the fields
* Add `JsonlEntry` driver

The indentation of `jsonlRecord` had to change as the result of putting the record inside of `_source` for Elasticsearch, so the diff shows more lines changed than the ones that are actually relevant.

This needs to be squashed before it's merged. I'll handle that when the time's right.
