### PR TITLE
Revisions to JSON-L model (PA QA)

### DIFF
--- a/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
+++ b/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
@@ -4,6 +4,7 @@ import java.net.URI
 
 import dpla.ingestion3.model._
 import org.json4s.jackson.JsonMethods.parse
+import org.json4s.JsonDSL._
 
 object EnrichedRecordFixture {
 
@@ -32,7 +33,7 @@ object EnrichedRecordFixture {
       isShownAt = EdmWebResource(
         uri = new URI("https://example.org/record/123")
       ),
-      sidecar = parse("""{"field": "value"}"""),
+      sidecar = ("prehashId" -> "oai:somestate:id123") ~ ("dplaId" -> "4b1bd605bd1d75ee23baadb0e1f24457"),
       sourceResource = DplaSourceResource(
         collection = Seq(DcmiTypeCollection(
           title = Some("The Collection"),
@@ -89,6 +90,7 @@ object EnrichedRecordFixture {
 
   val minimalEnrichedRecord =
     OreAggregation(
+      sidecar = ("prehashId" -> "oai:somestate:id123") ~ ("dplaId" -> "123"),
       sourceResource = DplaSourceResource(
         rights = Seq("Public Domain"),
         title = Seq("The Title"),

--- a/src/test/scala/dpla/ingestion3/model/JsonlStringTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/JsonlStringTest.scala
@@ -6,7 +6,6 @@ import dpla.ingestion3.data.EnrichedRecordFixture
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
 
-
 class JsonlStringTest extends FlatSpec {
 
   "jsonlRecord" should "print a valid JSON string" in {


### PR DESCRIPTION
* Add `prehashId` and `dplaId` values to `sidecar` in PAExtractor 
* Uses `prehashId` and `dplaId` to populate `@id` and `_id` in the JSON-L document 
* Tries to prettify OriginalRecord for output but this is not 100%. Issues with CQA frontend
*  nameOnlyConcept() now populates the `providedLabel` property not `concept`
* Fixup subject and language mapping in jsonlRecord()
* Add documentation