### PR TITLE
Fixup stillimage type mapping 

### DIFF
--- a/src/main/scala/dpla/ingestion3/enrichments/VocabEnforcer.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/VocabEnforcer.scala
@@ -114,7 +114,7 @@ object DcmiTypeMapper extends VocabEnforcer[String] {
     "sound" -> dcmiType.Sound,
     "specimen" -> dcmiType.Image,
     "statue" -> dcmiType.Image,
-    "stillimage" -> dcmiType.StillImage,
+    "stillimage" -> dcmiType.Image,
     "text" -> dcmiType.Text,
     "textile" -> dcmiType.Image,
     "tool" -> dcmiType.Image,


### PR DESCRIPTION
`stillimage` should map to `dcmiType.Image` so the IRI labels are consistent for all image records