### PR TITLE
Add EDTF Level 1 support to date enrichment

### DIFF
--- a/src/main/scala/dpla/ingestion3/utils/EDTFDate.scala
+++ b/src/main/scala/dpla/ingestion3/utils/EDTFDate.scala
@@ -1,0 +1,203 @@
+package dpla.ingestion3.utils
+
+import scala.util.matching.Regex
+
+
+object EDTFDate {
+
+  val yearPat4 = """-?\d{1,4}"""
+  val yearPatLong = """y-?\d{5,}"""
+  // monthPat and dayPat try to provide a little insurance against impossible
+  // dates, but do not verify whether the month actually has a particular
+  // day, like 2017-11-31 or 2017-02-29, which are both invalid.
+  val monthPat = "(?:0[1-9]|1[0-2])"
+  val dayPat = "(?:0[1-9]|[12][0-9]|3[01])"
+  val monthAndDayPat = s"-?(?:$monthPat?-?$dayPat?|2[1-4])"  // incl. season
+  val basicYmdPat = s"(?:$yearPat4|$yearPatLong)$monthAndDayPat"
+  val unspecDatePat = """(?:\d{3}u|\d{2}uu|\d{4}(?:-uu){1,2}|\d{4}-\d{2}-uu)"""
+  val fullYmdPat = s"(?:$basicYmdPat|$unspecDatePat)"
+
+  /*
+   * dateRegex has one match group, for the date. We allow for "uncertain /
+   * approximate" symbols at the end of the string, but don't return them
+   * with our range values.
+   */
+  val dateRegex: Regex =
+    ("^(" +                             // start capture
+      fullYmdPat +
+      ")" +                             // end capture
+      """(?:[?~]+)?$"""                 // optional "~" and "?"
+      ).r
+
+  /*
+   * dateAndTimeRegex captures the date part of the timestamp (YYYY-mm-dd)
+   * because it's assumed that edm:TimeSpan's 'begin' and 'end' are just
+   * supposed to be dates, without time. If that's wrong, change this and
+   * rangeForDateAndTime().
+   */
+  val dateAndTimeRegex: Regex =
+    """^(\d{4}-\d{2}-\d{2})T\d{2}:\d{2}:\d{2}(?:Z|[\+\-]\d{2}:\d{2})?$""".r
+
+  /*
+   * There are two capture groups in intervalRegex, one for the begin and one
+   * for the end.
+   */
+  val intervalRegex: Regex =
+    ("^(" +                             // start capture 1
+      "(?:" +                           // start grouping for "unknown"
+      fullYmdPat +
+      "|unknown" +
+      ")" +                             // end grouping for "unknown"
+      ")" +                             // end capture 1
+      """(?:[?~]+)?""" +                // optional "~" and "?"
+      "/" +                             // forward slash delimiter
+      "(" +                             // start capture 2
+      "(?:" +                           // start grouping for "unknown"
+      fullYmdPat +
+      "|unknown" +
+      ")" +                             // end grouping for "unknown"
+      ")" +                             // end capture 2
+      """(?:[?~]+)?""" +                // optional "~" and "?"
+      """$"""
+      ).r
+
+  /*
+   * extendedIntervalRegex deals with "open" dates in the Level 1
+   * spec.
+   */
+  val openIntervalRegex: Regex =
+    ("^(" +                             // start capture
+      fullYmdPat +
+      ")" +                             // end capture
+      """/open$"""
+      ).r
+
+  private def clean(s: String): String = {
+    s.replaceFirst("y", "")
+      .replaceFirst("unknown", "")
+      .replaceFirst("""(\d{4})-2[1-4]""", """$1""")  // strip season
+  }
+
+  /**
+    * Return a range that makes sense for an "unspecified" pattern
+    *
+    * @param s  The string to consider
+    * @return   Tuple of Strings (date, date)
+    */
+  private def rangeForUnspecDate(s: String): (String, String) = {
+    s match {
+      case x if x matches """^\d{3}u$""" =>
+        (x.replaceFirst("u", "0"), x.replaceFirst("u", "9"))
+      case x if x matches """^\d{2}uu$""" =>
+        (x.replaceFirst("uu", "00"), x.replaceFirst("uu", "99"))
+      case x if x matches """^\d{4}-\d{2}-uu$""" =>
+        val date = x.replaceAll("""^(\d{4}-\d{2})-uu$""", """$1""")
+        (date, date)
+      case x if x matches """^\d{4}-uu-uu$""" =>
+        (x.replaceAll("""^(\d{4})-uu-uu$""", """$1-01-01"""),
+          x.replaceAll("""^(\d{4})-uu-uu$""", """$1-12-31"""))
+      case _ => ("", "")
+    }
+  }
+
+  /**
+    * Return begin and end date range for an exact EDTF date, if matched
+    *
+    * @param s  The string to consider
+    * @return   Optional tuple of Strings (begin, end)
+    * @see      dpla.ingestion3.utils.EDTFDate.dateRegex
+    * @see      5.1.1 (Date) at
+    *           https://www.loc.gov/standards/datetime/pre-submission.html
+    */
+  def rangeForExactDate(s: String): Option[(String, String)] = {
+    dateRegex.findFirstMatchIn(s) match {
+      case Some(matched) =>
+        if (matched.group(1).contains("u")) {
+          Some(rangeForUnspecDate(matched.group(1)))
+        } else {
+          Some((clean(matched.group(1)), clean(matched.group(1))))
+        }
+      case None => None
+    }
+  }
+
+  /**
+    * Return begin and end date range for a timestamp, if matched
+    *
+    * @param s  The string to consider
+    * @return   Optional tuple of Strings (begin, end)
+    * @see      dpla.ingestion3.utils.EDTFDate.dateAndTimeRegex
+    * @see      5.1.2 (Date and Time) at
+    *           https://www.loc.gov/standards/datetime/pre-submission.html
+    */
+  def rangeForDateAndTime(s: String): Option[(String, String)] = {
+    dateAndTimeRegex.findFirstMatchIn(s) match {
+      case Some(matched) => Some((matched.group(1), matched.group(1)))
+      case None => None
+    }
+  }
+
+  /**
+    * Return begin and end date range for an interval, if matched
+    *
+    * Dates given as "unknown" will be represented as empty strings.
+    *
+    * @param s  The string to consider
+    * @return   Optional tuple of Strings (begin, end)
+    * @see      dpla.ingestion3.utils.EDTFDate.intervalRegex
+    * @see      5.1.3 (Interval) and 5.2.3 (Extended Interval) at
+    *           https://www.loc.gov/standards/datetime/pre-submission.html
+    */
+  def rangeForInterval(s: String): Option[(String, String)] = {
+    intervalRegex.findFirstMatchIn(s) match {
+      case Some(matched) =>
+        Some((clean(matched.group(1)), clean(matched.group(2))))
+      case None => None
+    }
+  }
+
+  /**
+    * Return begin date and "" for open end date, if "open" string is matched
+    *
+    * @param s  The string to consider
+    * @return   Optional tuple of Strings (begin, "")
+    * @see      dpla.ingestion3.utils.EDTFDate.openIntervalRegex
+    * @see      5.2.3 (Extended Interval) at
+    *           https://www.loc.gov/standards/datetime/pre-submission.html
+    */
+  def rangeForOpenInterval(s: String): Option[(String, String)] = {
+    openIntervalRegex.findFirstMatchIn(s) match {
+      case Some(matched) =>
+        Some((clean(matched.group(1)), ""))
+      case None => None
+    }
+  }
+
+  /**
+    * Return begin and end date range for an EDTF string, if matched
+    *
+    * @param s  The string to consider
+    * @return   Optional tuple of Strings (begin, end)
+    * @see      https://www.loc.gov/standards/datetime/pre-submission.html
+    */
+  def rangeForEDTF(s: String): Option[(String, String)] = {
+    rangeForExactDate(s) match {
+      case Some(rv) => Some(rv)
+      case None =>
+        rangeForDateAndTime(s) match {
+          case Some(rv) => Some(rv)
+          case None =>
+            rangeForInterval(s) match {
+              case Some(rv) => Some(rv)
+              case None =>
+                rangeForOpenInterval(s) match {
+                  case Some(rv) => Some(rv)
+                  case None => None
+                }
+            }
+        }
+    }
+  }
+
+
+}

--- a/src/test/scala/dpla/ingestion3/enrichments/ParseDateEnrichmentTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/ParseDateEnrichmentTest.scala
@@ -77,7 +77,7 @@ class ParseDateEnrichmentTest extends FlatSpec
     }
   }
 
-  "ParseDateEnrichment" should "parse calendar to iso Date'" in {
+  "ParseDateEnrichment.parse" should "parse calendar to iso Date'" in {
     val date = "Jan 10, 2011"
     val originalDate = EdmTimeSpan(originalSourceDate = Some(date))
     val enrichedDate = EdmTimeSpan(
@@ -91,7 +91,7 @@ class ParseDateEnrichmentTest extends FlatSpec
   }
 
 
-  it should "parse iso to iso Date" in {
+  it should "parse iso to iso Date (using EDTFDate class)" in {
     val date = "2014-05-15"
     val originalDate = EdmTimeSpan(originalSourceDate = Some(date))
     val enrichedDate = EdmTimeSpan(
@@ -171,83 +171,6 @@ class ParseDateEnrichmentTest extends FlatSpec
     )
 
     assert(enrichment.parse(originalDate) === enrichedDate)
-  }
-
-  "ParseDateEnrichment.edtfExactDate" should "return timespan for EDTF date" in {
-    val strings = List("2001-02-03", "2008-12", "2008")
-    for (s <- strings) {
-      val rv: Option[EdmTimeSpan] = enrichment.edtfExactDate(s)
-      val ts = rv.get
-      assert(ts.begin.getOrElse("") == s)
-      assert(ts.end.getOrElse("") == s)
-    }
-  }
-
-  "ParseDateEnrichment.edtfDateAndTime" should "return timespan for EDTF " +
-      "Date and Time timestamp" in {
-    val strings = List(
-      "2001-02-03T09:30:01",
-      "2004-01-01T10:10:10Z",
-      "2004-01-01T10:10:10+05:00"
-    )
-    // Dates correspond to the dates in the timestamps above.
-    val dates = List(
-      "2001-02-03",
-      "2004-01-01",
-      "2004-01-01"
-    )
-    for (i <- 0 to 2) {
-      val rv: Option[EdmTimeSpan] = enrichment.edtfDateAndTime(strings(i))
-      val ts = rv.get
-      assert(ts.begin.getOrElse("") == dates(i))
-      assert(ts.end.getOrElse("") == dates(i))
-    }
-  }
-
-  "ParseDateEnrichment.edtfInterval" should "return timespan for EDTF " +
-      "Interval" in {
-    val strings = List(
-      "1964/2008",
-      "2004-06/2006-08",
-      "2004-02-01/2005-02-08",
-      "2004-02-01/2005-02",
-      "2004-02-01/2005",
-      "2005/2006-02"
-    )
-    val dates = List(
-      List("1964", "2008"),
-      List("2004-06", "2006-08"),
-      List("2004-02-01", "2005-02-08"),
-      List("2004-02-01", "2005-02"),
-      List("2004-02-01", "2005"),
-      List("2005", "2006-02")
-    )
-    for (i <- 0 to 5) {
-      val rv: Option[EdmTimeSpan] = enrichment.edtfInterval(strings(i))
-      val ts = rv.get
-      assert(ts.begin.getOrElse("") == dates(i)(0))
-      assert(ts.end.getOrElse("") == dates(i)(1))
-    }
-  }
-
-  "ParseDateEnrichment.timeSpanFromEDTF" should "return an EdmTimeSpan for a " +
-      "valid EDTF string" in {
-    val strings = List(
-      "1964/2008",
-      "2004-01-01T10:10:10Z",
-      "2001-02-03"
-    )
-    val dates = List(
-      List("1964", "2008"),
-      List("2004-01-01", "2004-01-01"),
-      List("2001-02-03", "2001-02-03")
-    )
-    for (i <- 0 to 2) {
-      val rv: Option[EdmTimeSpan] = enrichment.timeSpanFromEDTF(strings(i))
-      val ts = rv.get
-      assert(ts.begin.getOrElse("") == dates(i)(0))
-      assert(ts.end.getOrElse("") == dates(i)(1))
-    }
   }
 
 }

--- a/src/test/scala/dpla/ingestion3/utils/EDTFDateTest.scala
+++ b/src/test/scala/dpla/ingestion3/utils/EDTFDateTest.scala
@@ -1,0 +1,150 @@
+package dpla.ingestion3.utils
+
+import org.scalatest.FlatSpec
+
+
+class EDTFDateTest extends FlatSpec {
+
+  "EDTFDate.rangeForExactDate" should "return timespan for EDTF date" in {
+    val dates = List(
+      ("1", "1"),
+      ("2001-02-03", "2001-02-03"),
+      ("2008-12", "2008-12"),
+      ("2008", "2008"),
+      ("-2008", "-2008"),
+      ("y19840", "19840"),
+      ("y-19840", "-19840"),
+      ("1984?", "1984"),
+      ("2004-06?", "2004-06"),
+      ("2004-06-11?", "2004-06-11"),
+      ("1984~", "1984"),
+      ("1984?~", "1984"),
+      ("2017-21", "2017") // season syntax, e.g. Spring, 2017.
+    )
+    for (d <- dates) {
+      val rv: Option[(String, String)] = EDTFDate.rangeForExactDate(d._1)
+      assert(rv.getOrElse(("", "")) == (d._2, d._2))
+    }
+  }
+
+  it should "return a range for certain unspecified dates" in {
+    val dates = List(
+      ("199u", "1990", "1999"),
+      ("19uu", "1900", "1999"),
+      // Level 1 spec says day precision for "1999-01-uu but we're leaving that
+      // for later -- too much work at the moment to find days per month
+      ("1999-01-uu", "1999-01", "1999-01"),
+      ("1999-uu-uu", "1999-01-01", "1999-12-31")
+    )
+    for (d <- dates) {
+      val rv: Option[(String, String)] = EDTFDate.rangeForExactDate(d._1)
+      assert(rv.getOrElse(("", "")) == (d._2, d._3))
+    }
+  }
+
+  it should "not return a timespan for some obviously invalid dates" in {
+    // Also verifies the month and day handling of the other methods in
+    // EDTFDate which use EDTFDate.monthPat and EDTFDate.dayPat.
+    val dates = List(
+      "2014-13-01",
+      "1999-01-32",
+      "2000-10-60",
+      "2017-01-00",
+      "2017-00-00"
+    )
+    // Known issue: it doesn't reject impossible dates like 2017-02-29,
+    // 2017-11-31, etc.
+    for (d <- dates) {
+      val rv: Option[(String, String)] = EDTFDate.rangeForExactDate(d)
+      assert(rv.getOrElse(None) == None)
+    }
+  }
+
+  "EDTFDate.rangeForDateAndTime" should "return timespan for EDTF Date and " +
+      "Time timesatmp" in {
+    val dates = List(
+      ("2001-02-03T09:30:01", "2001-02-03"),
+      ("2004-01-01T10:10:10Z", "2004-01-01"),
+      ("2004-01-01T10:10:10+05:00", "2004-01-01")
+    )
+    for (d <- dates) {
+      val rv: Option[(String, String)] = EDTFDate.rangeForDateAndTime(d._1)
+      assert(rv.getOrElse(("", "")) == (d._2, d._2))
+    }
+  }
+
+  "EDTFDate.rangeForInterval" should "return timespan for EDTF Interval" in {
+    val dates = List(
+      ("1964/2008", "1964", "2008"),
+      ("2004-06/2006-08", "2004-06", "2006-08"),
+      ("2004-02-01/2005-02-08", "2004-02-01", "2005-02-08"),
+      ("2004-02-01/2005-02", "2004-02-01", "2005-02"),
+      ("2004-02-01/2005", "2004-02-01", "2005"),
+      ("2005/2006-02", "2005", "2006-02"),
+      ("1984~/2004-06", "1984", "2004-06"),
+      ("1984/2004-06~", "1984", "2004-06"),
+      ("1984?/2004?~", "1984", "2004"),
+      ("y-10000/2000", "-10000", "2000"),
+      ("2017/y10000", "2017", "10000"),
+      ("unknown/1984", "", "1984"),
+      ("644/unknown", "644", "")
+    )
+    for (d <- dates) {
+      val rv: Option[(String, String)] = EDTFDate.rangeForInterval(d._1)
+      assert(rv.getOrElse(("", "")) == (d._2, d._3))
+    }
+  }
+
+  it should "not provide dates for invalid strings" in {
+    val dates = List(
+      "-unknown/1984",           // negative not allowed
+      "unknown-10-10/2017-1-1"   // "unknown" must be whole date
+    )
+    for (d <- dates) {
+      val rv: Option[(String, String)] = EDTFDate.rangeForInterval(d)
+      assert(rv.getOrElse(None) == None)
+    }
+  }
+
+  "EDTFDate.rangeForOpenInterval" should "return timespan for EDTF 'open' " +
+      "interval" in {
+    val dates = List(
+      ("1900/open", "1900", ""),
+      ("y21000/open", "21000", ""),
+      ("y-10000/open", "-10000", "")
+    )
+    for (d <- dates) {
+      val rv: Option[(String, String)] = EDTFDate.rangeForOpenInterval(d._1)
+      assert(rv.getOrElse(("", "")) == (d._2, d._3))
+    }
+  }
+
+  it should "not provide dates for invalid strings" in {
+    val dates = List(
+      "unknown/open",
+      "open/open"
+    )
+    for (d <- dates) {
+      val rv: Option[(String, String)] = EDTFDate.rangeForOpenInterval(d)
+      assert(rv.getOrElse(None) == None)
+    }
+  }
+
+  "EDTFDate.rangeForEDTF" should "handle the gamut of different patterns" in {
+    // Representative sample of each thing above
+    val dates = List(
+      ("2001-02-03", "2001-02-03", "2001-02-03"),
+      ("199u", "1990", "1999"),
+      ("2001-02-03T09:30:01", "2001-02-03", "2001-02-03"),
+      ("1964/2008", "1964", "2008"),
+      ("2017/y10000", "2017", "10000"),
+      ("1984~/2004-06", "1984", "2004-06"),
+      ("644/unknown", "644", ""),
+      ("1900/open", "1900", "")
+    )
+    for (d <- dates) {
+      val rv: Option[(String, String)] = EDTFDate.rangeForEDTF(d._1)
+      assert(rv.getOrElse("", "") == (d._2, d._3))
+    }
+  }
+}


### PR DESCRIPTION
See https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1638
See https://www.loc.gov/standards/datetime/pre-submission.html

This adds Level 1 support and breaks out the EDTF processing to a new object, `dpla.ingestion3.utils.EDTFDate`.

See the tests in `EDTFDateTest`, which document exactly how everything is handled. Confirm that I've got everything in Level 1.

A few things are not being done yet:
* We're just truncating season data, because it is not well implemented in Level 1, which lacks the hemisphere syntax of Level 2. Seasons also have cultural relevance issues, as mentioned in the spec above.
* We're not doing exhaustive validation of dates that might be out of range for the given month, like `2017-11-31`.
