### PR TITLE
Use accumulators for stats & add stack traces to error messages

### DIFF
--- a/src/main/scala/dpla/ingestion3/EnrichEntry.scala
+++ b/src/main/scala/dpla/ingestion3/EnrichEntry.scala
@@ -89,7 +89,8 @@ object EnrichEntry {
         case Success(dplaMapData) =>
           enrich(dplaMapData, driver, totalCount, successCount)
         case Failure(err) =>
-          (null, s"Error parsing mapped data: ${err.getMessage}")
+          (null, s"Error parsing mapped data: ${err.getMessage}\n" +
+                 s"${err.getStackTrace.mkString("\n")}")
       }
     })(tupleRowStringEncoder)
 

--- a/src/main/scala/dpla/ingestion3/EnrichEntry.scala
+++ b/src/main/scala/dpla/ingestion3/EnrichEntry.scala
@@ -11,6 +11,8 @@ import org.apache.log4j.{LogManager, Logger}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
+import org.apache.spark.util.LongAccumulator
+
 
 import scala.util.{Failure, Success, Try}
 
@@ -67,6 +69,8 @@ object EnrichEntry {
       .getOrCreate()
 
     val sc = spark.sparkContext
+    val totalCount: LongAccumulator = sc.longAccumulator("Total Record Count")
+    val successCount: LongAccumulator = sc.longAccumulator("Successful Record Count")
 
     // Need to keep this here despite what IntelliJ and Codacy say
     import spark.implicits._
@@ -82,8 +86,10 @@ object EnrichEntry {
     val enrichResults: Dataset[(Row, String)] = mappedRows.map(row => {
       val driver = new EnrichmentDriver(i3Conf)
       Try{ ModelConverter.toModel(row) } match {
-        case Success(dplaMapData) => enrich(dplaMapData, driver)
-        case Failure(err) => (null, s"Error parsing mapped data: ${err.getMessage}")
+        case Success(dplaMapData) =>
+          enrich(dplaMapData, driver, totalCount, successCount)
+        case Failure(err) =>
+          (null, s"Error parsing mapped data: ${err.getMessage}")
       }
     })(tupleRowStringEncoder)
 
@@ -103,23 +109,31 @@ object EnrichEntry {
       .format("com.databricks.spark.avro")
       .save(outputDir)
 
-    // Gather some stats
-    val mappedRecordCount = mappedRows.count()
-    val enrichedRecordCount = successResults.count()
-
     sc.stop()
 
     // Log error messages.
     failures.foreach(msg => enrichLogger.warn(s"Error: ${msg}"))
 
-    enrichLogger.debug(s"Mapped ${mappedRecordCount} records and enriched ${enrichedRecordCount} records")
-    enrichLogger.debug(s"${mappedRecordCount-enrichedRecordCount} enrichment errors")
+    enrichLogger.debug(
+      s"Mapped ${totalCount.value} records and enriched ${successCount.value}" +
+        s" records"
+    )
+    enrichLogger.debug(
+      s"${totalCount.value - successCount.value} enrichment errors"
+    )
   }
 
-  private def enrich(dplaMapData: OreAggregation, driver: EnrichmentDriver): (Row, String) = {
+  private def enrich(dplaMapData: OreAggregation,
+                     driver: EnrichmentDriver,
+                     totalCount: LongAccumulator,
+                     successCount: LongAccumulator): (Row, String) = {
+    totalCount.add(1)
     driver.enrich(dplaMapData) match {
-      case Success(enriched) => (RowConverter.toRow(enriched, model.sparkSchema), null)
-      case Failure(exception) => (null, exception.getMessage)
+      case Success(enriched) =>
+        successCount.add(1)
+        (RowConverter.toRow(enriched, model.sparkSchema), null)
+      case Failure(exception) =>
+        (null, exception.getMessage)
     }
   }
 

--- a/src/main/scala/dpla/ingestion3/MappingEntry.scala
+++ b/src/main/scala/dpla/ingestion3/MappingEntry.scala
@@ -146,7 +146,8 @@ object MappingEntry {
         successCount.add(1)
         (RowConverter.toRow(dplaMapData, model.sparkSchema), null)
       case Failure(exception) =>
-        (null, exception.getMessage)
+        (null, s"${exception.getMessage}\n" +
+               s"${exception.getStackTrace.mkString("\n")}")
     }
   }
 


### PR DESCRIPTION
See https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1617

Use Spark accumulators to track counts of total records processed and records successfully processed, instead of using `count()` methods.

Add stack trace strings to exception messages in `MappingEntry` and `EnrichEntry`.
