### PR TITLE
Refactor around making OreAggregation the top level entity

### DIFF
--- a/src/main/resources/avro/MAPRecord.avsc
+++ b/src/main/resources/avro/MAPRecord.avsc
@@ -8,10 +8,14 @@
 // pulled from the MAPv3.1 document.
 {
   "namespace": "dpla.avro.v1.MAP4_x",
-  "type": "record",
-  "name": "MAPRecord",
   "doc": "",
+  "name": "OreAggregation",
+  "type": "record",
   "fields": [
+    {
+      "name": "dplaUri",
+      "type": "string"
+    },
     {
       "name": "SourceResource",
       "type": {
@@ -400,8 +404,8 @@
                   {
                     "name": "region",
                     "type": [
-                        "null",
-                        "string"
+                      "null",
+                      "string"
                     ]
                   },
                   {
@@ -543,7 +547,7 @@
             "type": {
               "name": "RightsHolderEdmAgentArray",
               "type": "array",
-              "items" : {
+              "items": {
                 "name": "RightsHolderEdmAgent",
                 "type": "record",
                 "fields": [
@@ -664,7 +668,7 @@
             "type": {
               "name": "TemporalEdmTimeSpanArray",
               "type": "array",
-              "items" : {
+              "items": {
                 "name": "TemporalEdmTimeSpan",
                 "type": "record",
                 "fields": [
@@ -720,9 +724,176 @@
       }
     },
     {
-      "name": "EdmWebResource",
+      "name": "dataProvider",
       "type": {
-        "name": "EdmWebResource",
+        "name": "DataProviderEdmAgent",
+        "type": "record",
+        "fields": [
+          {
+            "name": "uri",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "name": "name",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "name": "providedLabel",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "name": "note",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "name": "scheme",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "name": "exactMatch",
+            "type": {
+              "name": "exactMatchArray",
+              "type": "array",
+              "items": "string"
+            }
+          },
+          {
+            "name": "closeMatch",
+            "type": {
+              "name": "closeMatchArray",
+              "type": "array",
+              "items": "string"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "originalRecord",
+      "type": "string"
+    },
+    {
+      "name": "hasView",
+      "type": {
+        "name": "HasViewEdmWebResourceArray",
+        "type": "array",
+        "items": {
+          "name": "HasViewEdmWebResource",
+          "type": "record",
+          "fields": [
+            {
+              "name": "uri",
+              "type": "string"
+            },
+            {
+              "name": "fileFormat",
+              "type": {
+                "name": "fileFormatsArray",
+                "type": "array",
+                "items": "string"
+              }
+            },
+            {
+              "name": "dcRights",
+              "type": {
+                "name": "dcRightsArray",
+                "type": "array",
+                "items": "string"
+              }
+            },
+            {
+              "name": "edmRights",
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "intermediateProvider",
+      "type": [
+        "null",
+        {
+          "name": "IntermediateProviderEdmAgent",
+          "type": "record",
+          "fields": [
+            {
+              "name": "uri",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            {
+              "name": "name",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            {
+              "name": "providedLabel",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            {
+              "name": "note",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            {
+              "name": "scheme",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            {
+              "name": "exactMatch",
+              "type": {
+                "name": "exactMatchArray",
+                "type": "array",
+                "items": "string"
+              }
+            },
+            {
+              "name": "closeMatch",
+              "type": {
+                "name": "closeMatchArray",
+                "type": "array",
+                "items": "string"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "isShownAt",
+      "type": {
+        "name": "IsShownAtEdmWebResource",
         "type": "record",
         "fields": [
           {
@@ -755,324 +926,152 @@
         ]
       }
     },
+
+
     {
-      "name": "OreAggregation",
+      "name": "object",
+      "type": [
+        "null",
+        {
+          "name": "ObjectEdmWebResource",
+          "type": "record",
+          "fields": [
+            {
+              "name": "uri",
+              "type": "string"
+            },
+            {
+              "name": "fileFormat",
+              "type": {
+                "name": "fileFormatsArray",
+                "type": "array",
+                "items": "string"
+              }
+            },
+            {
+              "name": "dcRights",
+              "type": {
+                "name": "dcRightsArray",
+                "type": "array",
+                "items": "string"
+              }
+            },
+            {
+              "name": "edmRights",
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "preview",
+      "type": [
+        "null",
+        {
+          "name": "PreviewEdmWebResource",
+          "type": "record",
+          "fields": [
+            {
+              "name": "uri",
+              "type": "string"
+            },
+            {
+              "name": "fileFormat",
+              "type": {
+                "name": "fileFormatsArray",
+                "type": "array",
+                "items": "string"
+              }
+            },
+            {
+              "name": "dcRights",
+              "type": {
+                "name": "dcRightsArray",
+                "type": "array",
+                "items": "string"
+              }
+            },
+            {
+              "name": "edmRights",
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "provider",
       "type": {
-        "name": "OreAggregation",
+        "name": "ProviderEdmAgent",
         "type": "record",
         "fields": [
           {
             "name": "uri",
-            "type": "string"
-          },
-          {
-            "name": "dataProvider",
-            "type": {
-              "name": "DataProviderEdmAgent",
-              "type": "record",
-              "fields": [
-                {
-                  "name": "uri",
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                },
-                {
-                  "name": "name",
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                },
-                {
-                  "name": "providedLabel",
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                },
-                {
-                  "name": "note",
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                },
-                {
-                  "name": "scheme",
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                },
-                {
-                  "name": "exactMatch",
-                  "type": {
-                    "name": "exactMatchArray",
-                    "type": "array",
-                    "items": "string"
-                  }
-                },
-                {
-                  "name": "closeMatch",
-                  "type": {
-                    "name": "closeMatchArray",
-                    "type": "array",
-                    "items": "string"
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "originalRecord",
-            "type": "string"
-          },
-          {
-            "name": "hasView",
-            "type": {
-              "name": "HasViewEdmWebResourceArray",
-              "type": "array",
-              "items": {
-                "name": "HasViewEdmWebResource",
-                "type": "record",
-                "fields": [
-                  {
-                    "name": "uri",
-                    "type": "string"
-                  },
-                  {
-                    "name": "fileFormat",
-                    "type": {
-                      "name": "fileFormatsArray",
-                      "type": "array",
-                      "items": "string"
-                    }
-                  },
-                  {
-                    "name": "dcRights",
-                    "type": {
-                      "name": "dcRightsArray",
-                      "type": "array",
-                      "items": "string"
-                    }
-                  },
-                  {
-                    "name": "edmRights",
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "name": "intermediateProvider",
-            "type": [
-              "null",
-              {
-                "name": "IntermediateProviderEdmAgent",
-                "type": "record",
-                "fields": [
-                  {
-                    "name": "uri",
-                    "type": ["null", "string"]
-                  },
-                  {
-                    "name": "name",
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  {
-                    "name": "providedLabel",
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  {
-                    "name": "note",
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  {
-                    "name": "scheme",
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  {
-                    "name": "exactMatch",
-                    "type": {
-                      "name": "exactMatchArray",
-                      "type": "array",
-                      "items": "string"
-                    }
-                  },
-                  {
-                    "name": "closeMatch",
-                    "type": {
-                      "name": "closeMatchArray",
-                      "type": "array",
-                      "items": "string"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "object",
-            "type": [ "null", {
-              "name": "ObjectEdmWebResource",
-              "type": "record",
-              "fields": [
-                {
-                  "name": "uri",
-                  "type": "string"
-                },
-                {
-                  "name": "fileFormat",
-                  "type": {
-                    "name": "fileFormatsArray",
-                    "type": "array",
-                    "items": "string"
-                  }
-                },
-                {
-                  "name": "dcRights",
-                  "type": {
-                    "name": "dcRightsArray",
-                    "type": "array",
-                    "items": "string"
-                  }
-                },
-                {
-                  "name": "edmRights",
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                }
-              ]
-            } ]
-          },
-          {
-            "name": "preview",
-            "type": [
-              "null",
-              {
-                "name": "PreviewEdmWebResource",
-                "type": "record",
-                "fields": [
-                  {
-                    "name": "uri",
-                    "type": "string"
-                  },
-                  {
-                    "name": "fileFormat",
-                    "type": {
-                      "name": "fileFormatsArray",
-                      "type": "array",
-                      "items": "string"
-                    }
-                  },
-                  {
-                    "name": "dcRights",
-                    "type": {
-                      "name": "dcRightsArray",
-                      "type": "array",
-                      "items": "string"
-                    }
-                  },
-                  {
-                    "name": "edmRights",
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "provider",
-            "type": {
-              "name": "ProviderEdmAgent",
-              "type": "record",
-              "fields": [
-                {
-                  "name": "uri",
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                },
-                {
-                  "name": "name",
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                },
-                {
-                  "name": "providedLabel",
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                },
-                {
-                  "name": "note",
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                },
-                {
-                  "name": "scheme",
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                },
-                {
-                  "name": "exactMatch",
-                  "type": {
-                    "name": "exactMatchArray",
-                    "type": "array",
-                    "items": "string"
-                  }
-                },
-                {
-                  "name": "closeMatch",
-                  "type": {
-                    "name": "closeMatchArray",
-                    "type": "array",
-                    "items": "string"
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "edmRights",
             "type": [
               "null",
               "string"
             ]
+          },
+          {
+            "name": "name",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "name": "providedLabel",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "name": "note",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "name": "scheme",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "name": "exactMatch",
+            "type": {
+              "name": "exactMatchArray",
+              "type": "array",
+              "items": "string"
+            }
+          },
+          {
+            "name": "closeMatch",
+            "type": {
+              "name": "closeMatchArray",
+              "type": "array",
+              "items": "string"
+            }
           }
         ]
       }
+    },
+    {
+      "name": "edmRights",
+      "type": [
+        "null",
+        "string"
+      ]
     }
   ]
 }

--- a/src/main/scala/dpla/ingestion3/EnrichEntry.scala
+++ b/src/main/scala/dpla/ingestion3/EnrichEntry.scala
@@ -48,8 +48,6 @@ object EnrichEntry {
       .setAppName("Enrichment")
       .setMaster(i3Conf.spark.sparkMaster.getOrElse("local[*]"))
 
-    implicit val dplaMapDataEncoder = org.apache.spark.sql.Encoders.kryo[DplaMapData]
-
     val spark = SparkSession.builder()
       .config(sparkConf)
       .getOrCreate()
@@ -79,7 +77,6 @@ object EnrichEntry {
     enrichedRows.toDF().write
       .format("com.databricks.spark.avro")
       .save(outputDir)
-
 
     // Gather some stats
     val mappedRecordCount = mappedRows.count()

--- a/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
@@ -30,9 +30,9 @@ class EnrichmentDriver(conf: i3Conf) extends Serializable {
     * @param record The mapped record
     * @return An enriched record
     */
-  def enrich(record: DplaMapData): DplaMapData = {
+  def enrich(record: OreAggregation): OreAggregation = {
     record.copy(
-      record.sourceResource.copy(
+      sourceResource = record.sourceResource.copy(
         date = record.sourceResource.date.map(d => dateEnrichment.parse(d)),
         language = record.sourceResource.language.map(l => LanguageMapper.mapLanguage(l)),
         place = record.sourceResource.place.map(p => spatialEnrichment.enrich(p))

--- a/src/main/scala/dpla/ingestion3/mappers/providers/Extractor.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/Extractor.scala
@@ -2,7 +2,7 @@ package dpla.ingestion3.mappers.providers
 
 import java.net.URI
 
-import dpla.ingestion3.model.{DplaMapData, EdmAgent}
+import dpla.ingestion3.model.{DplaMapData, EdmAgent, OreAggregation}
 import dpla.ingestion3.utils.Utils
 
 import scala.util.{Failure, Success, Try}
@@ -15,7 +15,7 @@ trait Extractor {
   // Base item uri
   private val baseItemUri = "http://dp.la/api/items/"
 
-  def build(): Try[DplaMapData]
+  def build(): Try[OreAggregation]
   def agent: EdmAgent
   /**
     * Build the base ID to be hashed. Implemented per provider

--- a/src/main/scala/dpla/ingestion3/mappers/providers/WiExtractor.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/WiExtractor.scala
@@ -13,28 +13,15 @@ class WiExtractor(rawData: String) extends Extractor with XmlExtractionUtils {
 
   implicit val xml: NodeSeq = XML.loadString(rawData)
 
-  def agent = EdmAgent(
-    name = Some("Recollection Wisconsin"),
-    uri = Some(new URI("http://dp.la/api/contributor/wisconsin"))
-  )
-
-  def dataProvider(): ExactlyOne[EdmAgent] = {
-    extractString(xml \ "metadata" \\ "dataProvider") match {
-      case Some(provider) => nameOnlyAgent(provider)
-      case None => throw new Exception("Missing required property dataProvider")
-    }
-  }
-  // Get the second occurrence of the dc:identifier property
-  def itemUri(): ExactlyOne[URI] = {
-    extractString(xml \ "metadata" \\ "isShownAt") match {
-      case Some(uri) => new URI(uri)
-      case None => throw new Exception("Missing required property isShownAt")
-    }
-  }
-
-  def build(): Try[DplaMapData] = Try {
-    DplaMapData(
-      DplaSourceResource(
+  def build(): Try[OreAggregation] = Try {
+    OreAggregation(
+      dplaUri = mintDplaItemUri(),
+      dataProvider = dataProvider(),
+      originalRecord = rawData,
+      provider = agent,
+      preview = extractString(xml \ "metadata" \\ "preview").map(x => uriOnlyWebResource(new URI(x))),
+      isShownAt = uriOnlyWebResource(itemUri),
+      sourceResource = DplaSourceResource(
         alternateTitle = extractStrings(xml \ "metadata" \\ "alternative"),
         // This method of using NodeSeq is required because of namespace issues.
         collection = extractStrings(xml \ "metadata" \\ "isPartOf").headOption.map(nameOnlyCollection).toSeq,
@@ -43,7 +30,7 @@ class WiExtractor(rawData: String) extends Extractor with XmlExtractionUtils {
         date = extractStrings(xml \ "metadata" \\ "date").map(stringOnlyTimeSpan),
         description = extractStrings(xml \ "metadata" \\ "description"),
         format = extractStrings(xml \ "metadata" \\ "format").filterNot(isDcmiType) ++
-          extractStrings(xml \ "metadata" \\ "medium").filterNot(isDcmiType) ,
+          extractStrings(xml \ "metadata" \\ "medium").filterNot(isDcmiType),
         identifier = extractStrings(xml \ "metadata" \\ "identifier"),
         language = extractStrings(xml \ "metadata" \\ "language").map(nameOnlyConcept),
         place = extractStrings(xml \ "metadata" \\ "spatial").map(nameOnlyPlace),
@@ -55,20 +42,28 @@ class WiExtractor(rawData: String) extends Extractor with XmlExtractionUtils {
         subject = extractStrings(xml \ "metadata" \\ "subject").map(nameOnlyConcept),
         title = extractStrings(xml \ "metadata" \\ "title"),
         `type` = extractStrings(xml \ "metadata" \\ "type").filter(isDcmiType)
-      ),
-
-      EdmWebResource(
-        uri = itemUri
-      ),
-
-      OreAggregation(
-        uri = mintDplaItemUri(),
-        dataProvider = dataProvider(),
-        originalRecord = rawData,
-        provider = agent,
-        preview = extractString(xml \ "metadata" \\ "preview").map(x => uriOnlyWebResource(new URI(x)))
       )
     )
+  }
+
+  def agent = EdmAgent(
+    name = Some("Recollection Wisconsin"),
+    uri = Some(new URI("http://dp.la/api/contributor/wisconsin"))
+  )
+
+  def dataProvider(): ExactlyOne[EdmAgent] = {
+    extractString(xml \ "metadata" \\ "dataProvider") match {
+      case Some(provider) => nameOnlyAgent(provider)
+      case None => throw new Exception("Missing required property dataProvider")
+    }
+  }
+
+  // Get the second occurrence of the dc:identifier property
+  def itemUri(): ExactlyOne[URI] = {
+    extractString(xml \ "metadata" \\ "isShownAt") match {
+      case Some(uri) => new URI(uri)
+      case None => throw new Exception("Missing required property isShownAt")
+    }
   }
 
   override def getProviderBaseId(): Option[String] = extractString(xml \ "header" \ "identifier")

--- a/src/main/scala/dpla/ingestion3/mappers/rdf/DplaRdfMapper.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/rdf/DplaRdfMapper.scala
@@ -9,14 +9,13 @@ import org.eclipse.rdf4j.model.{Model, Resource}
   * @param doc DPLA MAP Record to express as RDF
   */
 
-class DplaRdfMapper(doc: DplaMapData) extends RdfBuilderUtils {
+class DplaRdfMapper(doc: OreAggregation) extends RdfBuilderUtils {
 
   def map(): Model = {
     assert(true) //todo assertions
     registerNamespaces(defaultVocabularies)
     mapSourceResource()
     mapOreAggregation()
-    mapItemEdmWebResource()
     build()
   }
 
@@ -24,7 +23,7 @@ class DplaRdfMapper(doc: DplaMapData) extends RdfBuilderUtils {
 
   def mapSourceResource(): Unit = {
     val sourceResource = doc.sourceResource
-    createResource(doc.oreAggregation.uri.resolve("#sourceResource"))
+    createResource(doc.dplaUri.resolve("#sourceResource"))
     setType(dpla.SourceResource)
     map(dc.date, sourceResource.date.map(edmTimespan))
     map(dcTerms.title, sourceResource.title)
@@ -37,18 +36,14 @@ class DplaRdfMapper(doc: DplaMapData) extends RdfBuilderUtils {
     map(dcTerms.`type`, sourceResource.`type`)
   }
 
-  def mapItemEdmWebResource(): Unit =
-    edmWebResource(doc.edmWebResource)
-
-
   def mapOreAggregation(): Unit = {
-    val oreAggregation = doc.oreAggregation
-    createResource(oreAggregation.uri)
+    val oreAggregation = doc
+    createResource(oreAggregation.dplaUri)
     setType(ore.Aggregation)
     //links the SourceResource in the record to the Aggregation
-    map(edm.aggregatedCHO, iri(oreAggregation.uri.toString + "#sourceResource"))
+    map(edm.aggregatedCHO, iri(oreAggregation.dplaUri.toString + "#sourceResource"))
     //links the top level edm:WebResource to the Aggregation
-    map(edm.isShownAt, iri(doc.edmWebResource.uri))
+    map(edm.isShownAt, iri(doc.isShownAt.uri))
     map(edm.provider, edmAgent(oreAggregation.provider))
     map(dpla.originalRecord, oreAggregation.originalRecord) //TODO what to do with ORs
     map(edm.dataProvider, edmAgent(oreAggregation.dataProvider))

--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -59,37 +59,37 @@ package object model {
     }
   }
 
-  def jsonlRecord(record: DplaMapData): String = {
-    val recordID: String = generateMd5(Some(record.oreAggregation.uri.toString))
+  def jsonlRecord(record: OreAggregation): String = {
+    val recordID: String = generateMd5(Some(record.dplaUri.toString)) //todo this is almost definitely wrong
     val jobj: JObject =
       ("_type" -> "item") ~
       // For _id, we should have a provider token like "nara" or "ia"
       ("_id" ->
-        (s"${providerToken(record.oreAggregation.provider.uri)}--" +
-         s"${record.oreAggregation.uri.toString}")) ~
+        (s"${providerToken(record.provider.uri)}--" +
+         s"${record.isShownAt.toString}")) ~
       ("_source" ->
         ("id" -> recordID) ~
         ("_id" ->
-          (s"${providerToken(record.oreAggregation.provider.uri)}--" +
-           s"${record.oreAggregation.uri.toString}")) ~
+          (s"${providerToken(record.provider.uri)}--" +
+           s"${record.dplaUri.toString}")) ~ //todo this is almost definitely wrong
         ("@context" -> "http://dp.la/api/items/context") ~
         ("@id" -> ("http://dp.la/api/items/" + recordID)) ~
         ("admin" ->
           ("sourceResource" -> ("title" -> record.sourceResource.title))) ~
         ("aggregatedCHO" -> "#sourceResource") ~
-        ("dataProvider" -> record.oreAggregation.dataProvider.name) ~
+        ("dataProvider" -> record.dataProvider.name) ~
         ("ingestDate" -> ingestDate) ~
         ("ingestType" -> "item") ~
-        ("isShownAt" -> record.edmWebResource.uri.toString) ~
-        ("object" -> record.oreAggregation.`object`.map{o => o.uri.toString}) ~
+        ("isShownAt" -> record.isShownAt.toString) ~
+        ("object" -> record.`object`.map{o => o.uri.toString}) ~
         ("originalRecord" ->
-          ("stringValue" -> record.oreAggregation.originalRecord )) ~
+          ("stringValue" -> record.originalRecord )) ~
         ("provider" ->
-          ("@id" -> record.oreAggregation.provider.uri
+          ("@id" -> record.provider.uri
                       .getOrElse(
                         throw new RuntimeException("Invalid Provider URI")
                       ).toString) ~
-          ("name" -> record.oreAggregation.provider.name)) ~
+          ("name" -> record.provider.name)) ~
         ("sourceResource" ->
           ("@id" ->
             ("http://dp.la/api/items/" + recordID + "#SourceResource")) ~

--- a/src/main/scala/dpla/ingestion3/reports/MetadataCompletenessReport.scala
+++ b/src/main/scala/dpla/ingestion3/reports/MetadataCompletenessReport.scala
@@ -32,7 +32,7 @@ class MetadataCompletenessReport(
     * @param spark  The Spark session, which contains encoding / parsing info.
     * @return       DataFrame, typically of Row[value: String, count: Int]
     */
-  override def process(ds: Dataset[DplaMapData], spark: SparkSession): DataFrame = {
+  override def process(ds: Dataset[OreAggregation], spark: SparkSession): DataFrame = {
 
     val sqlContext = spark.sqlContext
 
@@ -85,7 +85,7 @@ class MetadataCompletenessReport(
   /**
     * Map a Dataset of DplaMapData to a Dataset of CompletenessTally.
     */
-  private def getItemTallies(ds: Dataset[DplaMapData], spark: SparkSession):
+  private def getItemTallies(ds: Dataset[OreAggregation], spark: SparkSession):
     Dataset[CompletenessTally] = {
 
     import spark.implicits._
@@ -109,13 +109,13 @@ class MetadataCompletenessReport(
         extent = tally(dplaMapData.sourceResource.extent),
         format = tally(dplaMapData.sourceResource.format),
         relation = tally(dplaMapData.sourceResource.relation),
-        id = tally(Seq(dplaMapData.oreAggregation.uri)),
-        dataProvider = tally(Seq(dplaMapData.oreAggregation.dataProvider)),
-        provider = tally(Seq(dplaMapData.oreAggregation.provider)),
-        preview = tally(Seq(dplaMapData.oreAggregation.preview)),
+        id = tally(Seq(dplaMapData.dplaUri)),
+        dataProvider = tally(Seq(dplaMapData.dataProvider)),
+        provider = tally(Seq(dplaMapData.provider)),
+        preview = tally(Seq(dplaMapData.preview)),
         rights = {
           val sourceResourceRights = dplaMapData.sourceResource.rights
-          val edmRights = dplaMapData.oreAggregation.edmRights
+          val edmRights = dplaMapData.edmRights
           if (sourceResourceRights.nonEmpty || edmRights.nonEmpty) 1 else 0
         },
         // add isShownAt value once it has been added to DplaMapData

--- a/src/main/scala/dpla/ingestion3/reports/PropertyDistinctValueReport.scala
+++ b/src/main/scala/dpla/ingestion3/reports/PropertyDistinctValueReport.scala
@@ -68,7 +68,7 @@ class PropertyDistinctValueReport(
     * @param spark  The Spark session, which contains encoding / parsing info.
     * @return       DataFrame, typically of Row[value: String, count: Int]
     */
-  override def process(ds: Dataset[DplaMapData],
+  override def process(ds: Dataset[OreAggregation],
                        spark: SparkSession
                       ): DataFrame = {
 

--- a/src/main/scala/dpla/ingestion3/reports/PropertyValueReport.scala
+++ b/src/main/scala/dpla/ingestion3/reports/PropertyValueReport.scala
@@ -46,7 +46,7 @@ class PropertyValueReport (
     * @param spark The Spark session, which contains encoding / parsing info.
     * @return DataFrame, typically of Row[value: String, count: Int]
     */
-  override def process(ds: Dataset[DplaMapData], spark: SparkSession): DataFrame = {
+  override def process(ds: Dataset[OreAggregation], spark: SparkSession): DataFrame = {
     import spark.implicits._
 
     val token: String = getParams match {
@@ -55,199 +55,199 @@ class PropertyValueReport (
     }
 
     implicit val dplaMapDataEncoder =
-      org.apache.spark.sql.Encoders.kryo[DplaMapData]
+      org.apache.spark.sql.Encoders.kryo[OreAggregation]
 
     val rptDataset: Dataset[PropertyValueRpt] = token match {
       case "sourceResource.alternateTitle" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.alternateTitle)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.alternateTitle)
           )
         })
       case "sourceResource.contributor.name" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.contributor)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.contributor)
           )
         })
       case "sourceResource.collection.title" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.collection)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.collection)
           )
         })
       case "sourceResource.creator.name" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.creator)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.creator)
           )
         })
       case "sourceResource.date.originalSourceDate" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.date)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.date)
           )
         })
       case "sourceResource.description" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.description)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.description)
           )
         })
       case "sourceResource.extent" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.extent)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.extent)
           )
         })
       case "sourceResource.format" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.format)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.format)
           )
         })
       case "sourceResource.genre" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.genre)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.genre)
           )
         })
       case "sourceResource.identifier" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.identifier)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.identifier)
           )
         })
       case "sourceResource.language.providedLabel" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.language)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.language)
           )
         })
       case "sourceResource.place.name" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.place)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.place)
           )
         })
       case "sourceResource.place.name" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.place)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.place)
           )
         })
       case "sourceResource.publisher.name" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.publisher)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.publisher)
           )
         })
       case "sourceResource.relation" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.relation)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.relation)
           )
         })
       case "sourceResource.replacedBy" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.replacedBy)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.replacedBy)
           )
         })
       case "sourceResource.replacedBy" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.replacedBy)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.replacedBy)
           )
         })
       case "sourceResource.replaces" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.replaces)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.replaces)
           )
         })
       case "sourceResource.rights" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.rights)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.rights)
           )
         })
       case "sourceResource.rightsHolder.name" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.rightsHolder)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.rightsHolder)
           )
         })
       case "sourceResource.subject.providedLabel" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.subject)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.subject)
           )
         })
       case "sourceResource.temporal.originalSourceDate" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.temporal)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.temporal)
           )
         })
       case "sourceResource.title" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.title)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.title)
           )
         })
       case "sourceResource.type" =>
-        ds.map(dplaMapData => {
+        ds.map(oreAggregation => {
           PropertyValueRpt(
-            dplaUri = dplaMapData.edmWebResource.uri.toString,
-            localUri = dplaMapData.oreAggregation.uri.toString,
-            value = extractValue(dplaMapData.sourceResource.`type`)
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.toString,
+            value = extractValue(oreAggregation.sourceResource.`type`)
           )
         })
       case x =>

--- a/src/main/scala/dpla/ingestion3/reports/Report.scala
+++ b/src/main/scala/dpla/ingestion3/reports/Report.scala
@@ -55,13 +55,13 @@ trait Report {
       "spark.serializer", "org.apache.spark.serializer.KryoSerializer"
     )
     implicit val dplaMapDataEncoder =
-      org.apache.spark.sql.Encoders.kryo[DplaMapData]
+      org.apache.spark.sql.Encoders.kryo[OreAggregation]
     val spark: SparkSession =
       SparkSession.builder().config(sparkConf).getOrCreate()
     val sc = spark.sparkContext
 
-    val input: Dataset[DplaMapData] =
-      spark.read.avro(getInputURI).as[DplaMapData]
+    val input: Dataset[OreAggregation] =
+      spark.read.avro(getInputURI).as[OreAggregation]
     val output: DataFrame = process(input, spark)
 
     Utils.deleteRecursively(new File(getOutputURI))
@@ -87,7 +87,7 @@ trait Report {
     * @param spark  The Spark session, which contains encoding / parsing info.
     * @return       DataFrame, typically of Row[value: String, count: Int]
     */
-  def process(ds: Dataset[DplaMapData], spark: SparkSession): DataFrame
+  def process(ds: Dataset[OreAggregation], spark: SparkSession): DataFrame
 
   /**
     * Accepts Seq[Any] and tries to extract the String values which

--- a/src/main/scala/dpla/ingestion3/reports/ThumbnailReport.scala
+++ b/src/main/scala/dpla/ingestion3/reports/ThumbnailReport.scala
@@ -1,8 +1,9 @@
 package dpla.ingestion3.reports
 
-import dpla.ingestion3.model.DplaMapData
+import dpla.ingestion3.model.{DplaMapData, OreAggregation}
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
-import scala.util.{Try, Failure, Success}
+
+import scala.util.{Failure, Success, Try}
 import javax.imageio.ImageIO
 import java.net.URI
 
@@ -62,11 +63,11 @@ class ThumbnailReport (
     * @param spark The Spark session, which contains encoding / parsing info.
     * @return DataFrame, typically of Row[value: String, count: Int]
     */
-  override def process(ds: Dataset[DplaMapData], spark: SparkSession): DataFrame = {
+  override def process(ds: Dataset[OreAggregation], spark: SparkSession): DataFrame = {
 
 
     implicit val dplaMapDataEncoder =
-      org.apache.spark.sql.Encoders.kryo[DplaMapData]
+      org.apache.spark.sql.Encoders.kryo[OreAggregation]
 
     val token: String = getParams match {
       case Some(p) => p.headOption.getOrElse("")
@@ -85,7 +86,7 @@ class ThumbnailReport (
     * Get images with missing thumbnails.
     * Images are items where sourceResource.`type` = image
     */
-  def missingReport(ds: Dataset[DplaMapData], spark: SparkSession): DataFrame = {
+  def missingReport(ds: Dataset[OreAggregation], spark: SparkSession): DataFrame = {
     import spark.implicits._
 
     val thumbnailData: Dataset[MissingThumbnail] = ds.map(dplaMapData => {
@@ -113,7 +114,7 @@ class ThumbnailReport (
     * request the thumbnail endpoint.
     * Warning: This process takes a long time to run.
     */
-  def dimensionsReport(ds: Dataset[DplaMapData], spark: SparkSession): DataFrame = {
+  def dimensionsReport(ds: Dataset[OreAggregation], spark: SparkSession): DataFrame = {
     import spark.implicits._
 
     val thumbnailData: Dataset[ThumbnailDimensions] = ds.map(dplaMapData => {
@@ -137,25 +138,25 @@ class ThumbnailReport (
   }
 
   /**
-    * @param dplaMapData
+    * @param oreAggregation
     * @return String, the DPLA URI for an item
     */
-  def localUri(dplaMapData: DplaMapData): String =
-    dplaMapData.edmWebResource.uri.toString
+  def localUri(oreAggregation: OreAggregation): String =
+    oreAggregation.dplaUri.toString
 
   /**
-    * @param dplaMapData
+    * @param oreAggregation
     * @return String, the provider URI for an item
     */
-  def dplaUri(dplaMapData: DplaMapData): String =
-    dplaMapData.oreAggregation.uri.toString
+  def dplaUri(oreAggregation: OreAggregation): String =
+    oreAggregation.isShownAt.toString
 
   /**
     * @param dplaMapData
     * @return Option[URI], the thumbnail URI
     */
-  def previewUri(dplaMapData: DplaMapData): Option[URI] =
-    dplaMapData.oreAggregation.preview.map(_.uri)
+  def previewUri(oreAggregation: OreAggregation): Option[URI] =
+    oreAggregation.preview.map(_.uri)
 
   /**
     * Parse the height and width from the thumbnail image.

--- a/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
+++ b/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
@@ -6,82 +6,12 @@ import dpla.ingestion3.model._
 
 object EnrichedRecordFixture {
 
-  val enrichedRecord = DplaMapData(
-    DplaSourceResource(
-      collection = Seq(DcmiTypeCollection(
-        title = Some("The Collection"),
-        description = Some("The Archives of Some Department, U. of X")
-      )),
-      contributor = Seq(EdmAgent(
-        name = Some("J Doe")
-      )),
-      creator = Seq(EdmAgent(
-        name = Some("J Doe")
-      )),
-      date = Seq(EdmTimeSpan(
-        originalSourceDate=Some("5.7.2012"),
-        prefLabel = Some("2012-05-07"),
-        begin = Some("2012-05-07"),
-        end = Some("2012-05-07")
-      )),
-      description = Seq("The description"),
-      extent = Seq("200 pp.", "8 x 10 in."),
-      format = Seq("handwritten letter", "gelatin silver print"),
-      identifier = Seq("us-history-13243", "j-doe-archives-2343"),
-      language = Seq(SkosConcept(
-        providedLabel = Some("English"),
-        concept = Some("eng"),
-        note = None,
-        scheme = None,
-        exactMatch= Seq(),
-        closeMatch = Seq())
-      ),
-      publisher = Seq(EdmAgent(
-        name = Some("The Publisher")
-      )),
-      relation = Seq("x", "https://example.org/x").map(eitherStringOrUri),
-      rights = Seq("Public Domain"),
-      subject = Seq(SkosConcept(
-        providedLabel = Some("Birds")
-      )),
-      temporal = Seq(
-        EdmTimeSpan(
-          originalSourceDate = Some("1920s"),
-          begin = Some("1920-01-01"),
-          end = Some("1929-12-31")
-        ),
-        EdmTimeSpan(
-          originalSourceDate = Some("1930s"),
-          begin = Some("1930-01-01"),
-          end = Some("1939-12-31")
-        )
-      ),
-      place = Seq(
-        DplaPlace(
-          name = Some("Somerville, MA, United States"),
-          city = Some("Somerville"),
-          county = Some("Middlesex County"),
-          country = Some("United States"),
-          coordinates = Some("42.3876,-71.0995")
-        ),
-        DplaPlace(
-          name = Some("California"),
-          country = Some("United States")
-          // Unspecified fields verify serialization of places without optional
-          // fields.
-        )
-      ),
-      title = Seq("The Title"),
-      `type` = Seq("image", "text")
-    ),
-    EdmWebResource(
-      uri = new URI("https://example.org/record/123")
-    ),
+  val enrichedRecord =
     OreAggregation(
       dataProvider = EdmAgent(
         name = Some("The Data Provider")
       ),
-      uri = new URI("https://example.org/record/123"),
+      dplaUri = new URI("https://dp.la/item/123"),
       originalRecord = "The Original Record",
       provider = EdmAgent(
         uri = Some(new URI("http://dp.la/api/contributor/thedataprovider")),
@@ -97,24 +27,76 @@ object EnrichedRecordFixture {
       preview = Some(
         EdmWebResource(uri = new URI("https://example.org/thumbnail/123.jpg"))
       ),
-      edmRights = Some(new URI("https://example.org/rights/public_domain.html"))
+      edmRights = Some(new URI("https://example.org/rights/public_domain.html")),
+      isShownAt = EdmWebResource(
+        uri = new URI("https://example.org/record/123")
+      ),
+      sourceResource = DplaSourceResource(
+        collection = Seq(DcmiTypeCollection(
+          title = Some("The Collection"),
+          description = Some("The Archives of Some Department, U. of X")
+        )),
+        contributor = Seq(EdmAgent(
+          name = Some("J Doe")
+        )),
+        creator = Seq(EdmAgent(
+          name = Some("J Doe")
+        )),
+        date = Seq(EdmTimeSpan(
+          originalSourceDate = Some("5.7.2012"),
+          prefLabel = Some("2012-05-07"),
+          begin = Some("2012-05-07"),
+          end = Some("2012-05-07")
+        )),
+        description = Seq("The description"),
+        extent = Seq("200 pp.", "8 x 10 in."),
+        format = Seq("handwritten letter", "gelatin silver print"),
+        identifier = Seq("us-history-13243", "j-doe-archives-2343"),
+        language = Seq(SkosConcept(
+          providedLabel = Some("English"),
+          concept = Some("eng"),
+          note = None,
+          scheme = None,
+          exactMatch = Seq(),
+          closeMatch = Seq())
+        ),
+        publisher = Seq(EdmAgent(
+          name = Some("The Publisher")
+        )),
+        relation = Seq("x", "https://example.org/x").map(eitherStringOrUri),
+        rights = Seq("Public Domain"),
+        subject = Seq(SkosConcept(
+          providedLabel = Some("Birds")
+        )),
+        temporal = Seq(
+          EdmTimeSpan(
+            originalSourceDate = Some("1920s"),
+            begin = Some("1920-01-01"),
+            end = Some("1929-12-31")
+          ),
+          EdmTimeSpan(
+            originalSourceDate = Some("1930s"),
+            begin = Some("1930-01-01"),
+            end = Some("1939-12-31")
+          )
+        ),
+        title = Seq("The Title"),
+        `type` = Seq("image", "text")
+      )
     )
-  )
 
-  val minimalEnrichedRecord = DplaMapData(
-    DplaSourceResource(
-      rights = Seq("Public Domain"),
-      title = Seq("The Title"),
-      `type` = Seq("image", "text")
-    ),
-    EdmWebResource(
-      uri = new URI("https://example.org/record/123")
-    ),
+  val minimalEnrichedRecord =
     OreAggregation(
+      sourceResource = DplaSourceResource(
+        rights = Seq("Public Domain"),
+        title = Seq("The Title"),
+        `type` = Seq("image", "text")
+      ),
       dataProvider = EdmAgent(
         name = Some("The Data Provider")
       ),
-      uri = new URI(""),
+      dplaUri = new URI("https://dp.la/item/123"),
+      isShownAt = EdmWebResource(uri = new URI("https://example.org/record/123")),
       originalRecord = "The Original Record",
       provider = EdmAgent(
         name = Some("The Provider"),
@@ -132,6 +114,4 @@ object EnrichedRecordFixture {
       ),
       edmRights = Some(new URI("https://example.org/rights/public_domain.html"))
     )
-  )
-
 }

--- a/src/test/scala/dpla/ingestion3/data/MappedRecordsFixture.scala
+++ b/src/test/scala/dpla/ingestion3/data/MappedRecordsFixture.scala
@@ -5,10 +5,18 @@ import java.net.URI
 import dpla.ingestion3.model._
 
 object MappedRecordsFixture {
-  val mappedRecord = DplaMapData(
-    new DplaSourceResource(
+
+  val mappedRecord = OreAggregation(
+    dataProvider = EdmAgent(
+      uri = Some(new URI("http://example.com"))
+    ),
+    dplaUri = new URI(""), //uri of the record on our site
+    originalRecord = "", //map v4 specifies this as a ref, but that's LDP maybe?
+    provider = EdmAgent(),
+    isShownAt = EdmWebResource(uri = new URI("http:/example.com/foo")),
+    sourceResource = DplaSourceResource(
       date = Seq(EdmTimeSpan(
-        originalSourceDate=Some("5.7.2012"),
+        originalSourceDate = Some("5.7.2012"),
         prefLabel = None,
         begin = None,
         end = None
@@ -17,18 +25,9 @@ object MappedRecordsFixture {
         providedLabel = Some("eng"),
         note = None,
         scheme = None,
-        exactMatch= Seq(),
+        exactMatch = Seq(),
         closeMatch = Seq())
       )
-    ),
-    EdmWebResource(
-      uri = new URI("")
-    ),
-    new OreAggregation(
-      dataProvider = new EdmAgent(),
-      uri = new URI(""), //uri of the record on our site
-      originalRecord = "", //map v4 specifies this as a ref, but that's LDP maybe?
-      provider = new EdmAgent()
     )
   )
 }

--- a/src/test/scala/dpla/ingestion3/enrichments/EnrichmentDriverTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/EnrichmentDriverTest.scala
@@ -12,10 +12,15 @@ class EnrichmentDriverTest extends FlatSpec with BeforeAndAfter {
 
   val driver = new EnrichmentDriver(i3Conf())
 
-  val mappedRecord = DplaMapData(
-    DplaSourceResource(
+  val mappedRecord = OreAggregation(
+    dataProvider = EdmAgent(),
+    dplaUri = new URI("https://example.org/item/123"), //uri of the record on our site
+    originalRecord = "", //map v4 specifies this as a ref, but that's LDP maybe?
+    provider = EdmAgent(),
+    isShownAt = EdmWebResource(new URI("http://foo.com")),
+    sourceResource = DplaSourceResource(
       date = Seq(EdmTimeSpan(
-        originalSourceDate=Some("4.3.2015"),
+        originalSourceDate = Some("4.3.2015"),
         prefLabel = None,
         begin = None,
         end = None
@@ -24,27 +29,18 @@ class EnrichmentDriverTest extends FlatSpec with BeforeAndAfter {
         providedLabel = Some("eng"),
         note = None,
         scheme = None,
-        exactMatch= Seq(),
+        exactMatch = Seq(),
         closeMatch = Seq())
       )
-    ),
-    EdmWebResource(
-      uri = new URI("")
-    ),
-    OreAggregation(
-      dataProvider = EdmAgent(),
-      uri = new URI("https://example.org/item/123"), //uri of the record on our site
-      originalRecord = "", //map v4 specifies this as a ref, but that's LDP maybe?
-      provider = EdmAgent()
     )
   )
 
   "EnrichmentDriver" should " enrich both language and date" in {
-    val expectedValue = MappedRecordsFixture.mappedRecord.copy(new DplaSourceResource(
+    val expectedValue = MappedRecordsFixture.mappedRecord.copy(sourceResource = DplaSourceResource(
       date = Seq(new EdmTimeSpan(
-          prefLabel = Some("2012-05-07"),
-          originalSourceDate = Some("5.7.2012")
-        )),
+        prefLabel = Some("2012-05-07"),
+        originalSourceDate = Some("5.7.2012")
+      )),
       language = Seq(SkosConcept(
 
         /*

--- a/src/test/scala/dpla/ingestion3/model/JsonlStringTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/JsonlStringTest.scala
@@ -20,7 +20,7 @@ class JsonlStringTest extends FlatSpec {
     val jvalue = parse(s)
     assert(
       compact(render(jvalue \ "_source" \ "id")) ==
-        "\"7738a840caff15224f50cf17eade27e6\""
+        "\"4b1bd605bd1d75ee23baadb0e1f24457\""
     )
   }
 

--- a/src/test/scala/dpla/ingestion3/model/RowConverterTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/RowConverterTest.scala
@@ -78,19 +78,19 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "convert a DcmiTypeCollection" in {
-    val row = RowConverter.dcmiTypeCollection(dcmiTypeCollection)
+    val row = RowConverter.fromDcmiTypeCollection(dcmiTypeCollection)
     assert(row(0) === dcmiTypeCollection.title.orNull)
     assert(row(1) === dcmiTypeCollection.description.orNull)
   }
 
   it should "convert an empty DcmiTypeCollection" in {
-    val row = RowConverter.dcmiTypeCollection(emptyDcmiTypeCollection)
+    val row = RowConverter.fromDcmiTypeCollection(emptyDcmiTypeCollection)
     assert(row(0) === null)
     assert(row(1) === null)
   }
 
   it should "convert an EdmTimeSpan" in {
-    val row = RowConverter.edmTimeSpan(edmTimeSpan)
+    val row = RowConverter.fromEdmTimeSpan(edmTimeSpan)
     assert(row(0) === edmTimeSpan.originalSourceDate.orNull)
     assert(row(1) === edmTimeSpan.prefLabel.orNull)
     assert(row(2) === edmTimeSpan.begin.orNull)
@@ -98,7 +98,7 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "convert an empty EdmTimeSpan" in {
-    val row = RowConverter.edmTimeSpan(emptyEdmTimeSpan)
+    val row = RowConverter.fromEdmTimeSpan(emptyEdmTimeSpan)
     assert(row(0) === null)
     assert(row(1) === null)
     assert(row(2) === null)
@@ -106,7 +106,7 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "convert a SkosConcept" in {
-    val row = RowConverter.skosConcept(skosConcept)
+    val row = RowConverter.fromSkosConcept(skosConcept)
     assert(row(0) === skosConcept.concept.orNull)
     assert(row(1) === skosConcept.providedLabel.orNull)
     assert(row(2) === skosConcept.note.orNull)
@@ -116,7 +116,7 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "convert an empty SkosConcpet" in {
-    val row = RowConverter.skosConcept(emtpySkosConcept)
+    val row = RowConverter.fromSkosConcept(emtpySkosConcept)
     assert(row(0) === null)
     assert(row(1) === null)
     assert(row(2) === null)
@@ -126,7 +126,7 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "convert a DplaPlace" in {
-    val row = RowConverter.dplaPlace(dplaPlace)
+    val row = RowConverter.fromDplaPlace(dplaPlace)
     assert(row(0) === dplaPlace.name.orNull)
     assert(row(1) === dplaPlace.city.orNull)
     assert(row(2) === dplaPlace.county.orNull)
@@ -137,7 +137,7 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "convert an empty DplaPlace" in {
-    val row = RowConverter.dplaPlace(emptyDplaPlace)
+    val row = RowConverter.fromDplaPlace(emptyDplaPlace)
     assert(row(0) === null)
     assert(row(1) === null)
     assert(row(2) === null)
@@ -148,17 +148,17 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "convert a LiteralOrUri" in {
-    val stringRow = RowConverter.literalOrUri(stringLiteralOrUri)
+    val stringRow = RowConverter.fromLiteralOrUri(stringLiteralOrUri)
     assert(stringRow(0) === "String")
     assert(stringRow(1) === false)
 
-    val uriRow = RowConverter.literalOrUri(uriLiteralOrUri)
+    val uriRow = RowConverter.fromLiteralOrUri(uriLiteralOrUri)
     assert(uriRow(0) === uri1.toString)
     assert(uriRow(1) === true)
   }
 
   it should "convert an EdmAgent" in {
-    val row = RowConverter.edmAgent(edmAgent)
+    val row = RowConverter.fromEdmAgent(edmAgent)
     assert(row(0) === edmAgent.uri.map(_.toString).orNull)
     assert(row(1) === edmAgent.name.orNull)
     assert(row(2) === edmAgent.providedLabel.orNull)
@@ -169,7 +169,7 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "convert an empty EdmAgent" in {
-    val row = RowConverter.edmAgent(emptyEdmAgent)
+    val row = RowConverter.fromEdmAgent(emptyEdmAgent)
     assert(row(0) === null)
     assert(row(1) === null)
     assert(row(2) === null)
@@ -180,7 +180,7 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "convert an EdmWebResource" in {
-    val row = RowConverter.edmWebResource(edmWebResource)
+    val row = RowConverter.fromEdmWebResource(edmWebResource)
     assert(row(0) === edmWebResource.uri.toString)
     assert(row(1) === edmWebResource.fileFormat)
     assert(row(2) === edmWebResource.dcRights)
@@ -188,35 +188,53 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "convert an empty EdmWebResource" in {
-    val row = RowConverter.edmWebResource(emptyEdmWebResource)
+    val row = RowConverter.fromEdmWebResource(emptyEdmWebResource)
     assert(row(0) === emptyEdmWebResource.uri.toString)
     assert(row(1) === Seq())
     assert(row(2) === Seq())
     assert(row(3) === null)
   }
 
+  /*
+  dplaUri: ExactlyOne[URI],
+                           sourceResource: ExactlyOne[DplaSourceResource],
+                           dataProvider: ExactlyOne[EdmAgent],
+                           originalRecord: ExactlyOne[String],
+                           hasView: ZeroToMany[EdmWebResource] = Seq(),
+                           intermediateProvider: ZeroToOne[EdmAgent] = None,
+                           isShownAt: ExactlyOne[EdmWebResource],
+                           `object`: ZeroToOne[EdmWebResource] = None, // full size image
+                           preview: ZeroToOne[EdmWebResource] = None, // thumbnail
+                           provider: ExactlyOne[EdmAgent],
+                           edmRights: ZeroToOne[URI] = None
+   */
+
   it should "convert an OreAggregation" in {
     val oreAggregation = OreAggregation(
-      uri = uri3,
+      dplaUri = uri3,
+      sourceResource = DplaSourceResource(),
       dataProvider = edmAgent,
       originalRecord = "I'm very original",
       hasView = Seq(edmWebResource, edmWebResource),
       intermediateProvider = Some(edmAgent),
+      isShownAt = edmWebResource,
       `object` = Some(edmWebResource),
       preview = Some(edmWebResource),
       provider = edmAgent,
       edmRights = Some(uri1)
     )
-    val row = RowConverter.oreAggregation(oreAggregation)
-    assert(row(0) === oreAggregation.uri.toString)
-    assert(row(1) === RowConverter.edmAgent(oreAggregation.dataProvider))
-    assert(row(2) === oreAggregation.originalRecord)
-    assert(row(3) === oreAggregation.hasView.map(RowConverter.edmWebResource))
-    assert(row(4) === oreAggregation.intermediateProvider.map(RowConverter.edmAgent).orNull)
-    assert(row(5) === oreAggregation.`object`.map(RowConverter.edmWebResource).orNull)
-    assert(row(6) === oreAggregation.preview.map(RowConverter.edmWebResource).orNull)
-    assert(row(7) === RowConverter.edmAgent(oreAggregation.provider))
-    assert(row(8) === oreAggregation.edmRights.map(_.toString).orNull)
+    val row = RowConverter.toRow(oreAggregation, sparkSchema)
+    assert(row(0) === oreAggregation.dplaUri.toString)
+    assert(row(1) === RowConverter.fromSourceResource(oreAggregation.sourceResource))
+    assert(row(2) === RowConverter.fromEdmAgent(oreAggregation.dataProvider))
+    assert(row(3) === oreAggregation.originalRecord)
+    assert(row(4) === oreAggregation.hasView.map(RowConverter.fromEdmWebResource))
+    assert(row(5) === oreAggregation.intermediateProvider.map(RowConverter.fromEdmAgent).orNull)
+    assert(row(6) === RowConverter.fromEdmWebResource(oreAggregation.isShownAt))
+    assert(row(7) === oreAggregation.`object`.map(RowConverter.fromEdmWebResource).orNull)
+    assert(row(8) === oreAggregation.preview.map(RowConverter.fromEdmWebResource).orNull)
+    assert(row(9) === RowConverter.fromEdmAgent(oreAggregation.provider))
+    assert(row(10) === oreAggregation.edmRights.map(_.toString).orNull)
   }
 
   it should "convert a SourceResource" in {
@@ -244,27 +262,27 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
       title = Seq("some", "title"),
       `type` = Seq("rock", "magic", "grass")
     )
-    val row = RowConverter.dplaSourceResource(sourceResource)
+    val row = RowConverter.fromSourceResource(sourceResource)
     assert(row(0) === sourceResource.alternateTitle)
-    assert(row(1) === sourceResource.collection.map(RowConverter.dcmiTypeCollection))
-    assert(row(2) === sourceResource.contributor.map(RowConverter.edmAgent))
-    assert(row(3) === sourceResource.creator.map(RowConverter.edmAgent))
-    assert(row(4) === sourceResource.date.map(RowConverter.edmTimeSpan))
+    assert(row(1) === sourceResource.collection.map(RowConverter.fromDcmiTypeCollection))
+    assert(row(2) === sourceResource.contributor.map(RowConverter.fromEdmAgent))
+    assert(row(3) === sourceResource.creator.map(RowConverter.fromEdmAgent))
+    assert(row(4) === sourceResource.date.map(RowConverter.fromEdmTimeSpan))
     assert(row(5) === sourceResource.description)
     assert(row(6) === sourceResource.extent)
     assert(row(7) === sourceResource.format)
-    assert(row(8) === sourceResource.genre.map(RowConverter.skosConcept))
+    assert(row(8) === sourceResource.genre.map(RowConverter.fromSkosConcept))
     assert(row(9) === sourceResource.identifier)
-    assert(row(10) === sourceResource.language.map(RowConverter.skosConcept))
-    assert(row(11) === sourceResource.place.map(RowConverter.dplaPlace))
-    assert(row(12) === sourceResource.publisher.map(RowConverter.edmAgent))
-    assert(row(13) === sourceResource.relation.map(RowConverter.literalOrUri))
+    assert(row(10) === sourceResource.language.map(RowConverter.fromSkosConcept))
+    assert(row(11) === sourceResource.place.map(RowConverter.fromDplaPlace))
+    assert(row(12) === sourceResource.publisher.map(RowConverter.fromEdmAgent))
+    assert(row(13) === sourceResource.relation.map(RowConverter.fromLiteralOrUri))
     assert(row(14) === sourceResource.replacedBy)
     assert(row(15) === sourceResource.replaces)
     assert(row(16) === sourceResource.rights)
-    assert(row(17) === sourceResource.rightsHolder.map(RowConverter.edmAgent))
-    assert(row(18) === sourceResource.subject.map(RowConverter.skosConcept))
-    assert(row(19) === sourceResource.temporal.map(RowConverter.edmTimeSpan))
+    assert(row(17) === sourceResource.rightsHolder.map(RowConverter.fromEdmAgent))
+    assert(row(18) === sourceResource.subject.map(RowConverter.fromSkosConcept))
+    assert(row(19) === sourceResource.temporal.map(RowConverter.fromEdmTimeSpan))
     assert(row(20) === sourceResource.title)
     assert(row(21) === sourceResource.`type`)
 


### PR DESCRIPTION
- Makes OreAggregation the top level entity in the data model. 
- DplaSourceResource is now a child of OreAggregation. 
- The previously top level EdmWebResource is now isShownAt.
- Adds dplaUri field to OreAggregation as the place to store the DPLA URI