### PR TITLE
Fixup bug when mapping multiple dataProvider values 

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/NaraMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/NaraMapping.scala
@@ -37,8 +37,8 @@ class NaraMapping extends Mapping[NodeSeq] with XmlExtractor with IdMinter[NodeS
       copyStatus = (physicalOccurrenceArray \\ "copyStatus" \ "termName").text
       //todo Preservation-Reproduction-Reference
       if copyStatus.contains("Reproduction-Reference") || copyStatus.contains("Preservation")
-      referenceUnit = (physicalOccurrenceArray \\ "referenceUnit" \ "termName").map(_.text).head
-    } yield referenceUnit).headOption
+      referenceUnit = (physicalOccurrenceArray \\ "referenceUnit" \ "termName").map(_.text).headOption
+    } yield referenceUnit).head
 
     nameOnlyAgent(referenceUnit.getOrElse("National Records and Archives Administration"))
   }

--- a/src/main/scala/dpla/ingestion3/mappers/providers/NaraMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/NaraMapping.scala
@@ -37,8 +37,9 @@ class NaraMapping extends Mapping[NodeSeq] with XmlExtractor with IdMinter[NodeS
       copyStatus = (physicalOccurrenceArray \\ "copyStatus" \ "termName").text
       //todo Preservation-Reproduction-Reference
       if copyStatus.contains("Reproduction-Reference") || copyStatus.contains("Preservation")
-      referenceUnit = (physicalOccurrenceArray \\ "referenceUnit" \ "termName").text
+      referenceUnit = (physicalOccurrenceArray \\ "referenceUnit" \ "termName").map(_.text).head
     } yield referenceUnit).headOption
+
     nameOnlyAgent(referenceUnit.getOrElse("National Records and Archives Administration"))
   }
 

--- a/src/test/scala/dpla/ingestion3/mappers/providers/NaraMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/NaraMappingTest.scala
@@ -249,4 +249,32 @@ class NaraMappingTest extends FlatSpec with BeforeAndAfter {
 
     assert(nameOnlyAgent("John F. Kennedy Library") === dataProvider)
   }
+
+  it should "extract the default dataProvider value if none exist" in {
+    // DPLA ID 0f7032c62e1cb4b6939694b0a808124c
+    val xml = <item xmlns="http://description.das.nara.gov/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <physicalOccurrenceArray>
+                  <itemPhysicalOccurrence>
+                    <copyStatus>
+                      <naId>10031433</naId>
+                      <termName>Preservation-Reproduction</termName>
+                    </copyStatus>
+                  </itemPhysicalOccurrence>
+                  <itemPhysicalOccurrence>
+                    <copyStatus>
+                      <termName>Reference</termName>
+                    </copyStatus>
+                  </itemPhysicalOccurrence>
+                  <itemPhysicalOccurrence>
+                    <copyStatus>
+                      <termName>Reproduction-Reference</termName>
+                    </copyStatus>
+                  </itemPhysicalOccurrence>
+                </physicalOccurrenceArray>
+              </item>
+
+    val dataProvider = extractor.dataProvider(Document(xml))
+
+    assert(nameOnlyAgent("National Records and Archives Administration") === dataProvider)
+  }
 }

--- a/src/test/scala/dpla/ingestion3/mappers/providers/NaraMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/NaraMappingTest.scala
@@ -206,4 +206,47 @@ class NaraMappingTest extends FlatSpec with BeforeAndAfter {
     println(extractor.dataProvider(Document(xml)))
 
   }
+
+  it should "extract a single dataProvider value" in {
+    // DPLA ID 0f7032c62e1cb4b6939694b0a808124c
+    val xml = <item xmlns="http://description.das.nara.gov/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <physicalOccurrenceArray>
+                  <itemPhysicalOccurrence>
+                    <copyStatus>
+                      <naId>10031433</naId>
+                      <termName>Preservation-Reproduction</termName>
+                    </copyStatus>
+                    <referenceUnitArray>
+                      <referenceUnit>
+                        <termName>John F. Kennedy Library</termName>
+                      </referenceUnit>
+                    </referenceUnitArray>
+                  </itemPhysicalOccurrence>
+                  <itemPhysicalOccurrence>
+                    <copyStatus>
+                      <termName>Reference</termName>
+                    </copyStatus>
+                    <referenceUnitArray>
+                      <referenceUnit>
+                        <termName>John F. Kennedy Library</termName>
+                      </referenceUnit>
+                    </referenceUnitArray>
+                  </itemPhysicalOccurrence>
+                  <itemPhysicalOccurrence>
+                    <copyStatus>
+                      <termName>Reproduction-Reference</termName>
+                    </copyStatus>
+                    <referenceUnitArray>
+                      <referenceUnit>
+                        <termName>John F. Kennedy Library</termName>
+                      </referenceUnit>
+                    </referenceUnitArray>
+                  </itemPhysicalOccurrence>
+                </physicalOccurrenceArray>
+              </item>
+
+    val dataProvider = extractor.dataProvider(Document(xml))
+
+    assert(nameOnlyAgent("John F. Kennedy Library") === dataProvider)
+  }
 }


### PR DESCRIPTION
Addresses IN-330. Fixup bug in dataProvider mapping that was merging all values when multiple referenceUnit properties exist under physicalOccurrenceArray. 

See https://dp.la/item/0f7032c62e1cb4b6939694b0a808124c all three "John F. Kennedy Library values" are concatenated into a single value when calling .text() on multiple nodes. This change maps the nodes so their values are not merged and then only returns the first value. 