### PR TITLE
Fixup jsonl output

### DIFF
--- a/src/main/scala/dpla/ingestion3/entries/ingest/JsonlEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/JsonlEntry.scala
@@ -75,7 +75,10 @@ object JsonlEntry {
       }
     )
 
-    indexRecords.coalesce(1).write.json(dataOut)
+    // This should always write out as #text() because if we use #json() then the
+    // data will be written out inside a JSON object (e.g. {'value': <doc>}) which is
+    // invalid for our use
+    indexRecords.coalesce(1).write.text(dataOut)
     sc.stop()
 
     logger.info("JSON-L export complete")


### PR DESCRIPTION
Not sure how this got changed but it was probably on me. Added a note about why text() and not json() is used. 