### PR TITLE
Fixes to PA mapping

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/PaExtractor.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/PaExtractor.scala
@@ -50,19 +50,19 @@ class PaExtractor(rawData: String, shortName: String) extends Extractor with Xml
         collection = extractStrings(xml \ "metadata" \\ "relation").headOption.map(nameOnlyCollection).toSeq,
         contributor = extractStrings(xml \ "metadata" \\ "contributor").dropRight(1).map(nameOnlyAgent),
         creator = extractStrings(xml \ "metadata" \\ "creator").map(nameOnlyAgent),
-        date = extractStrings(xml \ "metadata" \\ "date").map(stringOnlyTimeSpan),
+        date = extractStrings(xml \ "metadata" \\ "date").distinct.map(stringOnlyTimeSpan),
         description = extractStrings(xml \ "metadata" \\ "description"),
-        format = extractStrings(xml \ "metadata" \\ "type").filterNot(isDcmiType),
-        genre = extractStrings(xml \ "metadata" \\ "type").map(nameOnlyConcept),
+        format = extractStrings(xml \ "metadata" \\ "type").distinct.filterNot(isDcmiType),
+        genre = extractStrings(xml \ "metadata" \\ "type").distinct.map(nameOnlyConcept),
         identifier = extractStrings(xml \ "metadata" \\ "identifier"),
-        language = extractStrings(xml \ "metadata" \\ "language").map(nameOnlyConcept),
-        place = extractStrings(xml \ "metadata" \\ "coverage").map(nameOnlyPlace),
-        publisher = extractStrings(xml \ "metadata" \\ "publisher").map(nameOnlyAgent),
+        language = extractStrings(xml \ "metadata" \\ "language").distinct.map(nameOnlyConcept),
+        place = extractStrings(xml \ "metadata" \\ "coverage").distinct.map(nameOnlyPlace),
+        publisher = extractStrings(xml \ "metadata" \\ "publisher").distinct.map(nameOnlyAgent),
         relation = extractStrings(xml \ "metadata" \\ "relation").drop(1).map(eitherStringOrUri),
         rights = extractStrings(xml \ "metadata" \\ "rights").filter(r => !isUrl(r)),
         subject = extractStrings(xml \ "metadata" \\ "subject").map(nameOnlyConcept),
         title = extractStrings(xml \ "metadata" \\ "title"),
-        `type` = extractStrings(xml \ "metadata" \\ "type").filter(isDcmiType)
+        `type` = extractStrings(xml \ "metadata" \\ "type").filter(isDcmiType).map(_.toLowerCase)
       ),
       //below will throw if not enough contributors
       dataProvider = extractDataProvider(),
@@ -75,7 +75,7 @@ class PaExtractor(rawData: String, shortName: String) extends Extractor with Xml
   }
 
   def agent = EdmAgent(
-    name = Some("Pennsylvania Digital Collections Project"),
+    name = Some("PA Digital"),
     uri = Some(new URI("http://dp.la/api/contributor/pa"))
   )
 

--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -88,7 +88,7 @@ package object model {
         ("ingestType" -> "item") ~
         ("isShownAt" -> record.isShownAt.uri.toString) ~
         ("object" -> record.`preview`.map{o => o.uri.toString}) ~ // in dpla map 3, object is the thumbnail
-        ("rights" -> record.edmRights.toString) ~
+        ("rights" -> record.edmRights.map(r => r.toString)) ~
         ("originalRecord" ->
           ("stringValue" -> record.originalRecord )) ~  // work around b/c original record viewer in CQA
                                                         // expects JSON and all ORs in ingest1 were converted to JSON

--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -39,8 +39,6 @@ package object model {
 
   def eitherStringOrUri(uri: URI): LiteralOrUri = new Right(uri)
 
-  def dedup(seq: Seq[String]): Seq[String] = seq.distinct
-
   lazy val ingestDate: String = {
     val now = Calendar.getInstance().getTime
     val sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")

--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -9,9 +9,11 @@ import dpla.ingestion3.model.DplaMapData.LiteralOrUri
 import dpla.ingestion3.utils.FlatFileIO
 import org.apache.avro.Schema
 import org.apache.spark.sql.types.StructType
-import org.json4s.JsonAST.{JObject, JString}
+import org.json4s.DefaultFormats
+import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
+import org.json4s.prefs.EmptyValueStrategy
 
 
 package object model {
@@ -36,6 +38,8 @@ package object model {
   def eitherStringOrUri(string: String): LiteralOrUri = new Left(string)
 
   def eitherStringOrUri(uri: URI): LiteralOrUri = new Right(uri)
+
+  def dedup(seq: Seq[String]): Seq[String] = seq.distinct
 
   lazy val ingestDate: String = {
     val now = Calendar.getInstance().getTime
@@ -84,6 +88,7 @@ package object model {
         ("ingestType" -> "item") ~
         ("isShownAt" -> record.isShownAt.uri.toString) ~
         ("object" -> record.`preview`.map{o => o.uri.toString}) ~ // in dpla map 3, object is the thumbnail
+        ("rights" -> record.edmRights.toString) ~
         ("originalRecord" ->
           ("stringValue" -> record.originalRecord )) ~  // work around b/c original record viewer in CQA
                                                         // expects JSON and all ORs in ingest1 were converted to JSON
@@ -153,7 +158,25 @@ package object model {
         ("@type" -> "ore:Aggregation")
       )
 
-    compact(render(jobj))
+
+    // Taken from
+    // https://stackoverflow.com/questions/40128816/remove-json-field-when-empty-value-in-serialize-with-json4s
+    implicit val formats = DefaultFormats.withEmptyValueStrategy(new EmptyValueStrategy {
+      def noneValReplacement = None
+
+      def replaceEmpty(value: JValue): JValue = value match {
+        case JString("") => JNothing
+        case JArray(items) =>
+          if(items.isEmpty) JNothing
+          else JArray(items.map(replaceEmpty))
+        case JObject(fields) => JObject(fields map {
+          case JField(name, v) => JField(name, value = replaceEmpty(v))
+        })
+        case oth => oth
+      }
+    })
+
+    compact(render(jobj)(formats))
   }
 
   val avroSchema: Schema = new Schema.Parser().parse(new FlatFileIO().readFileAsString("/avro/MAPRecord.avsc"))

--- a/src/main/scala/dpla/ingestion3/utils/HttpUtils.scala
+++ b/src/main/scala/dpla/ingestion3/utils/HttpUtils.scala
@@ -87,7 +87,6 @@ object HttpUtils {
       case x: Success[T] => x
       // If we haven't maxed out our retries
       case _ if n > 1 => {
-        println(s"Sleeping ${wait}ms")
         Thread.sleep(wait)
         // TODO some better way of incrementing wait period
         retry(n - 1, wait*2)(fn)

--- a/src/test/scala/dpla/ingestion3/model/JsonlStringTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/JsonlStringTest.scala
@@ -41,13 +41,12 @@ class JsonlStringTest extends FlatSpec {
     )
   }
 
-  it should "have empty arrays for fields that have no data" in {
+  it should "not have empty arrays for fields that have no data" in {
     // Those fields that are optional are 0-n, so they will be arrays.
     val s: String = jsonlRecord(EnrichedRecordFixture.minimalEnrichedRecord)
     val jvalue = parse(s)
     assert(
-      compact(render(jvalue \ "_source" \ "sourceResource" \ "collection")) ==
-        "[]"
+      compact(render(jvalue \ "_source" \ "sourceResource" \ "collection")) == ""
     )
   }
 


### PR DESCRIPTION
Addressees DT-1833 
* Lowercase `type` values
* Get distinct values for `date`, `format`, `genre`, `language`, `place`, `publisher`
* Remove empty values for JSON-L export
* Fix provider name ("PA Digital")
* Add `edm:rights` to JSON-L export
* Remove print statement logging from HttpUtils