### PR TITLE
save all harvests in consistent directory structure

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/Harvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/Harvester.scala
@@ -52,7 +52,7 @@ abstract class Harvester(shortName: String,
   def harvest = {
 
     // If the output directory already exists then delete it and its contents.
-    outputFile.getParentFile.mkdir()
+    val outputFile = new File(outputDir)
     if (outputFile.exists)
       harvestLogger.info(s"Output directory already exists. Deleting ${outputDir}...")
     Utils.deleteRecursively(outputFile)
@@ -79,8 +79,6 @@ abstract class Harvester(shortName: String,
     // Shut down spark session.
     sc.stop()
   }
-
-  protected val outputFile = new File(outputDir)
 
   /**
     * Initiate a spark session using the configs specified in the i3Conf.

--- a/src/main/scala/dpla/ingestion3/harvesters/api/ApiHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/ApiHarvester.scala
@@ -41,7 +41,7 @@ abstract class ApiHarvester(shortName: String,
   protected lazy val avroWriter: DataFileWriter[GenericRecord] = {
     val dirName = if (outputDir.endsWith("/")) outputDir.dropRight(1) else outputDir
     val fileName = dirName + "/api_harvest.avro"
-    val dir = new File(dirName).mkdir
+    val dir = new File(dirName).mkdirs
     val file = new File(fileName)
     getAvroWriter(file, schema)
   }

--- a/src/main/scala/dpla/ingestion3/harvesters/api/ApiHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/ApiHarvester.scala
@@ -1,5 +1,7 @@
 package dpla.ingestion3.harvesters.api
 
+import java.io.File
+
 import org.apache.avro.Schema
 import org.apache.spark.sql.DataFrame
 import com.databricks.spark.avro._
@@ -36,8 +38,13 @@ abstract class ApiHarvester(shortName: String,
     * This is lazy b/c queryParams should be printed before avroWriter is set.
     * @see doHarvest
     */
-  protected lazy val avroWriter: DataFileWriter[GenericRecord] =
-  getAvroWriter(outputFile, schema)
+  protected lazy val avroWriter: DataFileWriter[GenericRecord] = {
+    val dirName = if (outputDir.endsWith("/")) outputDir.dropRight(1) else outputDir
+    val fileName = dirName + "/api_harvest.avro"
+    val dir = new File(dirName).mkdir
+    val file = new File(fileName)
+    getAvroWriter(file, schema)
+  }
 
   /**
     * Saves the records

--- a/src/main/scala/dpla/ingestion3/harvesters/api/ApiHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/ApiHarvester.scala
@@ -8,7 +8,7 @@ import com.databricks.spark.avro._
 import dpla.ingestion3.confs.i3Conf
 import dpla.ingestion3.harvesters.Harvester
 import dpla.ingestion3.harvesters.file.NaraFileHarvestMain._
-import dpla.ingestion3.utils.FlatFileIO
+import dpla.ingestion3.utils.{AvroUtils, FlatFileIO}
 import org.apache.avro.file.DataFileWriter
 import org.apache.avro.generic.{GenericData, GenericRecord}
 import org.apache.log4j.Logger
@@ -43,7 +43,7 @@ abstract class ApiHarvester(shortName: String,
     val fileName = dirName + "/api_harvest.avro"
     val dir = new File(dirName).mkdirs
     val file = new File(fileName)
-    getAvroWriter(file, schema)
+    AvroUtils.getAvroWriter(file, schema)
   }
 
   /**


### PR DESCRIPTION
This changes the file structure of saved API harvests to be consistent with other harvests.  With this implementation, the `--output` command line param for all harvesters should be the name of a directory that will hold `.avro` files.  The API harvester creates the directory and the file within.

This has been tested locally with an MDL harvest.  It addresses [DT-1607](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1607).