### PR TITLE
Initial support for using Amazon S3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,8 @@ lazy val root = (project in file("."))
       "org.scalaj" % "scalaj-http_2.11" % "2.3.0",
       "org.rogach" % "scallop_2.11" % "3.0.3",
       "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0" % "test",
-      "com.typesafe" % "config" % "1.3.1"
+      "com.typesafe" % "config" % "1.3.1",
+      "com.amazonaws" % "aws-java-sdk-s3" % "1.10.6",
+      "org.apache.hadoop" % "hadoop-aws" % "2.8.1"
     )
   )

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 log4j.appender.stdout = org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Threshold = INFO
+log4j.appender.stdout.Threshold = ERROR
 log4j.appender.stdout.Target   = System.out
 log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern = %-5p %d [%t][%F:%L] : %m%n

--- a/src/main/scala/dpla/ingestion3/confs/ConfUtils.scala
+++ b/src/main/scala/dpla/ingestion3/confs/ConfUtils.scala
@@ -1,26 +1,72 @@
 package dpla.ingestion3.confs
 
 import java.net.URL
+
+import com.amazonaws.services.s3.{AmazonS3Client, AmazonS3URI}
+import com.amazonaws.services.s3.model.S3Object
 import com.typesafe.config.Config
-import scala.util.Try
+
+import scala.io.{BufferedSource, Source}
+import scala.util.{Failure, Success, Try}
 
 trait ConfUtils {
 
   /**
+    * TODO: There are multiple "validateUrl" methods floating around
+    * the project. Need to find them all and consolidate.
     *
-    * @param string
-    * @return
+    * @param url
+    * @return Boolean
     */
-  def validateUrl(string: String): Boolean = Try{ new URL(string) }.isSuccess
+  def validateUrl(url: String): Boolean = Try{ url match {
+    case str if str.startsWith("s3") => false
+    case str if str.startsWith("http") => new URL(url)
+    }}.isSuccess
 
   /**
+    * Get the contents of the configuration file
     *
-    * @param filePath
+    * @param path Path to configuration file
+    * @return Contents of file as a String
     */
-  def getConfFileLocation(filePath: String): String = validateUrl(filePath) match {
-    case true => "config.url"
-    case false => "config.file"
+  def getConfigContents(path: String): Option[String] = {
+    path match {
+      case path if path.startsWith("s3") => getS3Conf(path)
+      case path if path.startsWith("http") => throw new UnsupportedOperationException("HTTP not supported yet")
+      case _ => getLocalConf(path)
+    }
   }
+
+  /**
+    * Reads file on S3 and returns contents as Option[String]
+    *
+    * @param path Path to file
+    * @return Contents of file as Option[String]
+    */
+  def getS3Conf(path: String): Option[String] = {
+    val s3Client = new AmazonS3Client()
+    val uri: AmazonS3URI = new AmazonS3URI(path)
+    val s3Object: S3Object = s3Client.getObject(uri.getBucket, uri.getKey)
+    val source: BufferedSource = Source.fromInputStream(s3Object.getObjectContent)
+    // Try-block exists to ensure closure of input stream
+    try
+      Option(source.mkString)
+    finally
+      source.close()
+  }
+
+  /**
+    * Reads contents of file on path
+    *
+    * @param path Path to file
+    * @return Option[String] The contents of the file or None
+    */
+  def getLocalConf(path: String): Option[String] = Try {
+      Source.fromFile(path).getLines.mkString
+    } match {
+      case Success(s) => Some(s)
+      case Failure(_) => None
+    }
 
   /**
     *

--- a/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
+++ b/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
@@ -15,19 +15,17 @@ import org.rogach.scallop.{ScallopConf, ScallopOption}
   */
 class Ingestion3Conf(confFilePath: String, providerName: Option[String] = None) extends ConfUtils {
   def load(): i3Conf = {
-    // Loads config file for more information about loading hierarchy please read
-    // https://github.com/typesafehub/config#standard-behavior
     ConfigFactory.invalidateCaches()
 
     if (confFilePath.isEmpty) throw new IllegalArgumentException("Missing path to conf file")
 
-    System.setProperty(getConfFileLocation(confFilePath), confFilePath)
+    val confString = getConfigContents(confFilePath)
 
-    val baseConfig = ConfigFactory.load
+    val baseConfig = ConfigFactory.parseString(confString.getOrElse(
+      throw new RuntimeException(s"Unable to load configuration file at ${confFilePath}")))
 
     val providerConf = providerName match {
-      case Some(name) => ConfigFactory.load
-        .getConfig(name)
+      case Some(name) => baseConfig.getConfig(name)
         .withFallback(baseConfig)
         .resolve()
       case _ => baseConfig.resolve()


### PR DESCRIPTION
* Refactor Ingestion3Conf to support loading configuration
  file from local filesystem and S3. S3 support requires AWS
  keys to be set ENV props, JAVA props, .aws/credentials or EC2
  metadata (see DefaultAWSCredentialsProviderChain)
* Add support for saving harvester output to AWS S3 for all
  Harvesters by setting AWS S3 access and secret key values within
  SparkContext hadoopConfiguration