### PR TITLE
Fixup bug in reduceWhitespace

### DIFF
--- a/src/main/scala/dpla/ingestion3/enrichments/StringUtils.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/StringUtils.scala
@@ -104,8 +104,11 @@ object StringUtils {
       StringEscapeUtils.unescapeHtml(cleaned)
     }
 
+    /**
+      * Reduce multiple whitespace values to a single
+      */
     val reduceWhitespace: SingleStringEnrichment = {
-      value.replaceAll("  ", " ")
+      value.replaceAll(" +", " ")
     }
 
     /**

--- a/src/test/scala/dpla/ingestion3/enrichments/StringUtilsTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/StringUtilsTest.scala
@@ -161,6 +161,18 @@ class StringUtilsTest extends FlatSpec with BeforeAndAfter {
     assert(enrichedValue === "foo bar")
   }
 
+  it should "reduce five whitespaces to one whitespace" in {
+    val originalValue = "foo     bar"
+    val enrichedValue = originalValue.reduceWhitespace
+    assert(enrichedValue === "foo bar")
+  }
+
+  it should "reduce multiple occurrences duplicate whitespace to single whitespace" in {
+    val originalValue = " foo   bar  choo  "
+    val enrichedValue = originalValue.reduceWhitespace
+    assert(enrichedValue === " foo bar choo ")
+  }
+
   "capitalizeFirstChar" should "not capitalize the b in 3 blind mice because it is preceded by 3" in {
     val originalValue = "3 blind mice"
     val enrichedValue = originalValue.capitalizeFirstChar


### PR DESCRIPTION
Fixes a bug that was not reducing three or more whitespace. `foo  bar` would be reduced to `foo bar`
but `foo     bar` was not reduced at all

edit: markdown is auto removing the extra spaces in my example