### PR TITLE
LC mapping

### DIFF
--- a/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
@@ -42,10 +42,10 @@ class EnrichmentDriver(conf: i3Conf) extends Serializable {
 
     enriched.copy(
       sourceResource = enriched.sourceResource.copy(
-        date = enriched.sourceResource.date.map(d => dateEnrichment.parse(d)),
+        // date = enriched.sourceResource.date.map(d => dateEnrichment.parse(d)),
         language = enriched.sourceResource.language.map(languageEnrichment.enrichLanguage),
-        `type` = enriched.sourceResource.`type`.flatMap(typeEnrichment.enrich),
-        place = enriched.sourceResource.place.map(p => spatialEnrichment.enrich(p))
+        `type` = enriched.sourceResource.`type`.flatMap(typeEnrichment.enrich)
+        //, place = enriched.sourceResource.place.map(p => spatialEnrichment.enrich(p))
       )
     )
   }

--- a/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
@@ -137,7 +137,7 @@ class DplaMap extends Serializable {
         (RowConverter.toRow(dplaMapData, model.sparkSchema), null)
       case Failure(exception) =>
         failureCount.add(1)
-        (null, s"${exception.getMessage}\n")
+        (null, s"${exception.getMessage}")
     }
   }
 }

--- a/src/main/scala/dpla/ingestion3/mappers/providers/LcMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/LcMapping.scala
@@ -11,9 +11,6 @@ import org.json4s.JValue
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
 
-
-// TODO Should there be an implicit unwrapping of JSON values when calling extract*(JValue)
-
 class LcMapping() extends Mapping[JValue] with IdMinter[JValue] with JsonExtractor {
 
   // ID minting functions

--- a/src/main/scala/dpla/ingestion3/mappers/providers/LcMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/LcMapping.scala
@@ -17,7 +17,7 @@ import org.json4s.jackson.JsonMethods._
 class LcMapping() extends Mapping[JValue] with IdMinter[JValue] with JsonExtractor {
 
   // ID minting functions
-  override def useProviderName: Boolean = true
+  override def useProviderName: Boolean = false
 
   // Hard coded to prevent accidental changes to base ID
   override def getProviderName: String =
@@ -39,7 +39,7 @@ class LcMapping() extends Mapping[JValue] with IdMinter[JValue] with JsonExtract
     nameOnlyAgent(
       extractStrings(data.get \\ "repository").headOption
         .getOrElse("Missing required property " +
-        "'repository' for dataProvider mapping"))
+          "'repository' for dataProvider mapping"))
 
   override def originalRecord(data: Document[JValue]): ExactlyOne[String] =
     Utils.formatJson(data)
@@ -67,7 +67,6 @@ class LcMapping() extends Mapping[JValue] with IdMinter[JValue] with JsonExtract
     val otherTitles = extractStrings(data.get \ "item" \ "other-titles")
     val alternateTitle = extractStrings(data.get \ "item" \ "alternate_title")
 
-    // This seems stupid
     if (otherTitle.nonEmpty) otherTitle
     else if (otherTitles.nonEmpty) otherTitles
     else alternateTitle
@@ -83,11 +82,7 @@ class LcMapping() extends Mapping[JValue] with IdMinter[JValue] with JsonExtract
     val contributorNames = extractStrings(data.get \\ "contributor_names")
     val lcContributors = extractStrings(data.get \\ "contributors")
 
-    val contributors =
-      if(contributorNames.nonEmpty) contributorNames
-      else lcContributors
-
-    contributors.map(nameOnlyAgent)
+    (if (contributorNames.nonEmpty) contributorNames else lcContributors).map(nameOnlyAgent)
   }
 
   override def date(data: Document[JValue]): ZeroToMany[EdmTimeSpan] = {
@@ -95,8 +90,7 @@ class LcMapping() extends Mapping[JValue] with IdMinter[JValue] with JsonExtract
     val date = extractStrings(data.get \\ "date")
     val dates = extractStrings(data.get \\ "dates")
 
-    if (date.nonEmpty) date.map(stringOnlyTimeSpan)
-    else dates.map(stringOnlyTimeSpan)
+    (if (date.nonEmpty) date else dates).map(stringOnlyTimeSpan)
   }
 
   override def description(data: Document[JValue]): ZeroToMany[String] =
@@ -114,8 +108,7 @@ class LcMapping() extends Mapping[JValue] with IdMinter[JValue] with JsonExtract
       extractStrings(data.get \ "item" \ "genre")
     val formatType = extractStrings(data.get \ "item" \ "format" \ "type")
 
-    if (typeGenre.nonEmpty) typeGenre
-    else formatType
+    if (typeGenre.nonEmpty) typeGenre else formatType
   }
 
   override def identifier(data: Document[JValue]): ZeroToMany[String] =
@@ -151,8 +144,7 @@ class LcMapping() extends Mapping[JValue] with IdMinter[JValue] with JsonExtract
     val types = extractStrings(data.get \ "item" \ "type")
     val formatKeys = extractKeys(data.get \ "item" \ "format")
 
-    if (types.nonEmpty) types
-    else formatKeys
+    if (types.nonEmpty) types else formatKeys
   }
 
   // Helper methods

--- a/src/main/scala/dpla/ingestion3/mappers/providers/LcMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/LcMapping.scala
@@ -37,12 +37,18 @@ class LcMapping() extends Mapping[JValue] with IdMinter[JValue] with JsonExtract
       case Some(dp) => {
         if(dp.startsWith("Library of Congress")) {
           "Library of Congress"
-        } else if(dp.startsWith("Library of Virginia Richmend, VA" )) {
+        } else if(dp.startsWith("Library of Virginia Richmond, VA" )) {
           "Library of Virginia"
         } else if(dp.startsWith("Virginia Historical Society")) {
           "Virginia Historical Society"
-        } else
-          throw new RuntimeException(s"'repository' value, $dp, is not a valid term")
+        } else {
+          val dpError =
+            if(dp.isEmpty) "<EMPTY STRING>"
+              else dp
+          throw new RuntimeException(
+            s"Record ${getProviderId(data)} has invalid 'repository' value: $dpError")
+        }
+
       }
       case _ => throw new RuntimeException("Missing required property " +
         "'repository' for dataProvider mapping")

--- a/src/main/scala/dpla/ingestion3/mappers/providers/LcMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/LcMapping.scala
@@ -1,0 +1,165 @@
+package dpla.ingestion3.mappers.providers
+
+import java.net.URI
+
+import dpla.ingestion3.enrichments.normalizations.StringNormalizationUtils._
+import dpla.ingestion3.mappers.utils.{Document, IdMinter, JsonExtractor, Mapping}
+import dpla.ingestion3.model.DplaMapData._
+import dpla.ingestion3.model.{EdmAgent, _}
+import dpla.ingestion3.utils.Utils
+import org.json4s.JValue
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+
+
+// TODO Should there be an implicit unwrapping of JSON values when calling extract*(JValue)
+
+class LcMapping() extends Mapping[JValue] with IdMinter[JValue] with JsonExtractor {
+
+  // ID minting functions
+  override def useProviderName: Boolean = true
+
+  // Hard coded to prevent accidental changes to base ID
+  override def getProviderName: String =
+    "loc"
+
+  override def getProviderId(implicit data: Document[JValue]): String =
+    extractString(data.get \ "item" \ "id") // TODO confirm basis field for DPLA ID
+      .getOrElse(throw new RuntimeException(s"No ID for record: ${compact(data)}"))
+
+  // OreAggregation fields
+  override def dplaUri(data: Document[JValue]): ExactlyOne[URI] =
+    mintDplaItemUri(data)
+
+  override def sidecar(data: Document[JValue]): JValue =
+    ("prehashId", buildProviderBaseId()(data)) ~ ("dplaId", mintDplaId(data))
+
+  override def dataProvider(data: Document[JValue]): ExactlyOne[EdmAgent] =
+    // item['repository']
+    nameOnlyAgent(
+      extractStrings(data.get \\ "repository").headOption
+        .getOrElse("Missing required property " +
+        "'repository' for dataProvider mapping"))
+
+  override def originalRecord(data: Document[JValue]): ExactlyOne[String] =
+    Utils.formatJson(data)
+
+  // TODO Add test
+  override def preview(data: Document[JValue]): ZeroToOne[EdmWebResource] =
+    // resource['image'] (First instance)
+    // TODO Confirm mapping, "image_url" might be new field
+    extractStrings(data.get \ "item" \ "resource" \ "image")
+      .headOption.map(uri => uriOnlyWebResource(new URI(uri)))
+
+  override def provider(data: Document[JValue]): ExactlyOne[EdmAgent] = EdmAgent(
+    name = Some("Library of Congress"),
+    uri = Some(new URI("http://dp.la/api/contributor/lc"))
+  )
+
+  override def isShownAt(data: Document[JValue]): ExactlyOne[EdmWebResource] =
+    // item['url']
+    uriOnlyWebResource(providerUri(data))
+
+  // SourceResource
+  override def alternateTitle(data: Document[JValue]): ZeroToMany[String] = {
+    // item['other-title'] OR item['other-titles'] OR item['alternate_title']
+    val otherTitle = extractStrings(data.get \ "item" \ "other-title")
+    val otherTitles = extractStrings(data.get \ "item" \ "other-titles")
+    val alternateTitle = extractStrings(data.get \ "item" \ "alternate_title")
+
+    // This seems stupid
+    if (otherTitle.nonEmpty) otherTitle
+    else if (otherTitles.nonEmpty) otherTitles
+    else alternateTitle
+  }
+
+  override def collection(data: Document[JValue]): ZeroToMany[DcmiTypeCollection] =
+    // [partof['title'] for partof in item['partof']
+    extractStrings(data.get \\ "partof" \ "title")
+      .map(nameOnlyCollection)
+
+  override def contributor(data: Document[JValue]): ZeroToMany[EdmAgent] = {
+    // item['contributor_names'] OR name in item['contributors']]
+    val contributorNames = extractStrings(data.get \\ "contributor_names")
+    val lcContributors = extractStrings(data.get \\ "contributors")
+
+    val contributors =
+      if(contributorNames.nonEmpty) contributorNames
+      else lcContributors
+
+    contributors.map(nameOnlyAgent)
+  }
+
+  override def date(data: Document[JValue]): ZeroToMany[EdmTimeSpan] = {
+    // item['date'] OR item['dates']
+    val date = extractStrings(data.get \\ "date")
+    val dates = extractStrings(data.get \\ "dates")
+
+    if (date.nonEmpty) date.map(stringOnlyTimeSpan)
+    else dates.map(stringOnlyTimeSpan)
+  }
+
+  override def description(data: Document[JValue]): ZeroToMany[String] =
+    // item['description'] AND item['created_published']
+    extractStrings(data.get \ "item" \ "description") ++
+      extractStrings(data.get \ "item" \ "created_published" )
+
+  override def extent(data: Document[JValue]): ZeroToMany[String] =
+    // item['medium']
+    extractStrings(data.get \ "item" \ "medium")
+
+  override def format(data: Document[JValue]): ZeroToMany[String] = {
+    // (item['type'] AND item['genre']) OR type in item['format']],
+    val typeGenre = extractStrings(data.get \ "item" \ "type") ++
+      extractStrings(data.get \ "item" \ "genre")
+    val formatType = extractStrings(data.get \ "item" \ "format" \ "type")
+
+    if (typeGenre.nonEmpty) typeGenre
+    else formatType
+  }
+
+  override def identifier(data: Document[JValue]): ZeroToMany[String] =
+    // item['id']
+    extractStrings(data.get \ "item" \ "id")
+
+  override def language(data: Document[JValue]): ZeroToMany[SkosConcept] = {
+    // item['language']].keys
+    extractKeys(data.get \ "item" \ "language").map(nameOnlyConcept)
+  }
+
+  override def place(data: Document[JValue]): ZeroToMany[DplaPlace] =
+    // item['location']].keys
+    // loc.gov/item: item['coordinates']   << lat // TODO How should this integrate?
+    extractKeys(data.get \ "item" \ "location")
+      .map(_.capitalizeFirstChar) // capitalize first char since we are using json keys
+      .map(nameOnlyPlace)
+
+  override def rights(data: Document[JValue]): AtLeastOne[String] =
+    // "For rights relating to this resource, visit " + same mapping for isShownAt
+    Seq(s"For rights relating to this resource, visit ${providerUri(data).toString}")
+
+  override def subject(data: Document[JValue]): ZeroToMany[SkosConcept] =
+    // item['subject_headings']
+    extractStrings(data.get \ "item" \ "subject_headings").map(nameOnlyConcept)
+
+  override def title(data: Document[JValue]): AtLeastOne[String] =
+    // item['title']
+    extractStrings(data.get \ "item" \ "title")
+
+  override def `type`(data: Document[JValue]): ZeroToMany[String] = {
+    // item['type'] OR item['format']].keys
+    val types = extractStrings(data.get \ "item" \ "type")
+    val formatKeys = extractKeys(data.get \ "item" \ "format")
+
+    if (types.nonEmpty) types
+    else formatKeys
+  }
+
+  // Helper methods
+  def providerUri(json: JValue): URI =
+    // item['url']
+    extractString(json \ "item" \ "url") match {
+      case Some(url) => new URI(url)
+      case None => throw new RuntimeException("Missing required property 'url' for 'isShownAt' mapping ")
+    }
+}

--- a/src/main/scala/dpla/ingestion3/mappers/providers/LcMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/LcMapping.scala
@@ -67,9 +67,11 @@ class LcMapping() extends Mapping[JValue] with IdMinter[JValue] with JsonExtract
     val otherTitles = extractStrings(unwrap(data) \ "item" \ "other-titles")
     val alternateTitle = extractStrings(unwrap(data) \ "item" \ "alternate_title")
 
-    if (otherTitle.nonEmpty) otherTitle
-    else if (otherTitles.nonEmpty) otherTitles
-    else alternateTitle
+    (otherTitle.nonEmpty, otherTitles.nonEmpty) match {
+      case (true, _) => otherTitle
+      case (false, true) => otherTitles
+      case _ => alternateTitle
+    }
   }
 
   override def collection(data: Document[JValue]): ZeroToMany[DcmiTypeCollection] =

--- a/src/main/scala/dpla/ingestion3/mappers/providers/LcMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/LcMapping.scala
@@ -35,20 +35,15 @@ class LcMapping() extends Mapping[JValue] with IdMinter[JValue] with JsonExtract
     val dps = extractStrings(unwrap(data) \\ "repository")
     val dpName = dps.headOption match {
       case Some(dp) => {
-        if(dp.startsWith("Library of Congress")) {
-          "Library of Congress"
-        } else if(dp.startsWith("Library of Virginia Richmond, VA" )) {
-          "Library of Virginia"
-        } else if(dp.startsWith("Virginia Historical Society")) {
-          "Virginia Historical Society"
-        } else {
-          val dpError =
-            if(dp.isEmpty) "<EMPTY STRING>"
-              else dp
-          throw new RuntimeException(
-            s"Record ${getProviderId(data)} has invalid 'repository' value: $dpError")
+        dp match {
+          case s if s.startsWith("Library of Congress") => "Library of Congress"
+          case s if s.startsWith("Library of Virginia Richmond, VA") => "Library of Virginia"
+          case s if s.startsWith("Virginia Historical Society") => "Virginia Historical Society"
+          case _ =>
+            val dpError = if(dp.isEmpty) "<EMPTY STRING>" else dp
+            throw new RuntimeException(s"Record ${getProviderId(data)} " +
+              s"has invalid 'repository' value: $dpError")
         }
-
       }
       case _ => throw new RuntimeException("Missing required property " +
         "'repository' for dataProvider mapping")

--- a/src/main/scala/dpla/ingestion3/mappers/utils/Extractor.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/Extractor.scala
@@ -132,6 +132,18 @@ trait JsonExtractor extends Extractor[JValue] {
   }
 
   /**
+    * Sometimes we need to map the keys
+    *
+    * @param jValue
+    * @return
+    */
+  def extractKeys(jValue: JValue): Seq[String] = jValue match {
+    case JArray(array) => array.flatMap(entry => extractKeys(entry))
+    case JObject(fields) => fields.map(field => field._1)
+    case _ => Seq()
+  }
+
+  /**
     * Wraps the JValue in JArray if it is not already a JArray
     * Addresses the problem of inconsistent data types in value field.
     * e.g. '"prop": ["val1"]' vs '"prop": "val1"'

--- a/src/main/scala/dpla/ingestion3/mappers/utils/Extractor.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/Extractor.scala
@@ -78,8 +78,8 @@ trait JsonExtractor extends Extractor[JValue] {
     * @return Some(string) if one could be found. Will fail
     *         on non-primitive values like arrays or objects.
     */
-  def extractString(fieldName: String)(implicit json: JValue): Option[String]
-  = extractString(json \ fieldName)
+  def extractString(fieldName: String)(implicit json: JValue): Option[String] =
+    extractString(json \ fieldName)
 
   /**
     * Pulls a Seq[String] of values from the implicit json daa
@@ -98,8 +98,8 @@ trait JsonExtractor extends Extractor[JValue] {
     *
     *         Otherwise, an empty Seq is returned.
     */
-  def extractStrings(fieldName: String)(implicit json: JValue): Seq[String]
-  = extractStrings(json \ fieldName)
+  def extractStrings(fieldName: String)(implicit json: JValue): Seq[String] =
+    extractStrings(json \ fieldName)
 
   /**
     * @see definition of extractStrings(fieldName: String), save for this version

--- a/src/main/scala/dpla/ingestion3/mappers/utils/Extractor.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/Extractor.scala
@@ -139,7 +139,7 @@ trait JsonExtractor extends Extractor[JValue] {
     */
   def extractKeys(jValue: JValue): Seq[String] = jValue match {
     case JArray(array) => array.flatMap(entry => extractKeys(entry))
-    case JObject(fields) => fields.map(field => field._1)
+    case JObject(fields) => fields.map { case(field, _) => field }
     case _ => Seq()
   }
 

--- a/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
+++ b/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
@@ -30,10 +30,10 @@ class DcProfile extends XmlProfile {
   * Library of Congress
   */
 class LocProfile extends JsonProfile {
-  type Mapping = CdlMapping // FIXME Placeholder until LC mapping is written
+  type Mapping = LcMapping
 
   override def getHarvester = classOf[LocHarvester]
-  override def getMapping = new CdlMapping
+  override def getMapping = new LcMapping
 }
 
 /**

--- a/src/test/resources/lc.json
+++ b/src/test/resources/lc.json
@@ -1,0 +1,220 @@
+{
+  "item": {
+    "library_of_congress_control_number": "73691632",
+    "source_collection": [],
+    "display_offsite": true,
+    "creator": null,
+    "access_restricted": false,
+    "site": [
+      "ammem",
+      "catalog"
+    ],
+    "original_format": [
+      "map"
+    ],
+    "genre": [],
+    "subject_headings": [
+      "New Jersey--Boundaries--New York (State)--Maps, Manuscript--Early works to 1800",
+      "New York (State)--Boundaries--New Jersey--Maps, Manuscript--Early works to 1800",
+      "Manuscript maps--Early works to 1800",
+      "United States--New Jersey",
+      "United States--New York (State)"
+    ],
+    "created_published": [
+      "[1769?]"
+    ],
+    "extract_urls": [
+      "http://www.loc.gov/item/73691632#gmd.mar",
+      "http://lccn.loc.gov/73691632#catalog"
+    ],
+    "id": "http://www.loc.gov/item/73691632/",
+    "contents": [],
+    "subject": [
+      "new jersey",
+      "boundaries",
+      "new york (state)",
+      "maps, manuscript",
+      "early works to 1800",
+      "manuscript maps",
+      "united states"
+    ],
+    "index": 1,
+    "digital_id": [
+      "http://hdl.loc.gov/loc.gmd/g3811f.ar124400"
+    ],
+    "call_number": [
+      "G3811.F7 1769 .L5"
+    ],
+    "group": [
+      "gmd.mar",
+      "catalog",
+      "general-maps",
+      "main-catalog"
+    ],
+    "score": 11.362809,
+    "location_country": [
+      "united states"
+    ],
+    "title": "Lines run in the Jersies for determining boundaries between that Province & New York.",
+    "description": [
+      "Scale ca. 1:740,000. Title from verso. Manuscript, pen-and-ink. On verso: No 33. LC Maps of North America, 1750-1789, 1244 Available also through the Library of Congress Web site as a raster image. Vault AACR2"
+    ],
+    "related_items": [],
+    "online_format": [
+      "image"
+    ],
+    "subjects": [
+      {
+        "boundaries": "https://www.loc.gov/search/?at=item&fa=subject:boundaries&fo=json"
+      },
+      {
+        "early works to 1800": "https://www.loc.gov/search/?at=item&fa=subject:early+works+to+1800&fo=json"
+      },
+      {
+        "manuscript maps": "https://www.loc.gov/search/?at=item&fa=subject:manuscript+maps&fo=json"
+      },
+      {
+        "maps, manuscript": "https://www.loc.gov/search/?at=item&fa=subject:maps,+manuscript&fo=json"
+      },
+      {
+        "new jersey": "https://www.loc.gov/search/?at=item&fa=subject:new+jersey&fo=json"
+      },
+      {
+        "new york (state)": "https://www.loc.gov/search/?at=item&fa=subject:new+york+%28state%29&fo=json"
+      },
+      {
+        "united states": "https://www.loc.gov/search/?at=item&fa=subject:united+states&fo=json"
+      }
+    ],
+    "location": [
+      {
+        "new jersey": "https://www.loc.gov/search/?at=item&fa=location:new+jersey&fo=json"
+      },
+      {
+        "new york": "https://www.loc.gov/search/?at=item&fa=location:new+york&fo=json"
+      },
+      {
+        "new york (state)": "https://www.loc.gov/search/?at=item&fa=location:new+york+%28state%29&fo=json"
+      },
+      {
+        "united states": "https://www.loc.gov/search/?at=item&fa=location:united+states&fo=json"
+      }
+    ],
+    "_version_": 1595492341134655500,
+    "type": [
+      "map"
+    ],
+    "mime_type": [
+      "image/gif",
+      "image/tiff",
+      "image/jpeg",
+      "image/jp2"
+    ],
+    "digitized": true,
+    "rights_advisory": [],
+    "medium": [
+      "map, on sheet 39 x 29 cm."
+    ],
+    "reproduction_number": [],
+    "repository": [
+      "Library of Congress Geography and Map Division Washington, D.C. 20540-4650 USA dcu"
+    ],
+    "format": [
+      {
+        "map": "https://www.loc.gov/search/?at=item&fa=original_format:map&fo=json"
+      }
+    ],
+    "partof": [
+      {
+        "count": 1344,
+        "url": "https://www.loc.gov/collections/american-revolutionary-war-maps/?at=item&fo=json",
+        "title": "american revolution and its era: maps and charts of north america and the west indies, 1750-1789"
+      },
+      {
+        "count": 4344,
+        "url": "https://www.loc.gov/collections/military-battles-and-campaigns/?at=item&fo=json",
+        "title": "military battles and campaigns"
+      },
+      {
+        "count": 16740,
+        "url": "https://www.loc.gov/search/?at=item&fa=partof:geography+and+map+division&fo=json",
+        "title": "geography and map division"
+      },
+      {
+        "count": 492795,
+        "url": "https://www.loc.gov/search/?at=item&fa=partof:american+memory&fo=json",
+        "title": "american memory"
+      },
+      {
+        "count": 919981,
+        "url": "https://www.loc.gov/search/?at=item&fa=partof:catalog&fo=json",
+        "title": "catalog"
+      }
+    ],
+    "timestamp": "2018-03-20T21:07:47.679Z",
+    "campaigns": [],
+    "extract_timestamp": "2018-03-20T21:00:06.179Z",
+    "date": "1769",
+    "shelf_id": "G3811.F7 1769 .L5",
+    "other_title": [],
+    "location_state": [
+      "new jersey",
+      "new york (state)"
+    ],
+    "dates": [
+      {
+        "1769": "https://www.loc.gov/search/?at=item&dates=1769/1769&fo=json"
+      }
+    ],
+    "language": [
+      {
+        "english": "https://www.loc.gov/search/?at=item&fa=language:english&fo=json"
+      }
+    ],
+    "rights": [
+      "<p>The maps in the Map Collections materials were either published prior to \r1922, produced by the United States government, or both (see catalogue \rrecords that accompany each map for information regarding date of \rpublication and source). The Library of Congress is providing access to \rthese materials for educational and research purposes and is not aware of \rany U.S. copyright protection (see Title 17 of the United States Code) or any \rother restrictions in the Map Collection materials.\r</p>\r<p>Note that the written permission of the copyright owners and/or other rights \rholders (such as publicity and/or privacy rights) is required for distribution, \rreproduction, or other use of protected items beyond that allowed by fair use \ror other statutory exemptions.  Responsibility for making an independent \rlegal assessment of an item and securing any necessary permissions \rultimately rests with persons desiring to use the item.\r</p>\r<p>Credit Line: Library of Congress, Geography and Map Division. </p>"
+    ],
+    "url": "https://www.loc.gov/item/73691632/",
+    "notes": [
+      "Scale ca. 1:740,000.",
+      "Title from verso.",
+      "Manuscript, pen-and-ink.",
+      "On verso: No 33.",
+      "LC Maps of North America, 1750-1789, 1244",
+      "Available also through the Library of Congress Web site as a raster image.",
+      "Vault",
+      "AACR2"
+    ],
+    "control_number": "",
+    "summary": [],
+    "hassegments": false,
+    "image_url": [
+      "//cdn.loc.gov/service/gmd/gmd381/g3811/g3811f/ar124400.gif",
+      "//cdn.loc.gov/service/gmd/gmd381/g3811/g3811f/ar124400.gif#h=199&w=150",
+      "//tile.loc.gov/image-services/iiif/service:gmd:gmd381:g3811:g3811f:ar124400/full/pct:12.5/0/default.jpg#h=591&w=445",
+      "//tile.loc.gov/image-services/iiif/service:gmd:gmd381:g3811:g3811f:ar124400/full/pct:25/0/default.jpg#h=1183&w=891"
+    ],
+    "other_formats": [
+      {
+        "link": "https://lccn.loc.gov/73691632/marcxml",
+        "label": "MARCXML Record"
+      },
+      {
+        "link": "https://lccn.loc.gov/73691632/mods",
+        "label": "MODS Record"
+      },
+      {
+        "link": "https://lccn.loc.gov/73691632/dc",
+        "label": "Dublin Core Record"
+      }
+    ],
+    "aka": [
+      "http://www.loc.gov/item/73691632/",
+      "http://hdl.loc.gov/loc.gmd/g3811f.ar124400",
+      "http://www.loc.gov/resource/g3811f.ar124400/",
+      "http://lccn.loc.gov/73691632"
+    ],
+    "contributor_names": [],
+    "access_advisory": []
+  }
+}

--- a/src/test/resources/lc.json
+++ b/src/test/resources/lc.json
@@ -208,6 +208,11 @@
         "label": "Dublin Core Record"
       }
     ],
+    "resource": [
+      {
+        "image": "http:images.com"
+      }
+    ],
     "aka": [
       "http://www.loc.gov/item/73691632/",
       "http://hdl.loc.gov/loc.gmd/g3811f.ar124400",

--- a/src/test/scala/dpla/ingestion3/enrichments/TypeEnrichmentTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/TypeEnrichmentTest.scala
@@ -16,6 +16,11 @@ class TypeEnrichmentTest  extends FlatSpec with BeforeAndAfter {
     val expectedValue = Some("image")
     assert(typeEnrichment.enrich(originalValue) === expectedValue)
   }
+  it should "return an enriched string for 'book'" in {
+    val originalValue = "book"
+    val expectedValue = Some("text")
+    assert(typeEnrichment.enrich(originalValue) === expectedValue)
+  }
   it should "return None for 'bucket'" in {
     val originalValue = "Bucket"
     val expectedValue = None

--- a/src/test/scala/dpla/ingestion3/mappers/providers/LcMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/LcMappingTest.scala
@@ -88,7 +88,7 @@ class LcMappingTest extends FlatSpec with BeforeAndAfter {
 
   // TODO Add test for extracting format keys
   it should "extract the correct type" in {
-    val expected = Seq("map")
+    val expected = Seq("map", "map")
     assert(extractor.`type`(json) == expected)
   }
  }

--- a/src/test/scala/dpla/ingestion3/mappers/providers/LcMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/LcMappingTest.scala
@@ -1,0 +1,92 @@
+package dpla.ingestion3.mappers.providers
+
+import java.net.URI
+
+import dpla.ingestion3.mappers.utils.Document
+import dpla.ingestion3.model._
+import dpla.ingestion3.utils.FlatFileIO
+import org.json4s.JsonAST._
+import org.json4s.jackson.JsonMethods._
+import org.scalatest.{BeforeAndAfter, FlatSpec}
+
+class LcMappingTest extends FlatSpec with BeforeAndAfter {
+  val shortName = "loc"
+  val jsonString: String = new FlatFileIO().readFileAsString("/lc.json")
+  val json: Document[JValue] = Document(parse(jsonString))
+  val extractor = new LcMapping
+
+  it should "extract the correct dataProvider" in {
+    val expected = nameOnlyAgent("Library of Congress Geography and Map Division Washington, D.C. 20540-4650 USA dcu")
+    assert(extractor.dataProvider(json) === expected)
+  }
+
+  it should "extract the correct provider id" in {
+    val expected = "http://www.loc.gov/item/73691632/"
+    assert(extractor.getProviderId(json) == expected)
+  }
+
+  it should "extract the correct URL for isShownAt" in {
+    val expected = uriOnlyWebResource(new URI("https://www.loc.gov/item/73691632/"))
+    assert(extractor.isShownAt(json) === expected)
+  }
+
+  // TODO test extraction of other-titles and alternate_title
+  it should "extract the correct alternate title" in {
+    val json = Document(parse(
+      """{"item": {"other-title": ["alt title"], "other-titles": ["alt title 2"],"alternate_title": ["alt title 3"]}} """))
+
+    assert(extractor.alternateTitle(json) == Seq("alt title"))
+  }
+
+  // TODO test correct extraction from `dates` and if both present s
+  it should "extract the correct date" in {
+    val expected = Seq("1769").map(stringOnlyTimeSpan)
+    assert(extractor.date(json) == expected)
+  }
+
+  it should "extract the correct description" in {
+    val expected = Seq("Scale ca. 1:740,000. Title from verso. Manuscript, pen-and-ink. On verso: No 33. LC Maps of North America, 1750-1789, 1244 Available also through the Library of Congress Web site as a raster image. Vault AACR2", "[1769?]")
+
+    assert(extractor.description(json) == expected)
+  }
+
+  it should "extract the correct extent" in {
+    val expected = Seq("map, on sheet 39 x 29 cm.")
+    assert(extractor.extent(json) == expected)
+  }
+
+  // TODO test extraction from [item \ format \ type]
+  it should "extract the correct format" in {
+    val expected = Seq("map")
+    assert(extractor.format(json) == expected)
+  }
+
+  it should "extract the correct identifiers" in {
+    val expected = Seq("http://www.loc.gov/item/73691632/")
+    assert(extractor.identifier(json) == expected)
+  }
+
+  it should "extract the correct language" in {
+    val expected = Seq("english").map(nameOnlyConcept)
+    assert(extractor.language(json) == expected)
+  }
+
+  it should "extract the correct location" in {
+    val expected = Seq("New jersey", "New york", "New york (state)","United states")
+      .map(nameOnlyPlace)
+    assert(extractor.place(json) == expected)
+  }
+
+  it should "extract the correct title" in {
+    val expected = Seq("Lines run in the Jersies for determining boundaries between that Province & New York.")
+    assert(extractor.title(json) == expected)
+  }
+
+  // TODO Add test for extracting format keys
+  it should "extract the correct type" in {
+    val expected = Seq("map")
+    assert(extractor.`type`(json) == expected)
+  }
+
+
+ }

--- a/src/test/scala/dpla/ingestion3/mappers/providers/LcMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/LcMappingTest.scala
@@ -16,7 +16,7 @@ class LcMappingTest extends FlatSpec with BeforeAndAfter {
   val extractor = new LcMapping
 
   it should "extract the correct dataProvider" in {
-    val expected = nameOnlyAgent("Library of Congress Geography and Map Division Washington, D.C. 20540-4650 USA dcu")
+    val expected = nameOnlyAgent("Library of Congress")
     assert(extractor.dataProvider(json) === expected)
   }
 
@@ -30,6 +30,10 @@ class LcMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.isShownAt(json) === expected)
   }
 
+  it should "extract the correct url for preview" in {
+    val expected = Option(uriOnlyWebResource(new URI("http:images.com")))
+    assert(extractor.preview(json) === expected)
+  }
   // TODO test extraction of other-titles and alternate_title
   it should "extract the correct alternate title" in {
     val json = Document(parse(
@@ -87,6 +91,4 @@ class LcMappingTest extends FlatSpec with BeforeAndAfter {
     val expected = Seq("map")
     assert(extractor.`type`(json) == expected)
   }
-
-
  }


### PR DESCRIPTION
Intital mapping for Library of Congess.

LC Mapping 
* Update `ProviderRegistry.scala` with LC mapping values
* Add `LcMapping.scala`
* Add `LcMappingTest.scala`
* Add `lc.json` test data 

Other changes
* Comment out `date` and `place` enrichments from `EnrichmentDriver`. 
* Add `extractKeys` method to JsonExtractor to extract key values as Seq[String] from a given JObject. 
   * ex. ```{ "a": "b", "c": "d"}```  >>> Seq("a", "c")