### PR TITLE
Extent filter and extraction 

### DIFF
--- a/src/main/scala/dpla/ingestion3/enrichments/normalizations/StringNormalizationUtils.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/normalizations/StringNormalizationUtils.scala
@@ -33,22 +33,18 @@ object StringNormalizationUtils {
       *
       */
     lazy val applyAllowFilter: Set[String] => String = (allowList) => {
-      // val nonAllowedTerms =
-        // Remove terms in allowList from the original string
-        val termsToRemove = applyBlockFilter(allowList)
-        // Split the remaining terms (e.g. the terms to remove) on white space
-        // This allows for filtering of specific words from a string but that functionality
-        // is not yet a requirement of this filter.
-        // FIXME This assumption may not hold in all cases and they should be clearly documented
-        //  .split(" ")
-        // Create a new set of regular expressions from the non-allowed terms
-        // with a different base pattern
+      // Generates a term block list by applying a block filter with the allowed terms
+      val termsToRemove = applyBlockFilter(allowList)
 
-      val nonAllowedTerms = Seq(termsToRemove).map(FilterRegex.Regex(_).allowListRegex).toSet
+      // Create a new set of regular expressions from the non-allowed terms
+      // with a different base regex pattern
+      val nonAllowedTerms = Seq(termsToRemove)
+        .map(FilterRegex.Regex(_).allowListRegex)
+        .toSet
 
       // Applies the block filter using nonAllowedTerms created from the original
-      // string to the original string. Trims leading/trailing whitespace and
-      // reduces extra interior whitespace
+      // string to the original string.
+      // Trims leading/trailing whitespace and reduces extra interior whitespace
       applyBlockFilter(nonAllowedTerms).reduceWhitespace
     }
 

--- a/src/main/scala/dpla/ingestion3/enrichments/normalizations/filters/ExtentIdentificationList.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/normalizations/filters/ExtentIdentificationList.scala
@@ -8,8 +8,7 @@ import dpla.ingestion3.enrichments.normalizations.FilterList
 object ExtentIdentificationList extends FilterList {
   lazy val termList: Set[String] = Set(
     "^.*[^a-zA-Z]x[^a-zA-Z].*$", // 1 x 2 OR 1 X 2 OR 1x2 but not 1 xerox
-    // "^[0-9]+$", // only non-alpha chars, redundant with alpha-start
-    "^[0-9].*" // starts with non alpha char
+    "^[0-9].*" // starts with number
   )
 }
 

--- a/src/main/scala/dpla/ingestion3/enrichments/normalizations/filters/ExtentIdentificationList.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/normalizations/filters/ExtentIdentificationList.scala
@@ -1,0 +1,24 @@
+package dpla.ingestion3.enrichments.normalizations.filters
+
+import dpla.ingestion3.enrichments.normalizations.FilterList
+/**
+  * Identifies values that are likely extend statements
+  * This filter is most commonly applied to the sourceResource.format field
+  */
+object ExtentIdentificationList extends FilterList {
+  lazy val termList: Set[String] = Set(
+    "^.*[^a-zA-Z]x[^a-zA-Z].*$", // 1 x 2 OR 1 X 2 OR 1x2 but not 1 xerox
+    // "^[0-9]+$", // only non-alpha chars, redundant with alpha-start
+    "^[0-9].*" // starts with non alpha char
+  )
+}
+
+/**
+  * Exceptions to the rules outlines above
+  */
+object ExtentExceptionsList extends FilterList {
+  override lazy val termList: Set[String] = Set(
+    "mm", // 8mm 16mm
+    "millimeter"
+  )
+}

--- a/src/test/scala/dpla/ingestion3/enrichments/ExtentFromFormatTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/ExtentFromFormatTest.scala
@@ -1,0 +1,26 @@
+package dpla.ingestion3.enrichments
+
+import org.scalatest.{BeforeAndAfter, FlatSpec}
+
+class ExtentFromFormatTest extends FlatSpec with BeforeAndAfter {
+
+
+
+  val typeEnrichment = new TypeEnrichment
+
+  "ExtentFromFormatFilter" should "return an enriched string for 'appliance'" in {
+    val originalValue = "appliance"
+    val expectedValue = Some("physical object")
+    assert(typeEnrichment.enrich(originalValue) === expectedValue)
+  }
+  it should "return an enriched string for 'Image'" in {
+    val originalValue = "Image"
+    val expectedValue = Some("image")
+    assert(typeEnrichment.enrich(originalValue) === expectedValue)
+  }
+  it should "return None for 'bucket'" in {
+    val originalValue = "Bucket"
+    val expectedValue = None
+    assert(typeEnrichment.enrich(originalValue) === expectedValue)
+  }
+}

--- a/src/test/scala/dpla/ingestion3/mappers/providers/OhioMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/OhioMappingTest.scala
@@ -93,9 +93,17 @@ class OhioMappingTest extends FlatSpec with BeforeAndAfter {
   it should "extract the correct format and remove values in that are stop words ('image')" in {
     val xml: Document[NodeSeq] = Document(<record><metadata>
       <dcterms:format>photograph</dcterms:format>
+      <dcterms:format>1 x 2 x 3</dcterms:format>
       <dcterms:format>image</dcterms:format>
     </metadata></record>)
     val expected = Seq("photograph")
+    assert(extractor.format(xml) === expected)
+  }
+  it should "extract nothing if the format value looks like an extent" in {
+    val xml: Document[NodeSeq] = Document(<record><metadata>
+      <dcterms:format>1 score (3 p.) 33 cm</dcterms:format>
+    </metadata></record>)
+    val expected = Seq()
     assert(extractor.format(xml) === expected)
   }
   it should "extract the correct format when splitting on ';'  and remove values in that are stop words" in {
@@ -211,5 +219,16 @@ class OhioMappingTest extends FlatSpec with BeforeAndAfter {
   it should "extract the correct preview" in {
     val expected = Some(uriOnlyWebResource(new URI("https://digitalgallery.bgsu.edu/files/thumbnails/26e197915e9107914faa33ac166ead5a.jpg")))
     assert(extractor.preview(xml) === expected)
+  }
+
+  // Extent format helper
+  it should "extract extent values from format" in {
+    val xml: NodeSeq = <record><metadata>
+        <format>1 x 2 x 3</format>
+        <format>written</format>
+      </metadata></record>
+
+    val expected = Seq("1 x 2 x 3")
+    assert(extractor.extentFromFormat(Document(xml)) === expected)
   }
 }


### PR DESCRIPTION
* Add normalization filter to identify and extract extent values. This filter is typically applied to the format field but can be applied anywhere.
* Applies this normalization to Ohio format field mapping
* Add associated tests