### PR TITLE
Ohio mapping fixes

### DIFF
--- a/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
@@ -43,7 +43,16 @@ class EnrichmentDriver(conf: i3Conf) extends Serializable {
       sourceResource = enriched.sourceResource.copy(
         date = enriched.sourceResource.date.map(d => dateEnrichment.parse(d)),
         language = enriched.sourceResource.language.map(l => LanguageMapper.mapLanguage(l)),
-        place = enriched.sourceResource.place.map(p => spatialEnrichment.enrich(p))
+        place = enriched.sourceResource.place.map(p => spatialEnrichment.enrich(p)),
+        `type` = enriched.sourceResource.`type`.map(t => {
+          // Cast original type value to lower case and map it to DCMIType IRIs (@see DcmiTypeMap).
+          // If it can be mapped to a valid DCMIType IRI then lookup the local label for that IRI
+          // and then convert label to lower case.
+            DcmiTypeMapper.mapDcmiType(t.toLowerCase) match {
+              case Some(typeIri) => DcmiTypeStringMapper.mapDcmiTypeString(typeIri).toLowerCase
+            }
+          }
+        )
       ))
   }
 

--- a/src/main/scala/dpla/ingestion3/enrichments/StringUtils.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/StringUtils.scala
@@ -8,8 +8,6 @@ import org.jsoup.safety.Whitelist
 
 import scala.util.matching.Regex
 
-import util.control.Breaks._
-
 /**
   * String enrichments
   *
@@ -49,9 +47,10 @@ object StringUtils {
       * @return
       */
     val findAndRemoveAll: Set[String] => String = (stopWords) => {
+      // FIXME this is a case sensitive operation.
       value.splitAtDelimiter(" ")
         .filterNot(stopWords)
-           .filter(_.nonEmpty)
+        .filter(_.nonEmpty)
         .mkString(" ")
     }
 

--- a/src/main/scala/dpla/ingestion3/enrichments/StringUtils.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/StringUtils.scala
@@ -96,26 +96,28 @@ object StringUtils {
       */
     val capitalizeFirstChar: SingleStringEnrichment = {
       val charIndex = findFirstChar(value)
-      replaceCharAt(value, charIndex, value.charAt(charIndex).toUpper )
+      if (charIndex >= 0)
+        replaceCharAt(value, charIndex, value.charAt(charIndex).toUpper )
+      else
+        value
     }
 
-    private def replaceCharAt(s: String, pos: Int, c: Char): String =
-      s.substring(0, pos) + c + s.substring(pos + 1)
+    /**
+      * Replaces the character at the specified index in s with c
+      * @param s String value
+      * @param pos Index
+      * @param c New char
+      * @return A new String with Char c at index pos
+      */
+    private def replaceCharAt(s: String, pos: Int, c: Char): String = s.substring(0, pos) + c + s.substring(pos + 1)
 
     /**
-      * Iterates over the string to find the first alphanumeric char and returns the index
+      * Iterates over the string to find the first alphanumeric char
+      * and returns the index
+      *
       * @param str
       * @return
       */
-    private def findFirstChar(str: String): Int = {
-      var iter = 0
-      breakable {
-        str.foreach(chr => {
-          if(chr.isLetterOrDigit) break
-          else iter = iter + 1
-        })
-      }
-      iter
-    }
+    private def findFirstChar(str: String): Int = str.indexWhere(_.isLetterOrDigit)
   }
 }

--- a/src/main/scala/dpla/ingestion3/enrichments/StringUtils.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/StringUtils.scala
@@ -8,6 +8,8 @@ import org.jsoup.safety.Whitelist
 
 import scala.util.matching.Regex
 
+import util.control.Breaks._
+
 /**
   * String enrichments
   *
@@ -42,10 +44,22 @@ object StringUtils {
     }
 
     /**
+      * Removes all target strings from the source string
+      *
+      * @return
+      */
+    val findAndRemoveAll: Set[String] => String = (stopWords) => {
+      value.splitAtDelimiter(" ")
+        .filterNot(stopWords)
+           .filter(_.nonEmpty)
+        .mkString(" ")
+    }
+
+    /**
       * Splits a String value around a given delimiter.
       */
     val splitAtDelimiter: (String) => Array[String] = (delimiter) => {
-      value.split(delimiter).map(_.trim)
+      value.split(delimiter).map(_.trim).filter(_.nonEmpty)
     }
 
     val stripEndingPunctuation: SingleStringEnrichment = {
@@ -68,6 +82,40 @@ object StringUtils {
 
     val reduceWhitespace: SingleStringEnrichment = {
       value.replaceAll("  ", " ")
+    }
+
+    /**
+      * Find and capitalize the first character in a given string
+      *
+      * 3 blind mice -> 3 blind mice
+      * three blind mice -> Three blind mice.
+      * ...vacationland... -> ...Vacationland...
+      *   The first bike ->   The first bike
+      *
+      * @return
+      */
+    val capitalizeFirstChar: SingleStringEnrichment = {
+      val charIndex = findFirstChar(value)
+      replaceCharAt(value, charIndex, value.charAt(charIndex).toUpper )
+    }
+
+    private def replaceCharAt(s: String, pos: Int, c: Char): String =
+      s.substring(0, pos) + c + s.substring(pos + 1)
+
+    /**
+      * Iterates over the string to find the first alphanumeric char and returns the index
+      * @param str
+      * @return
+      */
+    private def findFirstChar(str: String): Int = {
+      var iter = 0
+      breakable {
+        str.foreach(chr => {
+          if(chr.isLetterOrDigit) break
+          else iter = iter + 1
+        })
+      }
+      iter
     }
   }
 }

--- a/src/main/scala/dpla/ingestion3/enrichments/VocabEnforcer.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/VocabEnforcer.scala
@@ -25,10 +25,10 @@ trait VocabEnforcer[T] {
     * in an external vocabulary returning the preferred form.
     */
   val matchToSkosVocab: (SkosConcept, Map[SkosConcept,SkosConcept]) => SkosConcept = (originalValue, skosVocab) => {
-    val enrichedLexvo = skosVocab.getOrElse(originalValue, originalValue)
+    // convert to lower case
+    val lcOrigingalValue = originalValue.copy(providedLabel = Option(originalValue.providedLabel.get.toLowerCase))
+    val enrichedLexvo = skosVocab.getOrElse(lcOrigingalValue, originalValue)
 
-    // TODO: Are these the correct mappings?
-    // TODO: should properties like exactMatch, closeMatch and note be set? If so with what?
     // If the lookup performed above returned a match then we need to merge the providedLabel value
     // from originalValue with the enriched concept and scheme values. If no match was found these
     // step are essentially no-ops (setting None values).
@@ -68,56 +68,58 @@ object DcmiTypeMapper extends VocabEnforcer[String] {
   val dcmiType = DCMIType()
 
   val DcmiTypeMap: Map[String, IRI] = Map(
-    "image" -> dcmiType.Image,
-    "photograph" -> dcmiType.Image,
-    "sample book" -> dcmiType.Image,
-    "specimen" -> dcmiType.Image,
-    "textile" -> dcmiType.Image,
-    "frame" -> dcmiType.Image,
-    "costume" -> dcmiType.Image,
-    "statue" -> dcmiType.Image,
-    "sculpture" -> dcmiType.Image,
+    "appliance" -> dcmiType.Image,
+    "audio" -> dcmiType.Sound,
+    "book" -> dcmiType.Text,
+    "cartographic" -> dcmiType.Image,
     "container" -> dcmiType.Image,
-    "jewelry" -> dcmiType.Image,
+    "correspondence" -> dcmiType.Text,
+    "costume" -> dcmiType.Image,
+    "drawing" -> dcmiType.Image,
+    "electronic component" -> dcmiType.Image,
+    "electronic resource" -> dcmiType.InteractiveResource,
+    "equipment" -> dcmiType.Image,
+    "film" -> dcmiType.MovingImage,
+    "finding aid" -> dcmiType.Collection,
+    "frame" -> dcmiType.Image,
     "furnishing" -> dcmiType.Image,
     "furniture" -> dcmiType.Image,
-    "drawing" -> dcmiType.Image,
-    "print" -> dcmiType.Image,
-    "painting" -> dcmiType.Image,
     "illumination" -> dcmiType.Image,
-    "poster" -> dcmiType.Image,
-    "appliance" -> dcmiType.Image,
-    "tool" -> dcmiType.Image,
-    "electronic component" -> dcmiType.Image,
-    "postcard" -> dcmiType.Image,
-    "equipment" -> dcmiType.Image,
-    "cartographic" -> dcmiType.Image,
-    "notated music" -> dcmiType.Image,
-    "mixed material" -> dcmiType.Image,
-    "text" -> dcmiType.Text,
-    "book" -> dcmiType.Text,
-    "publication" -> dcmiType.Text,
-    "magazine" -> dcmiType.Text,
+    "image" -> dcmiType.Image,
+    "jewelry" -> dcmiType.Image,
     "journal" -> dcmiType.Text,
-    "correspondence" -> dcmiType.Text,
-    "writing" -> dcmiType.Text,
-    "written" -> dcmiType.Text,
+    "magazine" -> dcmiType.Text,
     "manuscript" -> dcmiType.Text,
-    "online text" -> dcmiType.Text,
-    "audio" -> dcmiType.Sound,
-    "sound" -> dcmiType.Sound,
-    "oral history recording" -> dcmiType.Sound,
-    "finding aid" -> dcmiType.Collection,
-    "online collection" -> dcmiType.Collection,
-    "electronic resource" -> dcmiType.InteractiveResource,
-    "video game" -> dcmiType.InteractiveResource,
-    "online exhibit" -> dcmiType.InteractiveResource,
-    "moving image" -> dcmiType.MovingImage,
-    "movingimage" -> dcmiType.MovingImage, // TODO: this looks like a typo...
+    "mixed material" -> dcmiType.Image,
     "motion picture" -> dcmiType.MovingImage,
-    "film" -> dcmiType.MovingImage,
+    "moving image" -> dcmiType.MovingImage,
+    "movingimage" -> dcmiType.MovingImage,
+    "notated music" -> dcmiType.Image,
+    "object" -> dcmiType.PhysicalObject,
+    "online collection" -> dcmiType.Collection,
+    "online exhibit" -> dcmiType.InteractiveResource,
+    "online text" -> dcmiType.Text,
+    "oral history recording" -> dcmiType.Sound,
+    "painting" -> dcmiType.Image,
+    "photograph" -> dcmiType.Image,
+    "physicalobject" -> dcmiType.PhysicalObject,
+    "postcard" -> dcmiType.Image,
+    "poster" -> dcmiType.Image,
+    "print" -> dcmiType.Image,
+    "publication" -> dcmiType.Text,
+    "sample book" -> dcmiType.Image,
+    "sculpture" -> dcmiType.Image,
+    "sound" -> dcmiType.Sound,
+    "specimen" -> dcmiType.Image,
+    "statue" -> dcmiType.Image,
+    "stillimage" -> dcmiType.StillImage,
+    "text" -> dcmiType.Text,
+    "textile" -> dcmiType.Image,
+    "tool" -> dcmiType.Image,
+    "video game" -> dcmiType.InteractiveResource,
     "video" -> dcmiType.MovingImage,
-    "object" -> dcmiType.PhysicalObject
+    "writing" -> dcmiType.Text,
+    "written" -> dcmiType.Text
   )
 
   val mapDcmiType: (String) => Option[IRI] = mapVocab(_, DcmiTypeMap)
@@ -149,15 +151,15 @@ object LanguageMapper extends VocabEnforcer[String] {
   // Create the language lookup map
   val iso639Map = {
     // TODO: Make the path to the ISO data file configurable
+    // TODO: Find a clearer way to write the parsing of that file
+    // TODO: Does additional data need to be read in to more completely instantiate these objects?
     readFile("/iso-639-3.tab")
-      // TODO: Find a clearer way to write the parsing of that file
       .map(_.split("\t"))
-      .map(f = f => {
-        // TODO: Does additional data need to be read in to more completely instantiate these objects?
-        val languageAbbv = Option(f(0))
-        val languageTerm = Option(f(1))
-        val schemeUri = Option(new URI("http://lexvo.org/id/iso639-3/"))
-        // Create a tuple >> (SkosConcept(abbv), SkosConcept(term, scheme)) that will be used to perform
+      .map(f => {
+        val languageAbbv = Some(f(0))
+        val languageTerm = Some(f(1))
+        val schemeUri = Some(new URI("http://lexvo.org/id/iso639-3/"))
+        // Create a tuple >> (SkosConcept(Some("eng")), SkosConcept(term, scheme)) that will be used to perform
         // lookups when enriching a value
         (SkosConcept(providedLabel = languageAbbv), SkosConcept(concept = languageTerm, scheme = schemeUri))
       })

--- a/src/main/scala/dpla/ingestion3/entries/reports/ReporterMain.scala
+++ b/src/main/scala/dpla/ingestion3/entries/reports/ReporterMain.scala
@@ -25,6 +25,7 @@ object ReporterMain {
     "sourceResource.genre",
     "sourceResource.identifier",
     "sourceResource.language.providedLabel",
+    "sourceResource.language.concept",
     "sourceResource.place.name",
     "sourceResource.publisher.name",
     "sourceResource.relation",

--- a/src/main/scala/dpla/ingestion3/mappers/providers/Extractor.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/Extractor.scala
@@ -1,5 +1,6 @@
 package dpla.ingestion3.mappers.providers
 
+import java.io
 import java.net.URI
 
 import dpla.ingestion3.model.{EdmAgent, OreAggregation}
@@ -17,6 +18,19 @@ trait Extractor {
 
   def build(): Try[OreAggregation]
   def agent: EdmAgent
+
+  /**
+    *
+    * @param stringUri
+    * @return
+    */
+  def createUri(stringUri: String): URI = {
+    Try { new URI(stringUri) } match {
+      case Success(uri) => uri
+      case Failure(_) => throw new RuntimeException(s"Invalid URI $stringUri in ${getProviderId()} ")
+    }
+  }
+
 
   /**
     * Does the provider use a prefix (typically their provider abbreviation) to

--- a/src/main/scala/dpla/ingestion3/mappers/providers/OhioExtractor.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/OhioExtractor.scala
@@ -19,8 +19,8 @@ class OhioExtractor(rawData: String, shortName: String) extends Extractor with X
 
   // These values will be stripped out of the format field
   // FIXME Regex to ignore/include punctuation?
-  private val formatsToRemove = Set("application/pdf", "audio/mpeg", "Charset=ISO-8859-1", "Charset=iso-8859-1",
-    "charset=UTF-8", "charset=utf-8", "Charset=windows-1252", "HTML", "image/jp2", "image/jpeg", "image/jpg",
+  private val formatsToRemove = Set("application/pdf", "audio/mpeg", "charset=ISO-8859-1", "charset=iso-8859-1",
+    "charset=UTF-8", "charset=utf-8", "charset=windows-1252", "HTML", "image/jp2", "image/jpeg", "image/jpg",
     "image/png", "image/tiff", "JPEG 2000", "jpeg", "jpeg2000", "JPEG2000", "jpg", "mp3", "PDF", "pdf", "text/html",
     "text/pdf", "tif", "video/jpeg", "video/jpeg2000", "video/mp4", "video/mpeg")
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/OhioExtractor.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/OhioExtractor.scala
@@ -19,10 +19,10 @@ class OhioExtractor(rawData: String, shortName: String) extends Extractor with X
 
   // These values will be stripped out of the format field
   // FIXME Regex to ignore/include punctuation?
-  private val formatsToRemove = Set("jpg", "application/pdf", "image/jpeg", "image/jp2", "pdf", "video/jpeg",
-    "tif", "image/tiff", "video/jpeg2000", "HTML", "JPEG2000", "text/html", "audio/mpeg", "JPEG 2000", "image/jpg",
-    "jpeg2000", "charset=UTF-8", "charset=utf-8", "mp3", "video/mp4", "video/mpeg", "PDF", "image/png", "jpeg",
-    "text/pdf")
+  private val formatsToRemove = Set("application/pdf", "audio/mpeg", "Charset=ISO-8859-1", "Charset=iso-8859-1",
+    "charset=UTF-8", "charset=utf-8", "Charset=windows-1252", "HTML", "image/jp2", "image/jpeg", "image/jpg",
+    "image/png", "image/tiff", "JPEG 2000", "jpeg", "jpeg2000", "JPEG2000", "jpg", "mp3", "PDF", "pdf", "text/html",
+    "text/pdf", "tif", "video/jpeg", "video/jpeg2000", "video/mp4", "video/mpeg")
 
   // ID minting functions
   override def useProviderName(): Boolean = false

--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -118,11 +118,18 @@ package object model {
           ("format" -> record.sourceResource.format) ~
           ("identifier" -> record.sourceResource.identifier) ~
           ("language" ->
+            // FIXME The SkosConcept object needs refinement in MAP5.1 to address some of the modeling issues
+            // 1. Tracking ISO-639 term abbreviations
+            // 2. Recording ISO-639 term labels
+            // 3. Recording unenriched original value
             record.sourceResource.language.map { lang =>
+              // If lang was enriched then the concept property has been set and it should be mapped to the name
+              // property in ElasticSearch. If the lang value could not be enriched then use the original provided
+              // value. Always map the enriched concept label to the iso639_3 field.
               ("name" -> lang.concept.getOrElse(
-                          lang.providedLabel.getOrElse(""))) ~
-              ("iso639_3" -> lang.providedLabel.getOrElse(""))
-              // FIXME what other SkosConcept fields do we need in the index for language?
+                lang.providedLabel.getOrElse("")
+              )) ~
+              ("iso639_3" -> lang.concept)
             }) ~
           ("publisher" -> record.sourceResource.publisher.map{p => p.name}) ~
           ("relation" ->

--- a/src/main/scala/dpla/ingestion3/reports/PropertyDistinctValueReport.scala
+++ b/src/main/scala/dpla/ingestion3/reports/PropertyDistinctValueReport.scala
@@ -108,6 +108,10 @@ class PropertyDistinctValueReport(
         ds.map(dplaMapData => PropertyDistinctValueRpt(extractValue(dplaMapData.sourceResource.identifier)))
       case "sourceResource.language.providedLabel" =>
         ds.map(dplaMapData => PropertyDistinctValueRpt(extractValue(dplaMapData.sourceResource.language)))
+      // Special mapping for concept
+      case "sourceResource.language.concept" =>
+        ds.map(dplaMapData => PropertyDistinctValueRpt(dplaMapData.sourceResource.language.map(l =>
+          l.concept.getOrElse("__MISSING SkosConcept.concept__"))))
       case "sourceResource.place.name" =>
         ds.map(dplaMapData => PropertyDistinctValueRpt(extractValue(dplaMapData.sourceResource.place)))
       case "sourceResource.publisher.name" =>

--- a/src/main/scala/dpla/ingestion3/reports/PropertyValueReport.scala
+++ b/src/main/scala/dpla/ingestion3/reports/PropertyValueReport.scala
@@ -173,6 +173,15 @@ class PropertyValueReport (
             value = extractValue(oreAggregation.sourceResource.language)
           )
         })
+      case "sourceResource.language.concept" =>
+        ds.map(oreAggregation => {
+          PropertyValueRpt(
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.uri.toString,
+            value = oreAggregation.sourceResource.language.map(l =>
+              l.concept.getOrElse("__MISSING SkosConcept.concept__"))
+          )
+        })
       case "sourceResource.place.name" =>
         ds.map(oreAggregation => {
           PropertyValueRpt(

--- a/src/main/scala/dpla/ingestion3/utils/Utils.scala
+++ b/src/main/scala/dpla/ingestion3/utils/Utils.scala
@@ -1,6 +1,7 @@
 package dpla.ingestion3.utils
 
 import java.io.{File, PrintWriter}
+import java.net.URL
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.concurrent.TimeUnit
@@ -8,6 +9,7 @@ import java.util.concurrent.TimeUnit
 import dpla.ingestion3.confs.i3Conf
 import org.apache.log4j.{FileAppender, LogManager, Logger, PatternLayout}
 
+import scala.util.Try
 import scala.xml.Node
 
 
@@ -130,6 +132,14 @@ object Utils {
     s"Throughput: ${Utils.formatNumber(recordsPerSecond)} records per second"
   }
 
+  /**
+    * Tries to create a URL object from the string
+    *
+    * @param url String url
+    * @return True if a URL object can be made from url
+    *         False if it fails (malformed url, invalid characters, not a url)
+    */
+  def isUrl(url: String): Boolean = Try {new URL(url) }.isSuccess
 
   /**
     * Print mapping summary information

--- a/src/test/scala/dpla/ingestion3/data/MappedRecordsFixture.scala
+++ b/src/test/scala/dpla/ingestion3/data/MappedRecordsFixture.scala
@@ -27,7 +27,8 @@ object MappedRecordsFixture {
         scheme = None,
         exactMatch = Seq(),
         closeMatch = Seq())
-      )
+      ),
+      `type` = Seq("audio")
     )
   )
 }

--- a/src/test/scala/dpla/ingestion3/enrichments/EnrichmentDriverTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/EnrichmentDriverTest.scala
@@ -20,23 +20,15 @@ class EnrichmentDriverTest extends FlatSpec with BeforeAndAfter {
         prefLabel = Some("2012-05-07"),
         originalSourceDate = Some("5.7.2012")
       )),
-      language = Seq(SkosConcept(
-
-        /*
-         * FIXME: I think that providedLabel and concept are reversed.
-         * Concept is supposed to be the "The preferred form of the name of the
-         * concept," per
-         * http://dp.la/info/wp-content/uploads/2015/03/MAPv4.pdf
-         * Provided label is what the provider gave us. The language code is
-         * not "English", it's "eng", according to
-         * http://www.lexvo.org/page/term/eng/English
-         */
-        providedLabel = Some("eng"),
-        concept = Some("English"),
-        scheme = Some(new URI("http://lexvo.org/id/iso639-3/")))
-
+      language = Seq(
+        SkosConcept(
+          providedLabel = Some("eng"),
+          concept = Some("English")
+        )
+      ),
+      `type` = Seq("sound")
       )
-    ))
+    )
 
     val enrichedRecord = driver.enrich(MappedRecordsFixture.mappedRecord)
 

--- a/src/test/scala/dpla/ingestion3/enrichments/StringUtilsTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/StringUtilsTest.scala
@@ -119,23 +119,30 @@ class StringUtilsTest extends FlatSpec with BeforeAndAfter {
     val enrichedValue = originalValue.capitalizeFirstChar
     assert(enrichedValue === "3 blind mice")
   }
-
   it should "capitalize the t in three blind mice" in {
     val originalValue = "three blind mice"
     val enrichedValue = originalValue.capitalizeFirstChar
     assert(enrichedValue === "Three blind mice")
   }
-
   it should "capitalize the v in ...vacationland..." in {
     val originalValue = "...vacationland..."
     val enrichedValue = originalValue.capitalizeFirstChar
     assert(enrichedValue === "...Vacationland...")
   }
-
   it should "capitalize the t in '  telephone'" in {
     val originalValue = "  telephone"
     val enrichedValue = originalValue.capitalizeFirstChar
     assert(enrichedValue === "  Telephone")
+  }
+  it should "not capitalize anything in a string with alphanumeric characters" in {
+    val originalValue = "...@..|}"
+    val enrichedValue = originalValue.capitalizeFirstChar
+    assert(enrichedValue === "...@..|}")
+  }
+  it should "not capitalize anything in an empty string" in {
+    val originalValue = ""
+    val enrichedValue = originalValue.capitalizeFirstChar
+    assert(enrichedValue === "")
   }
 
   "findAndRemoveAll" should "remove all stop words from the given string" in {

--- a/src/test/scala/dpla/ingestion3/enrichments/StringUtilsTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/StringUtilsTest.scala
@@ -22,6 +22,14 @@ class StringUtilsTest extends FlatSpec with BeforeAndAfter {
     assert(enrichedValue === expectedValue)
   }
 
+  "splitAtDelimiter" should "drop empty values" in {
+    val originalValue = "subject-one; ; subject-three"
+    val enrichedValue = originalValue.splitAtDelimiter(";")
+    val expectedValue = Array("subject-one", "subject-three")
+
+    assert(enrichedValue === expectedValue)
+  }
+
   "splitAtDelimiter" should "split a string around comma." in {
     val originalValue = "subject-one, subject-two; subject-three"
     val enrichedValue = originalValue.splitAtDelimiter(",")
@@ -106,4 +114,34 @@ class StringUtilsTest extends FlatSpec with BeforeAndAfter {
     assert(enrichedValue === "foo bar")
   }
 
+  "capitalizeFirstChar" should "not capitalize the b in 3 blind mice because it is preceded by 3" in {
+    val originalValue = "3 blind mice"
+    val enrichedValue = originalValue.capitalizeFirstChar
+    assert(enrichedValue === "3 blind mice")
+  }
+
+  it should "capitalize the t in three blind mice" in {
+    val originalValue = "three blind mice"
+    val enrichedValue = originalValue.capitalizeFirstChar
+    assert(enrichedValue === "Three blind mice")
+  }
+
+  it should "capitalize the v in ...vacationland..." in {
+    val originalValue = "...vacationland..."
+    val enrichedValue = originalValue.capitalizeFirstChar
+    assert(enrichedValue === "...Vacationland...")
+  }
+
+  it should "capitalize the t in '  telephone'" in {
+    val originalValue = "  telephone"
+    val enrichedValue = originalValue.capitalizeFirstChar
+    assert(enrichedValue === "  Telephone")
+  }
+
+  "findAndRemoveAll" should "remove all stop words from the given string" in {
+    val stopWords = Set("jp2", "application/xml")
+    val originalValue = "application/xml photograph   jp2"
+    val enrichedValue = originalValue.findAndRemoveAll(stopWords)
+    assert(enrichedValue === "photograph")
+  }
 }

--- a/src/test/scala/dpla/ingestion3/enrichments/VocabEnforcerTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/VocabEnforcerTest.scala
@@ -60,6 +60,20 @@ class VocabEnforcerTest extends FlatSpec with BeforeAndAfter {
     assert(enrichedValue === expectedValue)
   }
 
+  it should " an enriched SkosConcept object when given a valid iso-639 regardless of case" +
+    "abbreviation" in {
+    val originalValue = Seq(SkosConcept(providedLabel = Option("ENG")))
+    val expectedValue = Seq(SkosConcept(
+      providedLabel = Option("ENG"),
+      concept = Option("English"),
+      scheme = Option(new URI("http://lexvo.org/id/iso639-3/"))
+    ))
+
+    val enrichedValue = originalValue.map(LanguageMapper.mapLanguage)
+
+    assert(enrichedValue === expectedValue)
+  }
+
   it should "return an unenriched SkosConcept object when given a invalid iso-639 " +
     "abbreviation. E.g. the return value should match the original value" in {
     val originalValue = SkosConcept(providedLabel = Option("b__"))

--- a/src/test/scala/dpla/ingestion3/enrichments/VocabEnforcerTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/VocabEnforcerTest.scala
@@ -51,8 +51,7 @@ class VocabEnforcerTest extends FlatSpec with BeforeAndAfter {
     val originalValue = Seq(SkosConcept(providedLabel = Option("eng")))
     val expectedValue = Seq(SkosConcept(
       providedLabel = Option("eng"),
-      concept = Option("English"),
-      scheme = Option(new URI("http://lexvo.org/id/iso639-3/"))
+      concept = Option("English")
     ))
 
     val enrichedValue = originalValue.map(LanguageMapper.mapLanguage)
@@ -65,8 +64,7 @@ class VocabEnforcerTest extends FlatSpec with BeforeAndAfter {
     val originalValue = Seq(SkosConcept(providedLabel = Option("ENG")))
     val expectedValue = Seq(SkosConcept(
       providedLabel = Option("ENG"),
-      concept = Option("English"),
-      scheme = Option(new URI("http://lexvo.org/id/iso639-3/"))
+      concept = Option("English")
     ))
 
     val enrichedValue = originalValue.map(LanguageMapper.mapLanguage)

--- a/src/test/scala/dpla/ingestion3/harvesters/oai/OaiResponseProcessorTest.scala
+++ b/src/test/scala/dpla/ingestion3/harvesters/oai/OaiResponseProcessorTest.scala
@@ -122,4 +122,15 @@ class OaiResponseProcessorTest extends FlatSpec with Matchers with MockFactory {
     val token = OaiResponseProcessor.getResumptionToken(text)
     assert(token === None)
   }
+
+  "isDeleted" should "returns false if not marked as deleted" in {
+    val xml = <oai><header><record></record></header></oai>
+    val status = OaiResponseProcessor.isDeleted(xml)
+    assert(status === false)
+  }
+  it should "returns true if marked as deleted" in {
+    val xml = <oai><header status="deleted"><record></record></header></oai>
+    val status = OaiResponseProcessor.isDeleted(xml)
+    assert(status === true)
+  }
 }


### PR DESCRIPTION
- Refactor of Ohio mapping and associated changes 
  - Cleanup flatMap(split).filter() calls into splitOnDelimiter()
  - Add capitalizeFirstChar() string enrichment. Capitializes the first alphanumeric character in a given string
  - Remove type mapping from OhioExtractor and use universal DCMIType enrichment 
- Reports for language now include SkosConcept.concept in addition to SkosConcept.providedLabel. We need to report on concept because that is where the enriched value is stored. 
- EnrichmentDriver now invokes the DCMIType enrichment which looks up the original type value against a mapping of terms to DCMIType IRIs. These IRIs are then used to lookup a label for the IRI and that string is finally downcased. 
- OaiResponseProcessor now ignores records marked as "deleted" in an OAI feed
- Change ElasticSearch JSON-L mapping to send the enriched value to the language.iso639 field.
    language.name will be either SkosConcept.concept (enriched value) and if that does not exist then map the original value from SkosConcept.providedLabel.