### PR TITLE
Universal string and dedupe enrichments

### DIFF
--- a/src/main/scala/dpla/ingestion3/enrichments/DeDuplicationEnrichment.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/DeDuplicationEnrichment.scala
@@ -1,0 +1,73 @@
+package dpla.ingestion3.enrichments
+
+import dpla.ingestion3.model._
+
+/**
+  * Enrichment to remove duplicate values in multi-value fields.
+  *
+  */
+class DeDuplicationEnrichment {
+
+  /**
+    * Main entry point.
+    *
+    * @param record OreAggregation
+    * @return enriched OreAggregation
+    */
+  def enrich(record: OreAggregation): OreAggregation = {
+    record.copy(
+      sourceResource = enrichSourceResource(record.sourceResource),
+      dataProvider = enrichEdmAgent(record.dataProvider),
+      hasView = record.hasView.map(enrichEdmWebResource(_)).distinct,
+      intermediateProvider = record.intermediateProvider.map(enrichEdmAgent(_)),
+      isShownAt = enrichEdmWebResource(record.isShownAt),
+      `object` = record.`object`.map(enrichEdmWebResource(_)),
+      preview = record.preview.map(enrichEdmWebResource(_)),
+      provider = enrichEdmAgent(record.provider)
+    )
+  }
+
+  def enrichSourceResource(sourceResource: DplaSourceResource): DplaSourceResource =
+    sourceResource.copy(
+      alternateTitle = sourceResource.alternateTitle.distinct,
+      collection = sourceResource.collection.distinct,
+      contributor = sourceResource.contributor.map(enrichEdmAgent(_)).distinct,
+      creator = sourceResource.creator.map(enrichEdmAgent(_)).distinct,
+      date = sourceResource.date.distinct,
+      description = sourceResource.description.distinct,
+      extent = sourceResource.extent.distinct,
+      format = sourceResource.format.distinct,
+      genre = sourceResource.genre.map(enrichSkosConcept(_)).distinct,
+      identifier = sourceResource.identifier.distinct,
+      language = sourceResource.language.map(enrichSkosConcept(_)).distinct,
+      place = sourceResource.place.distinct,
+      publisher = sourceResource.publisher.map(enrichEdmAgent(_)).distinct,
+      relation = sourceResource.relation.distinct,
+      replacedBy = sourceResource.replacedBy.distinct,
+      replaces = sourceResource.replaces.distinct,
+      rights = sourceResource.rights.distinct,
+      rightsHolder = sourceResource.rightsHolder.map(enrichEdmAgent(_)).distinct,
+      subject = sourceResource.subject.map(enrichSkosConcept(_)).distinct,
+      temporal = sourceResource.temporal.distinct,
+      title = sourceResource.title.distinct,
+      `type` = sourceResource.`type`.distinct
+    )
+
+  def enrichEdmAgent(edmAgent: EdmAgent): EdmAgent =
+    edmAgent.copy(
+      exactMatch = edmAgent.exactMatch.distinct,
+      closeMatch = edmAgent.closeMatch.distinct
+    )
+
+  def enrichEdmWebResource(edmWebResource: EdmWebResource): EdmWebResource =
+    edmWebResource.copy(
+      fileFormat = edmWebResource.fileFormat.distinct,
+      dcRights = edmWebResource.dcRights.distinct
+    )
+
+  def enrichSkosConcept(skosConcept: SkosConcept): SkosConcept =
+    skosConcept.copy(
+      exactMatch = skosConcept.exactMatch.distinct,
+      closeMatch = skosConcept.closeMatch.distinct
+    )
+}

--- a/src/main/scala/dpla/ingestion3/enrichments/StandardEnrichmentUtils.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/StandardEnrichmentUtils.scala
@@ -1,0 +1,21 @@
+package dpla.ingestion3.enrichments
+
+import dpla.ingestion3.model.OreAggregation
+
+/**
+  * Standard enrichments.
+  *
+  */
+object StandardEnrichmentUtils {
+
+  implicit class StandardRecordEnrichments(record: OreAggregation) {
+
+    lazy val deDuplicationEnrichment = new DeDuplicationEnrichment
+    lazy val stringEnrichments = new StringEnrichments
+
+    def deDuplicate: OreAggregation = deDuplicationEnrichment.enrich(record)
+
+    def standardStringEnrichments: OreAggregation =
+      stringEnrichments.enrich(record)
+  }
+}

--- a/src/main/scala/dpla/ingestion3/enrichments/StringUtils.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/StringUtils.scala
@@ -1,0 +1,73 @@
+package dpla.ingestion3.enrichments
+
+import org.apache.commons.lang.StringEscapeUtils
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document.OutputSettings
+import org.jsoup.nodes.Entities.EscapeMode
+import org.jsoup.safety.Whitelist
+
+import scala.util.matching.Regex
+
+/**
+  * String enrichments
+  *
+  */
+object StringUtils {
+
+  implicit class Enrichments(value: String) {
+
+    type SingleStringEnrichment = String
+    type MultiStringEnrichment = Array[String]
+
+    /**
+      * Accepts a String value and splits it around periods. Strips
+      * trailing and leading whitespace from those "sentences" and
+      * capitalizes the first character of each sentence leaving all
+      * other characters alone.
+      *
+      * We do not assume that all upper case characters should be
+      * downcased.
+      *
+      */
+    val convertToSentenceCase: SingleStringEnrichment = {
+      val pattern: Regex = """.*?(\.)""".r
+      val sentences = for( t <- pattern findAllIn value) yield t.trim.capitalize
+      // rejoin the sentences and add back the whitespace that was trimmed off
+      sentences.mkString(" ")
+    }
+
+    val limitCharacters: (Int) => (String) = (length) => {
+      if (value.length > length) value.substring(0, length)
+      else value
+    }
+
+    /**
+      * Splits a String value around a given delimiter.
+      */
+    val splitAtDelimiter: (String) => Array[String] = (delimiter) => {
+      value.split(delimiter).map(_.trim)
+    }
+
+    val stripEndingPunctuation: SingleStringEnrichment = {
+      value.replace("""[^\w\'\"\s]+$""", "")
+    }
+
+    val stripHTML: SingleStringEnrichment = {
+      val unescaped = StringEscapeUtils.unescapeHtml(value)
+      val cleaned = Jsoup.clean(unescaped, "", Whitelist.none(), new OutputSettings().escapeMode(EscapeMode.xhtml))
+      StringEscapeUtils.unescapeHtml(cleaned)
+    }
+
+    val stripLeadingPunctuation: SingleStringEnrichment = {
+      value.replace("""^[^\w\'\"\s]+""", "")
+    }
+
+    val stripPunctuation: SingleStringEnrichment = {
+      value.replaceAll("""[^\w\'\"\s]""", "")
+    }
+
+    val reduceWhitespace: SingleStringEnrichment = {
+      value.replaceAll("  ", " ")
+    }
+  }
+}

--- a/src/test/scala/dpla/ingestion3/enrichments/DeDuplicationEnrichmentTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/DeDuplicationEnrichmentTest.scala
@@ -1,0 +1,45 @@
+package dpla.ingestion3.enrichments
+
+import dpla.ingestion3.data.MappedRecordsFixture
+import dpla.ingestion3.model._
+import org.scalatest.{BeforeAndAfter, FlatSpec}
+
+class DeDuplicationEnrichmentTest extends FlatSpec with BeforeAndAfter {
+
+  val deDuplicationEnrichment = new DeDuplicationEnrichment
+
+  "enrich" should " remove duplicate Strings" in {
+    val originalValue = Seq("foo", "foo")
+    val expectedValue = Seq("foo")
+
+    val mappedRecord = MappedRecordsFixture.mappedRecord.copy(
+      sourceResource = DplaSourceResource(title = originalValue)
+    )
+
+    val expectedRecord= MappedRecordsFixture.mappedRecord.copy(
+      sourceResource = DplaSourceResource(title = expectedValue)
+    )
+
+    val enrichedRecord = deDuplicationEnrichment.enrich(mappedRecord)
+
+    assert(enrichedRecord === expectedRecord)
+  }
+
+  "enrich" should " remove duplicate entities" in {
+    def collection = DcmiTypeCollection(title = Some("foo"))
+    val originalValue = Seq(collection, collection)
+    val expectedValue = Seq(collection)
+
+    val mappedRecord = MappedRecordsFixture.mappedRecord.copy(
+      sourceResource = DplaSourceResource(collection = originalValue)
+    )
+
+    val expectedRecord= MappedRecordsFixture.mappedRecord.copy(
+      sourceResource = DplaSourceResource(collection = expectedValue)
+    )
+
+    val enrichedRecord = deDuplicationEnrichment.enrich(mappedRecord)
+
+    assert(enrichedRecord === expectedRecord)
+  }
+}

--- a/src/test/scala/dpla/ingestion3/enrichments/EnrichmentDriverTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/EnrichmentDriverTest.scala
@@ -14,29 +14,6 @@ class EnrichmentDriverTest extends FlatSpec with BeforeAndAfter {
 
   val driver = new EnrichmentDriver(i3Conf())
 
-  val mappedRecord = OreAggregation(
-    dataProvider = EdmAgent(),
-    dplaUri = new URI("https://example.org/item/123"), //uri of the record on our site
-    originalRecord = "", //map v4 specifies this as a ref, but that's LDP maybe?
-    provider = EdmAgent(),
-    isShownAt = EdmWebResource(new URI("http://foo.com")),
-    sourceResource = DplaSourceResource(
-      date = Seq(EdmTimeSpan(
-        originalSourceDate = Some("4.3.2015"),
-        prefLabel = None,
-        begin = None,
-        end = None
-      )),
-      language = Seq(SkosConcept(
-        providedLabel = Some("eng"),
-        note = None,
-        scheme = None,
-        exactMatch = Seq(),
-        closeMatch = Seq())
-      )
-    )
-  )
-
   "EnrichmentDriver" should " enrich both language and date" in {
     val expectedValue = MappedRecordsFixture.mappedRecord.copy(sourceResource = DplaSourceResource(
       date = Seq(new EdmTimeSpan(

--- a/src/test/scala/dpla/ingestion3/enrichments/StringUtilsTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/StringUtilsTest.scala
@@ -1,0 +1,109 @@
+package dpla.ingestion3.enrichments
+
+import org.scalatest.{BeforeAndAfter, FlatSpec}
+import dpla.ingestion3.enrichments.StringUtils._
+
+class StringUtilsTest extends FlatSpec with BeforeAndAfter {
+
+  "convertToSentenceCase" should "capitalize the first character in each " +
+    "sentence." in {
+    val originalValue = "this is a sentence about Moomins. this is another about Snorks."
+    val enrichedValue = originalValue.convertToSentenceCase
+    val expectedValue = "This is a sentence about Moomins. This is another about Snorks."
+
+    assert(enrichedValue === expectedValue)
+  }
+
+  "splitAtDelimiter" should "split a string around semi-colon" in {
+    val originalValue = "subject-one; subject-two; subject-three"
+    val enrichedValue = originalValue.splitAtDelimiter(";")
+    val expectedValue = Array("subject-one", "subject-two", "subject-three")
+
+    assert(enrichedValue === expectedValue)
+  }
+
+  "splitAtDelimiter" should "split a string around comma." in {
+    val originalValue = "subject-one, subject-two; subject-three"
+    val enrichedValue = originalValue.splitAtDelimiter(",")
+    val expectedValue = Array("subject-one", "subject-two; subject-three")
+
+    assert(enrichedValue === expectedValue)
+  }
+
+  "stripHMTL" should "remove html from a string" in {
+    val expectedValue = "foo bar baz buzz"
+    val originalValue = f"<p>$expectedValue%s</p>"
+    val enrichedValue = originalValue.stripHTML
+    assert(enrichedValue === expectedValue)
+  }
+
+  it should "handle strings with unbalanced and invalid html" in {
+    val expectedValue = "foo bar baz buzz"
+    val originalValue = f"<p>$expectedValue%s</i><html>"
+    val enrichedValue = originalValue.stripHTML
+    assert(enrichedValue === expectedValue)
+  }
+
+  it should "passthrough strings that do not contain html" in {
+    val expectedValue = "foo bar baz buzz"
+    val originalValue = expectedValue
+    val enrichedValue = originalValue.stripHTML
+    assert(enrichedValue === expectedValue)
+  }
+
+  it should "not emit HTML entities" in {
+    val expectedValue = "foo bar baz > buzz"
+    val originalValue = expectedValue
+    val enrichedValue = originalValue.stripHTML
+    assert(enrichedValue === expectedValue)
+  }
+
+  it should "not turn html entities into html" in {
+    val originalValue = "foo bar baz &lt;p&gt; buzz"
+    val expectedValue = "foo bar baz  buzz"
+    val enrichedValue = originalValue.stripHTML
+    assert(enrichedValue === expectedValue)
+  }
+
+  "stripPunctuation" should "strip all punctuation from the given string" in {
+    val originalValue = "\t\"It's @#$,.! OK\"\n"
+    val enrichedValue = originalValue.stripPunctuation
+    val expectedValue = "\t\"It's  OK\"\n"
+    assert(enrichedValue === expectedValue)
+  }
+
+  "stripLeadingPunctuation" should "strip leading punctuation from the " +
+      "given string" in {
+    val originalValue = "@#$,.!\t \"It's OK\""
+    val enrichedValue = originalValue.stripPunctuation
+    val expectedValue = "\t \"It's OK\""
+    assert(enrichedValue === expectedValue)
+  }
+
+  "stripEndingPunctuation" should "strip ending punctuation from the " +
+    "given string" in {
+    val originalValue = "\"It's OK\" @#$,.!"
+    val enrichedValue = originalValue.stripPunctuation
+    val expectedValue = "\"It's OK\" "
+    assert(enrichedValue === expectedValue)
+  }
+
+  "limitCharacters" should "limit the number of characters in long strings" in {
+    val longString = "Now is the time for all good people to come to the aid of the party."
+    val enrichedValue = longString.limitCharacters(10)
+    assert(enrichedValue.size === 10)
+  }
+
+  it should "not limit strings shorter or equal to the limit" in {
+    val shortString = "Now is the time"
+    val enrichedValue = shortString.limitCharacters(shortString.length)
+    assert(enrichedValue.size === shortString.length)
+  }
+
+  "reduceWhitespace" should "reduce two whitespaces to one whitespace" in {
+    val originalValue = "foo  bar"
+    val enrichedValue = originalValue.reduceWhitespace
+    assert(enrichedValue === "foo bar")
+  }
+
+}


### PR DESCRIPTION
This adds standard enrichments for the following:
* Deduplicate repeated values in multi-value fields
* Replace double-whitespace with single-whitespace
* Remove HTML markup

This also introduces a different model for organizing enrichments that we could consider using for other enrichments if the team likes it.

Methods that enrich a single strings are now in `StringUtils` and organized into an implicit class.  In any domain in which `StringUtils` are imported, you can call them directly on a string, e.g. `"mystring".stripPunctuation.reduceWhitespace.stripHTML` etc.  I thought the ability to call a method directly on a string would make it easier to read and organize enrichments.  We could follow this format enrichments on other value types, not just string enrichments, if we like it.

`StringEnrichments` and `DeDuplicationEnrichment` each take an `OreAggregation`, apply enrichments, and return an `OreAggregation`.  In `StringEnrichments`, I did my best to select which fields it made sense to apply the enrichments to, considering that some of the fields are from MAP 4.1 and therefore not yet in use - feedback would be appreciated about whether I should include or exclude any fields.

`StandardEnrichmentUtils` collects all the standard enrichments in another implicit class.  I used an implicit class again b/c I thought it would make it easier to read and organize enrichments, especially if we need to apply many enrichments in a particular order.  The idea is that in any given domain, you could import whatever enrichment utils you needed, and call them like this `myOreAggregation.deDuplicate.standardStringEnrichments.anotherEnrichment` etc.