### PR TITLE
Improve EDTF handling

### DIFF
--- a/src/main/scala/dpla/ingestion3/enrichments/ParseDateEnrichment.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/ParseDateEnrichment.scala
@@ -66,12 +66,13 @@ class ParseDateEnrichment extends Serializable {
         .replaceAll("\\s+", " ")
 
     val removedDecades =
-      if (removedLateAndEarly.matches("""^[1-9]+0s$"""))
-        removedLateAndEarly.replaceAll("0s", "x")
+      if (removedLateAndEarly.matches("""^\d{2,3}0s$"""))
+        removedLateAndEarly.replaceAll("""0s\b""", "x")
       else removedLateAndEarly
 
+    // What is the goal of this replacement?  Why turn "1978--" into "1978xx"?
     val removedRanges =
-      if (removedDecades.matches("""^[1-9]+\-+$"""))
+      if (removedDecades.matches("""^\d{2,4}\-+$"""))
         removedDecades.replaceAll("-", "x")
       else removedDecades
 


### PR DESCRIPTION
See https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1616

The changes here add what I think is EDTF Level 0 support.  See the tests. See https://www.loc.gov/standards/datetime/pre-submission.html (and note that the tests check for the example patterns in that document).

Though I've added the code to make sure Level 0 is handled, I haven't _removed_ old code that may be redundant. DT-1616 is a timebox, and I'm at my time limit.

For discussion:
1. Code quality. E.g. the embedded matches in `timeSpanFromEDTF` ... there is probably a better way. I could not get a chain of `getOrElse` to work.
2. What needs to be removed now?

I made the new methods I added public because I was having trouble testing them with `PrivateMethodTester`.
