### PR TITLE
Add JValue field, sidecar, to OreAggregation

### DIFF
--- a/src/main/resources/avro/MAPRecord.avsc
+++ b/src/main/resources/avro/MAPRecord.avsc
@@ -1072,6 +1072,13 @@
         "null",
         "string"
       ]
+    },
+    {
+      "name": "sidecar",
+      "type": [
+        "null",
+        "string"
+      ]
     }
   ]
 }

--- a/src/main/scala/dpla/ingestion3/model/DplaMapData.scala
+++ b/src/main/scala/dpla/ingestion3/model/DplaMapData.scala
@@ -3,6 +3,8 @@ package dpla.ingestion3.model
 import java.net.URI
 
 import dpla.ingestion3.model.DplaMapData._
+import org.json4s.JValue
+import org.json4s.JsonAST.JNothing
 
 /**
   * Contains type definitions that express cardinality of fields
@@ -34,7 +36,8 @@ case class OreAggregation(
                            `object`: ZeroToOne[EdmWebResource] = None, // full size image
                            preview: ZeroToOne[EdmWebResource] = None, // thumbnail
                            provider: ExactlyOne[EdmAgent],
-                           edmRights: ZeroToOne[URI] = None
+                           edmRights: ZeroToOne[URI] = None,
+                           sidecar: JValue = JNothing
                          )
 
 /**

--- a/src/main/scala/dpla/ingestion3/model/RowConverter.scala
+++ b/src/main/scala/dpla/ingestion3/model/RowConverter.scala
@@ -1,10 +1,10 @@
 package dpla.ingestion3.model
 
 import dpla.ingestion3.model.DplaMapData.LiteralOrUri
-import dpla.ingestion3.model.RowConverter.fromEdmAgent
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.types.StructType
+import org.json4s.jackson.JsonMethods._
 
 /**
   * Responsible for desugaring a DplaMapModel and converting it to a Spark-native Row-based structure.
@@ -31,7 +31,8 @@ object RowConverter {
         oreAggregation.`object`.map(fromEdmWebResource).orNull, //7
         oreAggregation.preview.map(fromEdmWebResource).orNull, //8
         fromEdmAgent(oreAggregation.provider), //9
-        oreAggregation.edmRights.map(_.toString).orNull //10
+        oreAggregation.edmRights.map(_.toString).orNull, //10
+        compact(oreAggregation.sidecar)
       ),
       sqlSchema
     )

--- a/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
+++ b/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
@@ -3,6 +3,7 @@ package dpla.ingestion3.data
 import java.net.URI
 
 import dpla.ingestion3.model._
+import org.json4s.jackson.JsonMethods.parse
 
 object EnrichedRecordFixture {
 
@@ -31,6 +32,7 @@ object EnrichedRecordFixture {
       isShownAt = EdmWebResource(
         uri = new URI("https://example.org/record/123")
       ),
+      sidecar = parse("""{"field": "value"}"""),
       sourceResource = DplaSourceResource(
         collection = Seq(DcmiTypeCollection(
           title = Some("The Collection"),

--- a/src/test/scala/dpla/ingestion3/model/ModelConverterTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/ModelConverterTest.scala
@@ -10,6 +10,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.StructType
 import org.scalatest.{BeforeAndAfter, FlatSpec}
 
+
 class ModelConverterTest extends FlatSpec with BeforeAndAfter {
 
   val schema = new Schema.Parser().parse(new FlatFileIO().readFileAsString("/avro/MAPRecord.avsc"))
@@ -263,7 +264,8 @@ class ModelConverterTest extends FlatSpec with BeforeAndAfter {
         testEdmWebResource,
         testEdmWebResource,
         testEdmAgent,
-        urlString1
+        urlString1,
+        """"{"field": "value"}"""
       )
     )
 


### PR DESCRIPTION
Allows mapped records to carry additional information within a JValue object. We can be more nuaunced about
what we track without forcing everything into a (String,String) map. The JValue is converted to a String
in the RowConverter.