### PR TITLE
Strip ending period

### DIFF
--- a/src/main/scala/dpla/ingestion3/enrichments/StringUtils.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/StringUtils.scala
@@ -104,6 +104,17 @@ object StringUtils {
       StringEscapeUtils.unescapeHtml(cleaned)
     }
 
+
+    /**
+      * Removes singular periods from the end of a string. Ignores and removes trailing whitespace
+      */
+    val stripEndingPeriod: SingleStringEnrichment = {
+      if (value.matches(""".*?[^\.]\.[\n\r\s]*$"""))
+        value.replaceAll("""\.[\n\r\s]*$""", "")
+      else
+        value
+    }
+
     /**
       * Reduce multiple whitespace values to a single
       */

--- a/src/main/scala/dpla/ingestion3/mappers/providers/CdlMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/CdlMapping.scala
@@ -95,7 +95,11 @@ class CdlMapping() extends Mapping[JValue] with IdMinter[JValue] with JsonExtrac
     extractStrings("rightsholder_ss")(data).map(nameOnlyAgent)
 
   override def subject(data: Document[JValue]): ZeroToMany[SkosConcept] =
-    extractStrings("subject_ss")(data).map(nameOnlyConcept)
+    extractStrings("subject_ss")(data)
+      .map(_.cleanupLeadingPunctuation)
+      .map(_.cleanupEndingPunctuation)
+      .map(_.stripEndingPeriod)
+      .map(nameOnlyConcept)
 
   override def temporal(data: Document[JValue]): ZeroToMany[EdmTimeSpan] =
     extractStrings("temporal_ss")(data).map(stringOnlyTimeSpan)

--- a/src/test/scala/dpla/ingestion3/enrichments/StringUtilsTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/StringUtilsTest.scala
@@ -210,7 +210,7 @@ class StringUtilsTest extends FlatSpec with BeforeAndAfter {
     val enrichedValue = originalValue.findAndRemoveAll(stopWords)
     assert(enrichedValue === "photograph")
   }
-
+  
   "stripBrackets" should "remove leading and trailing ( )" in {
     val originalValue = "(hello)"
     val enrichedValue = originalValue.stripBrackets
@@ -247,4 +247,34 @@ class StringUtilsTest extends FlatSpec with BeforeAndAfter {
     assert(enrichedValue === "(Hello")
   }
 
+  "stripEndingPeriod" should "remove a single trailing period" in {
+    val originalValue = "Hello."
+    val enrichedValue = originalValue.stripEndingPeriod
+    val expectedValue = "Hello"
+    assert(enrichedValue === expectedValue)
+  }
+  it should "not remove ellipsis" in {
+    val originalValue = "Hello..."
+    val enrichedValue = originalValue.stripEndingPeriod
+    val expectedValue = "Hello..."
+    assert(enrichedValue === expectedValue)
+  }
+  it should "not remove leading or interior periods" in {
+    val originalValue = "H.e.l.l.o."
+    val enrichedValue = originalValue.stripEndingPeriod
+    val expectedValue = "H.e.l.l.o"
+    assert(enrichedValue === expectedValue)
+  }
+  it should "return the original value if only given a single period (e.g. '.')" in {
+    val originalValue = "."
+    val enrichedValue = originalValue.stripEndingPeriod
+    val expectedValue = "."
+    assert(enrichedValue === expectedValue)
+  }
+  it should "remove a trailing period if it followed by whitespace" in {
+    val originalValue = "Hello.  "
+    val enrichedValue = originalValue.stripEndingPeriod
+    val expectedValue = "Hello"
+    assert(enrichedValue === expectedValue)
+  }
 }


### PR DESCRIPTION
[Addresses IN-351](https://digitalpubliclibraryofamerica.atlassian.net/browse/IN-351)

Add `stripEndingPeriod` member to `StringUtils`
- Removes singular trailing period from a string
- Ignores and removes trailing white space
- Ignores leading, interior and multiple trailing periods (i.e. ellipsis)

Fixup CDL subject mapping
- Call `stripEndinPeriod`
- Call `cleanupLeadingPunctuation` and `cleanupTrailingPunctuation`