### PR TITLE
stripBrackets enrichment

### DIFF
--- a/src/main/scala/dpla/ingestion3/enrichments/StringUtils.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/StringUtils.scala
@@ -129,6 +129,7 @@ object StringUtils {
         value
     }
 
+
     /**
       * Replaces the character at the specified index in s with c
       * @param s String value
@@ -142,7 +143,7 @@ object StringUtils {
       * Iterates over the string to find the first alphanumeric char
       * and returns the index
       *
-      * @param str
+      * @param str String to search
       * @return
       */
     private def findFirstChar(str: String): Int = {
@@ -164,5 +165,56 @@ object StringUtils {
       *   whitespace (\s)
       */
     private def beginAndEndPunctuationToRemove = """[;:/,-\\t\\r\\n\s]"""
+
+    /**
+      * Removes matching leading and trailing brackets (square, round and curly braces)
+      * from a string
+      */
+    val stripBrackets: SingleStringEnrichment = {
+      val replacementRegex = for( (p, r) <- bracketPatterns if value.matches(p)) yield r
+      // TODO is there a cleaner or safer way to convert Iterator[String] to String than mkString?
+      value.replaceAll(replacementRegex.mkString, "")
+    }
+
+    /**
+      * Bracket patterns to search for and the corresponding replacement regex
+      *
+      * E.x.
+      *   pattern to search for -> pattern to replace matches
+      *   if it starts with ( and ends with ) -> get the first ( and last )
+      *   """^(\(.*\)$)""" -> """^(\()|(\))$"""
+      *
+      *
+      * @return Map[String, String]
+      */
+    private def bracketPatterns = {
+      brackets.map(bracket => baseBracketSearchPattern(bracket) -> baseBracketReplacePattern(bracket))
+    }
+
+    /**
+      * Constructs the regex pattern to search a string
+      *
+      * @param bracket Bracket pairs to search for
+      * @return String Regex
+      */
+    def baseBracketSearchPattern(bracket: Bracket): String =
+      """^([\n\r\s]*\""" + bracket.openChar + """.*\""" + bracket.closeChar + """[\n\r\s]*)"""
+
+    /**
+      * Constructs the regex pattern to perform a replacement
+      *
+      * @param bracket Bracket pairs to search for
+      * @return String Regex
+      */
+    private def baseBracketReplacePattern(bracket: Bracket) =
+      """^([\n\r\s]*\""" + bracket.openChar + """[\n\r\s]*)|([\n\r\s]*\""" + bracket.closeChar + """[\n\r\s]*)$"""
+
+    private def brackets = Seq(
+      Bracket("{","}"),
+      Bracket("(",")"),
+      Bracket("[","]")
+    )
+
+    case class Bracket(openChar: String, closeChar: String)
   }
 }

--- a/src/main/scala/dpla/ingestion3/mappers/providers/CdlMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/CdlMapping.scala
@@ -2,6 +2,7 @@ package dpla.ingestion3.mappers.providers
 
 import java.net.URI
 
+import dpla.ingestion3.enrichments.StringUtils._
 import dpla.ingestion3.mappers.utils.{Document, IdMinter, JsonExtractor, Mapping}
 import dpla.ingestion3.model.DplaMapData._
 import dpla.ingestion3.model.{EdmAgent, _}
@@ -99,7 +100,8 @@ class CdlMapping() extends Mapping[JValue] with IdMinter[JValue] with JsonExtrac
   override def temporal(data: Document[JValue]): ZeroToMany[EdmTimeSpan] =
     extractStrings("temporal_ss")(data).map(stringOnlyTimeSpan)
 
-  override def title(data: Document[JValue]): AtLeastOne[String] = extractStrings("title_ss")(data)
+  override def title(data: Document[JValue]): AtLeastOne[String] =
+    extractStrings("title_ss")(data).map(_.stripBrackets)
 
   override def `type`(data: Document[JValue]): ZeroToMany[String] = extractStrings("type")(data)
 

--- a/src/test/scala/dpla/ingestion3/enrichments/StringUtilsTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/StringUtilsTest.scala
@@ -210,4 +210,41 @@ class StringUtilsTest extends FlatSpec with BeforeAndAfter {
     val enrichedValue = originalValue.findAndRemoveAll(stopWords)
     assert(enrichedValue === "photograph")
   }
+
+  "stripBrackets" should "remove leading and trailing ( )" in {
+    val originalValue = "(hello)"
+    val enrichedValue = originalValue.stripBrackets
+    assert(enrichedValue === "hello")
+  }
+  it should "remove leading and trailing [ ]" in {
+    val originalValue = "[hello]"
+    val enrichedValue = originalValue.stripBrackets
+    assert(enrichedValue === "hello")
+  }
+  it should "remove leading and trailing { }" in {
+    val originalValue = "{hello}"
+    val enrichedValue = originalValue.stripBrackets
+    assert(enrichedValue === "hello")
+  }
+  it should "ignore whitespace and remove leading and trailing { } " in {
+    val originalValue = " \t{hello} \n"
+    val enrichedValue = originalValue.stripBrackets
+    assert(enrichedValue === "hello")
+  }
+  it should "leave interior brackets alone" in {
+    val originalValue = "Hello ()[]{} Goodbye"
+    val enrichedValue = originalValue.stripBrackets
+    assert(enrichedValue === "Hello ()[]{} Goodbye")
+  }
+  it should "remove surrounding brackets and interior brackets alone" in {
+    val originalValue = "( {Hello ()[]{} Goodbye)"
+    val enrichedValue = originalValue.stripBrackets
+    assert(enrichedValue === "{Hello ()[]{} Goodbye")
+  }
+  it should "do nothing with unmatched brackets" in {
+    val originalValue = "(Hello"
+    val enrichedValue = originalValue.stripBrackets
+    assert(enrichedValue === "(Hello")
+  }
+
 }


### PR DESCRIPTION
[Addresses IN-350](https://digitalpubliclibraryofamerica.atlassian.net/secure/RapidBoard.jspa?rapidView=9&projectKey=IN&selectedIssue=IN-350)

Adds string normalization member `stringBrackets`. This method removes a defined set of paired characters (e.g {}, [], ()) from a provided string. It constructs two regular expressions, one to search the string for a match and a second to identify characters to replace. Both of these patterns are built from a base pattern (see `baseBracketSearchPattern` and `baseBracketReplacePattern`) and the target characters passed in (see `brackets` member and `Bracket` case class). Both of the regex patterns ignore and replace extraneous white space respectively.

