### PR TITLE
Fix/mdl mapping

### DIFF
--- a/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
@@ -63,10 +63,10 @@ object IngestRemap {
 
     // Json-l
     logger.info(s"Saving JSON-L output to: $jsonlDataOut")
-    executeJsonL(sparkConf, mapDataOut, jsonlDataOut, logger)
+    executeJsonL(sparkConf, enrichDataOut, jsonlDataOut, logger)
 
     // Reports
-//    executeAllReports(sparkConf, mapDataOut, baseRptOut, logger)
+    executeAllReports(sparkConf, enrichDataOut, baseRptOut, logger)
 
     logger.info("Ingest remapping complete")
   }

--- a/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
@@ -55,7 +55,7 @@ object IngestRemap {
     // TODO These processes should return some flag or metric to help determine whether to proceed
     // Mapping
     logger.info(s"Saving mapping output to: $mapDataOut")
-    executeMapping(sparkConf, harvestDataOut, mapDataOut, shortName, logger)
+     executeMapping(sparkConf, harvestDataOut, mapDataOut, shortName, logger)
 
     // Enrichment
     logger.info(s"Saving enrichment output to: $enrichDataOut")
@@ -63,10 +63,10 @@ object IngestRemap {
 
     // Json-l
     logger.info(s"Saving JSON-L output to: $jsonlDataOut")
-    executeJsonL(sparkConf, enrichDataOut, jsonlDataOut, logger)
+    executeJsonL(sparkConf, mapDataOut, jsonlDataOut, logger)
 
     // Reports
-    executeAllReports(sparkConf, enrichDataOut, baseRptOut, logger)
+//    executeAllReports(sparkConf, mapDataOut, baseRptOut, logger)
 
     logger.info("Ingest remapping complete")
   }

--- a/src/main/scala/dpla/ingestion3/entries/ingest/MappingEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/MappingEntry.scala
@@ -181,8 +181,7 @@ object MappingEntry {
         (RowConverter.toRow(dplaMapData, model.sparkSchema), null)
       case Failure(exception) =>
         failureCount.add(1)
-        (null, s"${exception.getMessage}\n" +
-               s"${exception.getStackTrace.mkString("\n")}")
+        (null, s"${exception.getMessage}")
     }
   }
 

--- a/src/main/scala/dpla/ingestion3/mappers/json/JsonExtractionUtils.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/json/JsonExtractionUtils.scala
@@ -48,10 +48,10 @@ trait JsonExtractionUtils {
     *
     */
   def extractStrings(jValue: JValue): Seq[String] = jValue match {
-    case JArray(array) => array.flatMap(entry => extractString(entry)).distinct
-    case JObject(fields) => fields.flatMap({case (_, value) => extractString(value)}).distinct
+    case JArray(array) => array.flatMap(entry => extractString(entry))
+    case JObject(fields) => fields.flatMap({case (_, value) => extractString(value)})
     case _ => extractString(jValue) match {
-      case Some(stringValue) => Seq(stringValue).distinct
+      case Some(stringValue) => Seq(stringValue)
       case None => Seq()
     }
   }

--- a/src/main/scala/dpla/ingestion3/mappers/json/JsonExtractionUtils.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/json/JsonExtractionUtils.scala
@@ -48,10 +48,10 @@ trait JsonExtractionUtils {
     *
     */
   def extractStrings(jValue: JValue): Seq[String] = jValue match {
-    case JArray(array) => array.flatMap(entry => extractString(entry))
-    case JObject(fields) => fields.flatMap({case (_, value) => extractString(value)})
+    case JArray(array) => array.flatMap(entry => extractString(entry)).distinct
+    case JObject(fields) => fields.flatMap({case (_, value) => extractString(value)}).distinct
     case _ => extractString(jValue) match {
-      case Some(stringValue) => Seq(stringValue)
+      case Some(stringValue) => Seq(stringValue).distinct
       case None => Seq()
     }
   }
@@ -71,4 +71,18 @@ trait JsonExtractionUtils {
     case _ => None
   }
 
+
+  /**
+    * Wraps the JValue in JArray if it is not already a JArray
+    * Addresses the problem of inconsistent data types in value field.
+    * e.g. '"prop": ["val1"]' vs '"prop": "val1"'
+    *
+    * @param jvalue
+    * @return
+    */
+  def iterify(jvalue: JValue): JArray = jvalue match {
+    case JArray(j) => JArray(j)
+    case JNothing => JArray(List())
+    case _ => JArray(List(jvalue))
+  }
 }

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MdlExtractor.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MdlExtractor.scala
@@ -5,10 +5,9 @@ import java.net.URI
 import dpla.ingestion3.mappers.json.JsonExtractionUtils
 import dpla.ingestion3.model.DplaMapData.{ExactlyOne, ZeroToMany}
 import dpla.ingestion3.model.{DplaSourceResource, EdmWebResource, OreAggregation, _}
-import org.json4s.JsonAST.JArray
+import org.json4s.JsonDSL._
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
-import org.json4s.JsonDSL._
 
 import scala.util.Try
 
@@ -30,12 +29,15 @@ class MdlExtractor(rawData: String, shortName: String) extends Extractor with Js
         sidecar = ("prehashId", buildProviderBaseId()) ~
                   ("dplaId", mintDplaId()),
         sourceResource = DplaSourceResource(
-          collection = collection(json \\ "record" \ "sourceResource" \ "collection"),
+          // There is inconsistent quality between originalRecord.collection and sourceResource.collection
+          // It is not clear why but someimtes OR has title and desc but SR only has title and vice versa
+          collection = collection(json \ "record" \ "sourceResource" \ "collection"), // TODO confirm this mapping
           contributor = extractStrings(json \\ "record" \ "sourceResource" \ "contributor").map(nameOnlyAgent),
           creator = extractStrings(json \\ "record" \ "sourceResource" \ "creator").map(nameOnlyAgent),
           date = date(json \\ "record" \ "sourceResource" \ "date"),
           description = extractStrings(json \\ "record" \ "sourceResource" \ "description"),
-          format = extractStrings(json \\ "record" \ "sourceResource" \ "format"), // FIXME
+          extent = extractStrings(json \\ "record" \\ "extent"),
+          format = extractStrings(json \\ "record" \ "sourceResource" \ "format"),
           genre = extractStrings(json \\ "record" \ "sourceResource" \ "type").map(nameOnlyConcept),
           language = extractStrings(json \\ "record" \ "sourceResource" \ "language" \ "iso636_3").map(nameOnlyConcept)
             ++ extractStrings(json \\ "record" \ "sourceResource" \ "language" \ "name").map(nameOnlyConcept),
@@ -44,7 +46,7 @@ class MdlExtractor(rawData: String, shortName: String) extends Extractor with Js
           rights = extractStrings(json \\ "record" \ "sourceResource" \ "rights"),
           subject = extractStrings(json \\ "record" \ "sourceResource" \ "subject" \ "name").map(nameOnlyConcept),
           title = extractStrings(json \\ "record" \ "sourceResource" \ "title"),
-          `type` = extractStrings(json \\ "record" \ "sourceResource" \ "type") // FIXME
+          `type` = extractType // FIXME
         ),
         dataProvider = dataProvider(json \\ "record" \ "dataProvider"),
         originalRecord = rawData,
@@ -55,16 +57,11 @@ class MdlExtractor(rawData: String, shortName: String) extends Extractor with Js
     }
   }
 
-
-  def wrapJValue(jvalue: JValue): JArray = jvalue match {
-    case JObject(obj) => JArray(List(obj))
-    case _ => JArray(List())
-  }
-
   def collection(collection: JValue): ZeroToMany[DcmiTypeCollection] = {
-    wrapJValue(collection).children.map(c => {
+    iterify(collection).children.map(c => {
       DcmiTypeCollection(
-        // This is incongruent with MAPv4 spec but aligns with ingest1 spec
+        // TODO confirm this mapping
+        // Example http://hub-client.lib.umn.edu/api/v1/records?q=32dc110dae8fa8471178e5fbfe5546446dcef7ec
         title = extractString(c \\ "title"),
         description = extractString(c \\ "description")
       )})
@@ -84,7 +81,7 @@ class MdlExtractor(rawData: String, shortName: String) extends Extractor with Js
   }
 
   def date(date: JValue): ZeroToMany[EdmTimeSpan] = {
-    wrapJValue(date).children.map(d =>
+    iterify(date).children.map(d =>
       EdmTimeSpan(
         begin = extractString(d \ "begin"),
         end = extractString(d \ "end"),
@@ -92,11 +89,23 @@ class MdlExtractor(rawData: String, shortName: String) extends Extractor with Js
       ))
   }
 
+  def extractType(): ZeroToMany[String] = {
+//    if not getprop(self.mapped_data, "sourceResource/type", True):
+//      object_id = getprop(self.provider_data, "sourceResource/object", True)
+//    if object_id:
+//      self.update_source_resource({"type": "image"}
+    extractStrings(json \\ "record" \ "sourceResource" \ "type") // FIXME see DCMI type enrichment
+  }
+
   def place(place: JValue): ZeroToMany[DplaPlace] = {
-    wrapJValue(place).children.map(p =>
+    iterify(place).children.map(p =>
       DplaPlace(
-        name = extractString(p \\ "name"),
-        coordinates = extractString(p \\ "coordinates")
+        // head is used b/c name and coordinate values can be string or arrays in original data
+        // TODO Is there a cleaner way to handle this case in JsonExtractionUtils extractString method?
+        // See http://cqa-pa.internal.dp.la:8080/qa/compare?id=cfa88467c38a5fa871252c7e0a76962d
+        // vs http://cqa-pa.internal.dp.la:8080/v2/items/8905a0065622a217b0d929cef3f62246?api_key=
+        name = extractStrings(p \\ "name").headOption,
+        coordinates = extractStrings(p \\ "coordinates").headOption
       ))
   }
 

--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -101,7 +101,10 @@ package object model {
           ("@id" ->
             (record.dplaUri.toString + "#SourceResource")) ~
           ("collection" ->
-            record.sourceResource.collection.map {c => "title" -> c.title}) ~
+            record.sourceResource.collection.map {c =>
+              ("title" -> c.title) ~
+              ("description" -> c.description)
+            }) ~
           ("contributor" -> record.sourceResource.contributor.map{c => c.name}) ~
           ("creator" -> record.sourceResource.creator.map{c => c.name}) ~
           ("date" ->
@@ -116,9 +119,10 @@ package object model {
           ("identifier" -> record.sourceResource.identifier) ~
           ("language" ->
             record.sourceResource.language.map { lang =>
-              "name" -> lang.concept.getOrElse(
-                          lang.providedLabel.getOrElse(""))
-               // FIXME what other SkosConcept fields do we need in the index for language?
+              ("name" -> lang.concept.getOrElse(
+                          lang.providedLabel.getOrElse(""))) ~
+              ("iso639_3" -> lang.providedLabel.getOrElse(""))
+              // FIXME what other SkosConcept fields do we need in the index for language?
             }) ~
           ("publisher" -> record.sourceResource.publisher.map{p => p.name}) ~
           ("relation" ->

--- a/src/test/scala/dpla/ingestion3/model/JsonlStringTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/JsonlStringTest.scala
@@ -37,7 +37,7 @@ class JsonlStringTest extends FlatSpec {
     val collection = jvalue \ "_source" \ "sourceResource" \ "collection"
     assert(collection.isInstanceOf[JArray])
     assert(
-      compact(render(collection(0))) == "{\"title\":\"The Collection\"}"
+      compact(render(collection(0))) == "{\"title\":\"The Collection\",\"description\":\"The Archives of Some Department, U. of X\"}"
     )
   }
 


### PR DESCRIPTION
* Mapping error no longer include full stacktrace
* A number of initial mapping fixes for MDL 
* extractStrings() in JsonExtractionUtils now returns unique values
* Add iterify() method to JsonExtractionUtils to ensure that all JValues are wrapped in a JArray
* Add collection.description and language.iso_639_3 properties to JSON-L export