### PR TITLE
Fix/id minting inversion

### DIFF
--- a/src/main/scala/dpla/ingestion3/MappingEntry.scala
+++ b/src/main/scala/dpla/ingestion3/MappingEntry.scala
@@ -66,7 +66,7 @@ object MappingEntry {
       case "cdl" => classOf[CdlExtractor]
       case "mdl" => classOf[MdlExtractor]
       case "nara" => classOf[NaraExtractor]
-      case "pa digital" => classOf[PaExtractor]
+      case "pa" => classOf[PaExtractor]
       case "wi" => classOf[WiExtractor]
       case _ =>
         logger.fatal(s"No match found for provider short name ${shortName}")

--- a/src/main/scala/dpla/ingestion3/MappingEntry.scala
+++ b/src/main/scala/dpla/ingestion3/MappingEntry.scala
@@ -75,7 +75,8 @@ object MappingEntry {
 
     // Run the mapping over the Dataframe
     val documents: Dataset[String] = harvestedRecords.select("document").as[String]
-    val mappingResults: Dataset[(Row, String)] = documents.map(document => map(extractorClass, document))(tupleRowStringEncoder)
+    val mappingResults: Dataset[(Row, String)] = documents.map(document =>
+      map(extractorClass, document, shortName))(tupleRowStringEncoder)
 
     // Delete the output location if it exists
     Utils.deleteRecursively(new File(dataOut))
@@ -98,8 +99,8 @@ object MappingEntry {
     spark.stop()
   }
 
-  private def map(extractorClass: Class[_ <: Extractor], document: String): (Row, String) =
-    extractorClass.getConstructor(classOf[String]).newInstance(document).build() match {
+  private def map(extractorClass: Class[_ <: Extractor], document: String, shortName: String): (Row, String) =
+    extractorClass.getConstructor(classOf[String]).newInstance(document, shortName).build() match {
       case Success(dplaMapData) => (RowConverter.toRow(dplaMapData, model.sparkSchema), null)
       case Failure(exception) => (null, exception.getMessage)
     }

--- a/src/main/scala/dpla/ingestion3/mappers/providers/Extractor.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/Extractor.scala
@@ -2,8 +2,8 @@ package dpla.ingestion3.mappers.providers
 
 import java.net.URI
 
-import dpla.ingestion3.model.{DplaMapData, EdmAgent, OreAggregation}
-import dpla.ingestion3.utils.Utils
+import dpla.ingestion3.model.{EdmAgent, OreAggregation}
+import org.apache.commons.codec.digest.DigestUtils
 
 import scala.util.{Failure, Success, Try}
 
@@ -13,29 +13,88 @@ import scala.util.{Failure, Success, Try}
 
 trait Extractor {
   // Base item uri
-  private val baseItemUri = "http://dp.la/api/items/"
+  private val baseDplaItemUri = "http://dp.la/api/items/"
 
   def build(): Try[OreAggregation]
   def agent: EdmAgent
+
   /**
-    * Build the base ID to be hashed. Implemented per provider
+    * Does the provider use a prefix (typically their provider abbreviation) to
+    * salt the identifier?
+    *
+    * @return Boolean
+    */
+  def useProviderName(): Boolean
+
+  /**
+    * Extract the record's "persistent" identifier. Implementations should raise
+    * an Exception if no ID can be extracted
+    *
+    * @return String Record identifier
+    * @throws Exception If ID can not be extracted
+    */
+  @throws(classOf[ExtractorException])
+  def getProviderId(): String
+
+  /**
+    * The value to salt the identifier with. Not all providers
+    * use this. If not, an empty string should be used
+    * @return
+    */
+  def getProviderName(): String
+
+  /**
+    * Builds the ID to be hashed by either concatenating the provider's
+    * abbreviated name and the persistent identifier for the record with
+    * a double dash `--` or only the persistent identifier.
+    *
+    * Some providers use a name prefix and some do not. Please see Hub
+    * mapping documentation and individual Extractor classes.
+    *
+    * ############################################################
+    * # WARNING DO NOT CHANGE UNLESS YOU KNOW WHAT YOU ARE DOING #
+    * ############################################################
     *
     * @return String
     */
-  def getProviderBaseId(): Option[String]
+  def buildProviderBaseId(): String = {
+    def idErrorMsg(): String = {
+      s"Unable to mint ID given values of:\n" +
+        s"useProviderName: ${useProviderName()}\n" +
+        s"getProviderName: ${getProviderName()}\n" +
+        s"getProviderId: ${getProviderId()}\n"
+    }
+    Try {
+      useProviderName() match {
+        // use prefix of provider short name
+        case true => s"${getProviderName()}--${getProviderId()}"
+        // do not use prefix
+        case false => getProviderId()
+      }
+    } match {
+      case Success(id) => id
+      case Failure(_) => throw ExtractorException(idErrorMsg())
+    }
+
+  }
 
   /**
     * Hashes the base ID
     *
-    * @return MD5 hash of the base ID
+    * ############################################################
+    * # WARNING DO NOT CHANGE UNLESS YOU KNOW WHAT YOU ARE DOING #
+    * ############################################################
+    *
+    * @return String MD5 hash of the base ID
     */
-  protected def mintDplaId(): String = Utils.generateMd5(getProviderBaseId())
+  protected def mintDplaId(): String = DigestUtils.md5Hex(buildProviderBaseId())
 
   /**
     * Builds the item URI
     *
     * @return URI
     */
-  protected def mintDplaItemUri(): URI = new URI(s"${baseItemUri}${mintDplaId()}")
-
+  protected def mintDplaItemUri(): URI = new URI(s"$baseDplaItemUri${mintDplaId()}")
 }
+
+case class ExtractorException(message: String) extends Exception(message)

--- a/src/main/scala/dpla/ingestion3/mappers/providers/WiExtractor.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/WiExtractor.scala
@@ -9,9 +9,19 @@ import dpla.ingestion3.model._
 import scala.util.Try
 import scala.xml._
 
-class WiExtractor(rawData: String) extends Extractor with XmlExtractionUtils {
+class WiExtractor(rawData: String, shortName: String) extends Extractor with XmlExtractionUtils {
 
   implicit val xml: NodeSeq = XML.loadString(rawData)
+
+  // ID minting functions
+  // TODO confirm WI does not use prefix.
+  override def useProviderName(): Boolean = false
+
+  override def getProviderName(): String = shortName
+
+  override def getProviderId(): String = extractString(xml \ "header" \ "identifier")
+    .getOrElse(throw ExtractorException(s"No ID for record ${xml}")
+  )
 
   def build(): Try[OreAggregation] = Try {
     OreAggregation(
@@ -65,6 +75,4 @@ class WiExtractor(rawData: String) extends Extractor with XmlExtractionUtils {
       case None => throw new Exception("Missing required property isShownAt")
     }
   }
-
-  override def getProviderBaseId(): Option[String] = extractString(xml \ "header" \ "identifier")
 }

--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -1,18 +1,18 @@
 package dpla.ingestion3
 
 import java.net.URI
+import java.text.SimpleDateFormat
+import java.util.{Calendar, TimeZone}
 
 import com.databricks.spark.avro.SchemaConverters
 import dpla.ingestion3.model.DplaMapData.LiteralOrUri
 import dpla.ingestion3.utils.FlatFileIO
+import org.apache.avro.Schema
+import org.apache.commons.codec.digest.DigestUtils
+import org.apache.spark.sql.types.StructType
 import org.json4s.JsonAST.JObject
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
-import dpla.ingestion3.utils.Utils.generateMd5
-import org.apache.avro.Schema
-import org.apache.spark.sql.types.StructType
-import java.util.{Calendar, TimeZone}
-import java.text.SimpleDateFormat
 
 
 package object model {
@@ -60,7 +60,7 @@ package object model {
   }
 
   def jsonlRecord(record: OreAggregation): String = {
-    val recordID: String = generateMd5(Some(record.dplaUri.toString)) //todo this is almost definitely wrong
+    val recordID: String = DigestUtils.md5Hex(record.dplaUri.toString) //todo this is almost definitely wrong
     val jobj: JObject =
       ("_type" -> "item") ~
       // For _id, we should have a provider token like "nara" or "ia"

--- a/src/main/scala/dpla/ingestion3/utils/Utils.scala
+++ b/src/main/scala/dpla/ingestion3/utils/Utils.scala
@@ -8,7 +8,6 @@ import java.util.Calendar
 import scala.xml.Node
 import java.util.concurrent.TimeUnit
 
-import org.apache.commons.codec.digest.DigestUtils
 import org.apache.http.client.fluent.Request
 import org.apache.log4j.{FileAppender, Logger, PatternLayout}
 
@@ -44,22 +43,6 @@ object Utils {
         }
       }
       case Failure(_) => false
-    }
-  }
-
-  /**
-    * Create an md5 hash from the given id value
-    *
-    * @param id Value to hash
-    * @return MD5 hash
-    * @throws IllegalArgumentException If no source value given
-    */
-  def generateMd5(id: Option[String]): String = {
-    id match {
-      case Some(i) => DigestUtils.md5Hex(i)
-      // TODO: Is more information required in this error message?
-      case _ => throw new IllegalArgumentException(s"Unable to mint an MD5 ID given local " +
-        s"ID of ${id.getOrElse("**No ID provided**")}")
     }
   }
 


### PR DESCRIPTION
Addresses DT-1594. 

Moves the construction of the base id (what DPLA hashes) into the Extractor trait and adds getter methods to be implemented in the provider's extractor.
 
`useProviderName(): Boolean`
`getProviderId(): String`
`getProviderName(): String`

These methods provide the Extractor trait with all it needs to create the base id, mint the DPLA id and construct the DPLA item URI.  The provider extractor now explicitly states what the base ID is to be constructed from and Extractor does the construction.

If the provider's identifier cannot be or if the combination of values for (useProviderName and getProviderName().isEmpty) do not make sense (e.g. false, false or true, true) extracted an exception is raised and the record is not mapped.