### PR TITLE
LC Harvester

### DIFF
--- a/src/main/scala/dpla/ingestion3/entries/ingest/HarvestEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/HarvestEntry.scala
@@ -4,6 +4,8 @@ import dpla.ingestion3.confs.{CmdArgs, Ingestion3Conf, i3Conf}
 import dpla.ingestion3.executors.HarvestExecutor
 import dpla.ingestion3.utils.Utils
 
+import scala.util.Failure
+
 /**
   * Entry point for running a harvest.
   *
@@ -31,6 +33,9 @@ object HarvestEntry extends HarvestExecutor {
     val providerConf: i3Conf = i3Conf.load()
 
     // Execute harvest.
-    execute(shortName, dataOut, providerConf, harvestLogger)
+    execute(shortName, dataOut, providerConf, harvestLogger) match {
+      case Failure(error) => error.printStackTrace()
+      case _ =>
+    }
   }
 }

--- a/src/main/scala/dpla/ingestion3/harvesters/api/ApiResponse.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/ApiResponse.scala
@@ -33,7 +33,7 @@ case class ApiError(message: String,
   * @param document
   */
 case class ApiRecord(id: String,
-                     document: String)
+                     document: String) extends ApiResponse
 
 /**
   *

--- a/src/main/scala/dpla/ingestion3/harvesters/api/LocHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/LocHarvester.scala
@@ -1,0 +1,168 @@
+
+package dpla.ingestion3.harvesters.api
+
+import java.net.URL
+
+import dpla.ingestion3.confs.i3Conf
+import dpla.ingestion3.utils.HttpUtils
+import org.apache.http.client.utils.URIBuilder
+import org.apache.log4j.Logger
+import org.json4s.DefaultFormats
+import org.json4s.jackson.JsonMethods._
+
+import scala.util.{Failure, Success}
+import scala.xml.XML
+
+/**
+  * Class for harvesting records from the Library of Congress's API
+  *
+  * API documentation
+  * https://libraryofcongress.github.io/data-exploration/
+  *
+  */
+class LocHarvester(shortName: String,
+                   conf: i3Conf,
+                   outputDir: String,
+                   harvestLogger: Logger)
+  extends ApiHarvester(shortName, conf, outputDir, harvestLogger) {
+
+  override protected val mimeType: String = "application_json"
+
+  override protected val queryParams: Map[String, String] = Map(
+    "query" -> conf.harvest.query,
+    "c" -> conf.harvest.rows
+  ).collect{ case (key, Some(value)) => key -> value } // remove None values
+
+  override protected def localApiHarvest: Unit = {
+    implicit val formats = DefaultFormats
+
+    // Mutable vars for controlling harvest loop
+    var continueHarvest = true
+    var page = "1"
+
+    // Runtime tracking
+    val startTime = System.currentTimeMillis()
+
+    val collections = conf.harvest.setlist.getOrElse(throw new RuntimeException("No sets")).split(",")
+
+    collections.foreach( collection => {
+      while(continueHarvest) getSinglePage(page, collection) match {
+        // Handle errors
+        case error: ApiError with ApiResponse =>
+          harvestLogger.error("Error returned by request %s\n%s\n%s".format(
+            error.errorSource.url.getOrElse("Undefined url"),
+            error.errorSource.queryParams,
+            error.message
+          ))
+          continueHarvest = false
+        // Handle a successful response
+        case src: ApiSource with ApiResponse =>
+          src.text match {
+            case Some(docs) =>
+              // Parse xml to get URLs for items
+              val xml = XML.loadString(docs)
+              val locItemUrls = xml \\ "url" \\ "loc"
+
+              val urls = locItemUrls
+                .filterNot(url => url.contains("www.loc.gov/item/"))
+                .map(node => buildItemUrl(node.text))
+
+              val locRecords = fetchLocRecords(urls)
+
+              // @see ApiHarvester
+              saveOut(locRecords.flatten.toList)
+
+              // Loop control
+              if (locItemUrls.size != queryParams.getOrElse("c", "10").toInt) {
+                continueHarvest = false
+              } else {
+                page = (page.toInt + 1).toString
+              }
+
+            case _ =>
+              harvestLogger.error(s"Response body is empty.\n" +
+                s"URL: ${src.url.getOrElse("!!! URL not set !!!")}\n" +
+                s"Params: ${src.queryParams}\n" +
+                s"Body: ${src.text}")
+              continueHarvest = false
+          }
+      }
+    })
+  }
+
+  /**
+    *
+    * @param urls
+    * @return
+    */
+  def fetchLocRecords(urls: Seq[URL]): Seq[Option[ApiRecord]] = {
+    sc.parallelize(urls).map(r => {
+      HttpUtils.makeGetRequest(r) match {
+        case Failure(e) =>
+          throw new Exception(e)
+        case Success(response) =>
+          val parsedRsp = parse(response)
+          Some(ApiRecord((parse(response) \\ "item" \\ "id").toString, compact(render(parsedRsp))))
+      }
+    }).collect().toList
+  }
+
+  /**
+    * Get a single-page, un-parsed response from the CDL feed, or an error if
+    * one occurs.
+    *
+    * @param sp Pagination
+    * @param collection Name of collection
+    * @return ApiSource or ApiError
+    */
+  private def getSinglePage(sp: String, collection: String): ApiResponse = {
+    val url = buildUrl(queryParams.updated("sp", sp).updated("collection", collection))
+
+    harvestLogger.info(s"Requesting ${url.toString}")
+
+    HttpUtils.makeGetRequest(url) match {
+      case Failure(e) =>
+        ApiError(e.toString, ApiSource(queryParams, Some(url.toString)))
+      case Success(response) => if (response.isEmpty) {
+        ApiError("Response body is empty", ApiSource(queryParams, Some(url.toString)))
+      } else {
+        ApiSource(queryParams, Some(url.toString), Some(response))
+      }
+    }
+  }
+
+  /**
+    * Constructs the URL for collection sitemamp requests
+    *
+    * @param params URL parameters
+    * @return
+    */
+  override protected def buildUrl(params: Map[String, String]): URL =
+    new URIBuilder()
+      .setScheme("http")
+      .setHost("www.loc.gov")
+      .setPath(s"/collections/${params.getOrElse("collection", throw new RuntimeException("No collection specified"))}")
+      .setParameter("c", params.getOrElse("c", "10"))
+      .setParameter("fo", "sitemap")
+      .setParameter("sp", params.getOrElse("sp", "1"))
+      .build()
+      .toURL
+
+  /**
+    *
+    * @param urlStr URL String
+    * @return
+    */
+  def buildItemUrl(urlStr: String) = {
+    val url = new URL(urlStr)
+
+    new URIBuilder()
+      .setScheme(url.getProtocol)
+      .setHost(url.getHost)
+      .setPath(url.getPath)
+      .setParameter("fo", "json")
+      .setParameter("at", "item")
+      .build()
+      .toURL
+  }
+}

--- a/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
+++ b/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
@@ -17,7 +17,6 @@ class CdlProfile extends JsonProfile {
 }
 
 /**
-<<<<<<< HEAD
   * District Digital
   */
 class DcProfile extends XmlProfile {

--- a/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
+++ b/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
@@ -17,6 +17,7 @@ class CdlProfile extends JsonProfile {
 }
 
 /**
+<<<<<<< HEAD
   * District Digital
   */
 class DcProfile extends XmlProfile {

--- a/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
+++ b/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
@@ -1,7 +1,7 @@
 package dpla.ingestion3.profiles
 
 import dpla.ingestion3.harvesters.Harvester
-import dpla.ingestion3.harvesters.api.CdlHarvester
+import dpla.ingestion3.harvesters.api.{CdlHarvester, LocHarvester}
 import dpla.ingestion3.harvesters.oai.OaiHarvester
 import dpla.ingestion3.mappers.providers._
 
@@ -24,7 +24,16 @@ class DcProfile extends XmlProfile {
 
   override def getHarvester = classOf[OaiHarvester]
   override def getMapping = new DcMapping
+}
 
+/**
+  * Library of Congress
+  */
+class LocProfile extends JsonProfile {
+  type Mapping = CdlMapping // FIXME Placeholder until LC mapping is written
+
+  override def getHarvester = classOf[LocHarvester]
+  override def getMapping = new CdlMapping
 }
 
 /**

--- a/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
+++ b/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
@@ -44,6 +44,7 @@ object ProviderRegistry {
     // FIXME Register is redundant here and should be removed
     "dc" -> Register(profile = new DcProfile),
     "cdl" -> Register(profile = new CdlProfile),
+    "loc" -> Register(profile = new LocProfile),
     "mdl" -> Register(profile = new MdlProfile),
     "nara" -> Register(profile = new NaraProfile),
     "ohio" -> Register(profile = new OhioProfile),


### PR DESCRIPTION
Initial working version of the LC API harvester.

Gathers all item URLs to be fetched by iterating over the `sitemap` output of collection URLs. Distributes those item requests across all workers.  Swallows all errors and reports them out to `loc-harvest-xxx.log`. 

Observed throughput of this harvester is ~5 records per second or ~6 hours to harvest 150,000 records.

ingestion3.conf properties for LC 
```
# Library of Congress
loc.provider = "Library of Congress"
loc.harvest.type = "api"
loc.harvest.endpoint="http://www.loc.gov/collections/"
loc.harvest.rows=50
loc.harvest.setlist="american-revolutionary-war-maps,bain,civil-war-maps,detroit-publishing-company,fsa-owi-color-photographs,harris-ewing,national-photo-company,panoramic-maps"
```