### PR TITLE
cleanupString enrichment

### DIFF
--- a/src/main/scala/dpla/ingestion3/enrichments/StringEnrichments.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/StringEnrichments.scala
@@ -51,13 +51,20 @@ class StringEnrichments {
       rightsHolder = sourceResource.rightsHolder.map(enrichEdmAgent(_)),
       subject = sourceResource.subject.map(enrichSkosConcept(_)),
       temporal = sourceResource.temporal.map(enrichEdmTimeSpan(_)),
-      title = sourceResource.title.map(_.stripHTML.reduceWhitespace),
+      title = sourceResource.title.map(_.stripHTML
+        .reduceWhitespace
+        .cleanupLeadingPunctuation
+        .cleanupEndingPunctuation),
       `type` = sourceResource.`type`.map(_.stripHTML.reduceWhitespace)
     )
 
   def enrichEdmAgent(edmAgent: EdmAgent): EdmAgent =
     edmAgent.copy(
-      name = edmAgent.name.map(_.stripHTML.reduceWhitespace)
+      name = edmAgent.name.map(
+        _.stripHTML
+          .reduceWhitespace
+          .cleanupLeadingPunctuation
+          .cleanupEndingPunctuation)
     )
 
   def enrichEdmWebResource(edmWebResource: EdmWebResource): EdmWebResource =
@@ -69,8 +76,14 @@ class StringEnrichments {
 
   def enrichSkosConcept(skosConcept: SkosConcept): SkosConcept =
     skosConcept.copy(
-      concept = skosConcept.concept.map(_.stripHTML.reduceWhitespace),
-      providedLabel = skosConcept.providedLabel.map(_.stripHTML.reduceWhitespace)
+      concept = skosConcept.concept.map(_.stripHTML
+        .reduceWhitespace
+        .cleanupLeadingPunctuation
+        .cleanupEndingPunctuation),
+      providedLabel = skosConcept.providedLabel.map(_.stripHTML
+        .reduceWhitespace
+        .cleanupLeadingPunctuation
+        .cleanupEndingPunctuation)
     )
 
   def enrichEdmTimeSpan(edmTimeSpan: EdmTimeSpan): EdmTimeSpan =

--- a/src/main/scala/dpla/ingestion3/enrichments/StringUtils.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/StringUtils.scala
@@ -155,9 +155,10 @@ object StringUtils {
       *   slash (/)
       *   comma (,)
       *   hyphen (-)
-      *   new line (/n)
-      *   tab (/t)
-      *   carriage return (/r)
+      *   new line (\n)
+      *   tab (\t)
+      *   carriage return (\r)
+      *   whitespace (\s)
       */
     private def beginAndEndPunctuationToRemove = """[;:/,-\\t\\r\\n\s]"""
   }

--- a/src/test/scala/dpla/ingestion3/enrichments/StringUtilsTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/StringUtilsTest.scala
@@ -73,26 +73,73 @@ class StringUtilsTest extends FlatSpec with BeforeAndAfter {
     assert(enrichedValue === expectedValue)
   }
 
-  "stripPunctuation" should "strip all punctuation from the given string" in {
-    val originalValue = "\t\"It's @#$,.! OK\"\n"
-    val enrichedValue = originalValue.stripPunctuation
-    val expectedValue = "\t\"It's  OK\"\n"
+  "cleanupLeadingPunctuation" should "strip leading punctuation from a string" in {
+    val originalValue = ":  ;; --  It's @@ OK --- "
+    val enrichedValue = originalValue.cleanupLeadingPunctuation
+    val expectedValue = "It's @@ OK --- "
     assert(enrichedValue === expectedValue)
   }
 
-  "stripLeadingPunctuation" should "strip leading punctuation from the " +
-      "given string" in {
-    val originalValue = "@#$,.!\t \"It's OK\""
-    val enrichedValue = originalValue.stripPunctuation
-    val expectedValue = "\t \"It's OK\""
+  it should "remove whitespace" in {
+    val originalValue = "   A good string "
+    val enrichedValue = originalValue.cleanupLeadingPunctuation
+    val expectedValue = "A good string "
     assert(enrichedValue === expectedValue)
   }
 
-  "stripEndingPunctuation" should "strip ending punctuation from the " +
-    "given string" in {
-    val originalValue = "\"It's OK\" @#$,.!"
-    val enrichedValue = originalValue.stripPunctuation
-    val expectedValue = "\"It's OK\" "
+  it should "remove tabs" in {
+    val originalValue = "\t\t\tA \tgood string "
+    val enrichedValue = originalValue.cleanupLeadingPunctuation
+    val expectedValue = "A \tgood string "
+    assert(enrichedValue === expectedValue)
+  }
+
+  it should "remove new line characters" in {
+    val originalValue = "\n\n\r\nA good string "
+    val enrichedValue = originalValue.cleanupLeadingPunctuation
+    val expectedValue = "A good string "
+    assert(enrichedValue === expectedValue)
+  }
+
+  it should "do nothing if there is no punctuation" in {
+    val originalValue = "A good string "
+    val enrichedValue = originalValue.cleanupLeadingPunctuation
+    val expectedValue = "A good string "
+    assert(enrichedValue === expectedValue)
+  }
+
+  "cleanupEndingPunctuation" should "strip punctuation following the last letter or digit character" in {
+    val originalValue = ".. It's OK  ;; .. ,, // \n"
+    val enrichedValue = originalValue.cleanupEndingPunctuation
+    val expectedValue = ".. It's OK"
+    assert(enrichedValue === expectedValue)
+  }
+
+  it should "remove whitespace" in {
+    val originalValue = "A good string   "
+    val enrichedValue = originalValue.cleanupEndingPunctuation
+    val expectedValue = "A good string"
+    assert(enrichedValue === expectedValue)
+  }
+
+  it should "remove tabs" in {
+    val originalValue = "A \tgood string\t\t\t"
+    val enrichedValue = originalValue.cleanupEndingPunctuation
+    val expectedValue = "A \tgood string"
+    assert(enrichedValue === expectedValue)
+  }
+
+  it should "remove new line characters" in {
+    val originalValue = "A good string\n\n\r\n"
+    val enrichedValue = originalValue.cleanupEndingPunctuation
+    val expectedValue = "A good string"
+    assert(enrichedValue === expectedValue)
+  }
+
+  it should "do nothing if there is no ending punctuation" in {
+    val originalValue = "A good string"
+    val enrichedValue = originalValue.cleanupEndingPunctuation
+    val expectedValue = "A good string"
     assert(enrichedValue === expectedValue)
   }
 


### PR DESCRIPTION
[IN-339](https://digitalpubliclibraryofamerica.atlassian.net/browse/IN-339) 
Adds two members to StringUtils (`cleanupLeadingPunctuation` and `cleanupEndingPunctuation`) that strip out leading and trailing occurrences of:

- semicolon `;`
- comma `,`
- new line `\n`
- tab `\t`
- carriage return`\n`
- colon `:`
- hyphen `-`

Applies both normalization methods to:
- sourceResource.title
- edmAgent.name (e.g. creator, contributor)
- skosConcept.providedLabel (e.g subject, language, genre)
- skosConcept.concept (e.g subject, language, genre)v