### PR TITLE
Fix to the _id field 

### DIFF
--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -66,7 +66,7 @@ package object model {
       // For _id, we should have a provider token like "nara" or "ia"
       ("_id" ->
         (s"${providerToken(record.provider.uri)}--" +
-         s"${record.isShownAt.toString}")) ~
+         s"${record.isShownAt.uri}")) ~
       ("_source" ->
         ("id" -> recordID) ~
         ("_id" ->


### PR DESCRIPTION
_id now looks like:

`"_id":"nara--http://catalog.archives.gov/id/2132862"`

This will probably need to be addressed again once DT-1594 is merged in.
