### PR TITLE
Feature/enrich entry error reporting

### DIFF
--- a/src/main/scala/dpla/ingestion3/EnrichEntry.scala
+++ b/src/main/scala/dpla/ingestion3/EnrichEntry.scala
@@ -2,21 +2,26 @@ package dpla.ingestion3
 
 import java.io.File
 
-import dpla.ingestion3.enrichments.{EnrichmentDriver, Twofisher}
-import dpla.ingestion3.model.{DplaMapData, ModelConverter, RowConverter}
+import dpla.ingestion3.enrichments.EnrichmentDriver
+import dpla.ingestion3.model.{ModelConverter, OreAggregation, RowConverter}
 import dpla.ingestion3.utils.Utils
-import org.apache.log4j.LogManager
+import org.apache.log4j.{LogManager, Logger}
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 import com.databricks.spark.avro._
 import dpla.ingestion3.confs.{CmdArgs, Ingestion3Conf}
+import dpla.ingestion3.mappers.providers.Extractor
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
+
+import scala.util.{Failure, Success, Try}
 
 /**
   * Expects three parameters:
   *   1) a path to the harvested data
   *   2) a path to output the mapped data
   *   3) a path to the application configuration file
+  *   4) provider short name
   *
   *   Usage
   *   -----
@@ -25,6 +30,7 @@ import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
   *     --input=/input/path/to/mapped.avro
   *     --output=/output/path/to/enriched.avro
   *     --conf=/path/to/application.conf
+  *     --name=provider
   *
   */
 
@@ -35,11 +41,18 @@ object EnrichEntry {
     // Read in command line args
     val cmdArgs = new CmdArgs(args)
 
-    val inputDir = cmdArgs.input.getOrElse(throw new IllegalArgumentException("Missing input dir"))
-    val outputDir = cmdArgs.output.getOrElse(throw new IllegalArgumentException("Missing output dir"))
-    val confFile = cmdArgs.configFile.getOrElse(throw new IllegalArgumentException("Missing conf file"))
+    val inputDir = cmdArgs.input
+      .getOrElse(throw new IllegalArgumentException("Missing input dir"))
+    val outputDir = cmdArgs.output
+      .getOrElse(throw new IllegalArgumentException("Missing output dir"))
+    val confFile = cmdArgs.configFile
+      .getOrElse(throw new IllegalArgumentException("Missing conf file"))
+    val shortName = cmdArgs.providerName
+      .getOrElse(throw new IllegalArgumentException("Missing provider short name"))
 
-    val logger = LogManager.getLogger(EnrichEntry.getClass)
+    val enrichLogger: Logger = LogManager.getLogger("ingestion3")
+    val appender = Utils.getFileAppender(shortName, "enrichment")
+    enrichLogger.addAppender(appender)
 
     // Load configuration from file
     val i3Conf = new Ingestion3Conf(confFile).load()
@@ -57,34 +70,56 @@ object EnrichEntry {
     // Need to keep this here despite what IntelliJ and Codacy say
     import spark.implicits._
     val dplaMapDataRowEncoder: ExpressionEncoder[Row] = RowEncoder(model.sparkSchema)
+    val tupleRowStringEncoder: ExpressionEncoder[Tuple2[Row, String]] =
+      ExpressionEncoder.tuple(RowEncoder(model.sparkSchema), ExpressionEncoder())
 
     // Load the mapped records
-    val mappedRows = spark.read.avro(inputDir)
+    val mappedRows: DataFrame = spark.read.avro(inputDir)
 
-    // Run the enrichments over the Dataframe
-    val enrichedRows = mappedRows.map(
-      row => {
-        val dplaMapData = ModelConverter.toModel(row)
-        val enrichedDplaMapData = new EnrichmentDriver(i3Conf).enrich(dplaMapData)
-        RowConverter.toRow(enrichedDplaMapData, model.sparkSchema)
+    val enrichResults: Dataset[(Row, String)] = mappedRows.map(row => {
+      Try{ ModelConverter.toModel(row) } match {
+        case Success(dplaMapData) => {
+          val driver = new EnrichmentDriver(i3Conf)
+          enrich(dplaMapData, driver)
+        }
+        case Failure(err) => (null, s"Error parsing mapped data: ${err.getMessage}")
       }
-    )(dplaMapDataRowEncoder)
+
+    })(tupleRowStringEncoder)
+
+    val successResults: Dataset[Row] = enrichResults
+      .filter(tuple => Option(tuple._1).isDefined)
+      .map(tuple => tuple._1)(dplaMapDataRowEncoder)
+
+    val failures:  Array[String] = enrichResults
+      .filter(tuple => Option(tuple._2).isDefined)
+      .map(tuple => tuple._2).collect()
 
     // Delete the output location if it exists
     Utils.deleteRecursively(new File(outputDir))
 
     // Save mapped records out to Avro file
-    enrichedRows.toDF().write
+    successResults.toDF().write
       .format("com.databricks.spark.avro")
       .save(outputDir)
 
     // Gather some stats
     val mappedRecordCount = mappedRows.count()
-    val enrichedRecordCount = enrichedRows.count()
+    val enrichedRecordCount = successResults.count()
 
     sc.stop()
 
-    logger.debug(s"Mapped ${mappedRecordCount} records and enriched ${enrichedRecordCount} records")
-    logger.debug(s"${mappedRecordCount-enrichedRecordCount} enrichment errors")
+    // Log error messages.
+    failures.foreach(msg => enrichLogger.warn(s"Error: ${msg}"))
+
+    enrichLogger.debug(s"Mapped ${mappedRecordCount} records and enriched ${enrichedRecordCount} records")
+    enrichLogger.debug(s"${mappedRecordCount-enrichedRecordCount} enrichment errors")
+  }
+
+  private def enrich(dplaMapData: OreAggregation, driver: EnrichmentDriver): (Row, String) = {
+    driver.enrich(dplaMapData) match {
+      case Success(enriched) => (RowConverter.toRow(enriched, model.sparkSchema), null)
+      case Failure(exception) => (null, exception.getMessage)
+    }
   }
 }

--- a/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
+++ b/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
@@ -54,7 +54,8 @@ class Ingestion3Conf(confFilePath: String, providerName: Option[String] = None) 
         sparkExecutorMemory= getProp(providerConf, "spark.executorMemory")
       ),
       i3Twofishes(
-        hostname = getProp(providerConf, "twofishes.hostname")
+        hostname = getProp(providerConf, "twofishes.hostname"),
+        port = getProp(providerConf, "twofishes.port")
       )
     )
   }
@@ -125,7 +126,8 @@ case class i3Conf(
                  )
 
 case class i3Twofishes(
-                  hostname: Option[String] = None
+                  hostname: Option[String] = None,
+                  port: Option[String] = None
                 )
 
 case class i3Spark (

--- a/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
@@ -8,13 +8,14 @@ import scala.util.Try
 
 class EnrichmentDriver(conf: i3Conf) extends Serializable {
   /**
-    * Reads twofishes hostname from application config file
+    * Reads Twofishes hostname and port from application config file
     *
     * @see dpla.ingestion3.enrichments.Twofisher
     * @see SpatialEnrichmentIntegrationTest
     */
   object Geocoder extends Twofisher {
     override def hostname = conf.twofishes.hostname.getOrElse("localhost")
+    override def port = conf.twofishes.port.getOrElse("8081")
   }
 
   val stringEnrichment = new StringEnrichments()
@@ -38,6 +39,6 @@ class EnrichmentDriver(conf: i3Conf) extends Serializable {
         date = record.sourceResource.date.map(d => dateEnrichment.parse(d)),
         language = record.sourceResource.language.map(l => LanguageMapper.mapLanguage(l)),
         place = record.sourceResource.place.map(p => spatialEnrichment.enrich(p))
-    ))
+      ))
   }
 }

--- a/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
@@ -3,6 +3,8 @@ package dpla.ingestion3.enrichments
 import dpla.ingestion3.confs.i3Conf
 import dpla.ingestion3.model._
 
+import scala.util.Try
+
 
 class EnrichmentDriver(conf: i3Conf) extends Serializable {
   /**
@@ -30,7 +32,7 @@ class EnrichmentDriver(conf: i3Conf) extends Serializable {
     * @param record The mapped record
     * @return An enriched record
     */
-  def enrich(record: OreAggregation): OreAggregation = {
+  def enrich(record: OreAggregation): Try[OreAggregation] = Try {
     record.copy(
       sourceResource = record.sourceResource.copy(
         date = record.sourceResource.date.map(d => dateEnrichment.parse(d)),

--- a/src/main/scala/dpla/ingestion3/enrichments/SpatialEnrichment.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/SpatialEnrichment.scala
@@ -6,9 +6,12 @@ import dpla.ingestion3.model.DplaPlace
 import org.apache.log4j.Logger
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
+
 import scalaj.http._
 import com.github.dvdme.Coordinates
-import util.{Try, Success, Failure}
+import dpla.ingestion3.utils.Utils
+
+import util.{Failure, Success, Try}
 
 
 /* Case classes for JSON parser ... */
@@ -56,7 +59,7 @@ trait Twofisher {
     *         interpretations
     */
   def geocoderResponse(queryType: String, term: String): JValue = {
-    val baseURI = s"http://$hostname:$port/query"
+    val baseURI = getBaseUri
     retry(3) {
       val response: HttpResponse[String] =
         Http(baseURI)
@@ -88,6 +91,9 @@ trait Twofisher {
   def hostname: String = "localhost"
 
   def port: String = "8081"
+
+  def getBaseUri: String = s"http://$hostname:$port/query"
+
 }
 
 /**

--- a/src/main/scala/dpla/ingestion3/utils/Utils.scala
+++ b/src/main/scala/dpla/ingestion3/utils/Utils.scala
@@ -13,35 +13,17 @@ import org.apache.log4j.{FileAppender, Logger, PatternLayout}
 
 import scala.util.{Failure, Success, Try}
 
-/**
-  * Created by scott on 1/18/17.
-  */
+
 object Utils {
   /**
-    * Accepts a String URL and validates it by making a request and returning true only if
-    * the response code is a 200.
+    * TODO This should be re-written after an HTTP library is chosen.
     *
     * @param str
     * @return
     */
   def validateUrl(str: String): Boolean = {
-    def url() : Try[URL] = Try {
-      new URL(str) // with throw exception if string is not valid URL
-    }
-
-    url() match {
-      case Success(endpoint) => {
-        val code = Request.Get(endpoint.toURI)
-          .execute()
-          .returnResponse()
-          .getStatusLine
-          .getStatusCode
-        // TODO Other appropriate codes or something like (code / 100) match case 2 => ?
-        code match {
-          case 200 => true
-          case _ => false
-        }
-      }
+    Try { Request.Get(new URL(str).toURI).execute() } match {
+      case Success(_) => true
       case Failure(_) => false
     }
   }

--- a/src/test/scala/dpla/ingestion3/enrichments/EnrichmentDriverTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/EnrichmentDriverTest.scala
@@ -7,6 +7,8 @@ import dpla.ingestion3.data.MappedRecordsFixture
 import dpla.ingestion3.model.{DplaSourceResource, EdmTimeSpan, SkosConcept, _}
 import org.scalatest.{BeforeAndAfter, FlatSpec}
 
+import scala.util.Success
+
 
 class EnrichmentDriverTest extends FlatSpec with BeforeAndAfter {
 
@@ -61,7 +63,7 @@ class EnrichmentDriverTest extends FlatSpec with BeforeAndAfter {
 
     val enrichedRecord = driver.enrich(MappedRecordsFixture.mappedRecord)
 
-    assert(enrichedRecord === expectedValue)
+    assert(enrichedRecord === Success(expectedValue))
   }
 }
 

--- a/src/test/scala/dpla/ingestion3/enrichments/SpatialEnrichmentTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/SpatialEnrichmentTest.scala
@@ -1,13 +1,15 @@
 package dpla.ingestion3.enrichments
 
-import org.json4s.jackson.JsonMethods
 import dpla.ingestion3.model.DplaPlace
+import org.json4s.jackson.JsonMethods
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FlatSpec, PrivateMethodTester}
-import util.Try
+
+import scala.util.Try
 
 
-class SpatialEnrichmentTest extends FlatSpec with PrivateMethodTester
+class SpatialEnrichmentTest extends FlatSpec
+    with PrivateMethodTester
     with MockFactory {
 
   val geocoder: Twofisher = mock[Twofisher]


### PR DESCRIPTION
This adds error reporting to `EnrichEntry`.  `EnrichmentDriver` now returns a `Try` object to facilitate reporting.  Also, an enrichment now fails if TwoFishes is unreachable (thanks @moltude!)  This has been tested locally.  It addresses [DT-1593](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1593).