### PR TITLE
Add support for ISO-639-1 in Language enrichment

### DIFF
--- a/src/main/resources/languages/iso639-1.csv
+++ b/src/main/resources/languages/iso639-1.csv
@@ -1,0 +1,206 @@
+# See http://www.loc.gov/standards/iso639-2/
+# code, English label
+aa,Afar
+ab,Abkhazian
+ae,Avestan
+af,Afrikaans
+ak,Akan
+am,Amharic
+an,Aragonese
+ar,Arabic
+as,Assamese
+av,Avaric
+ay,Aymara
+az,Azerbaijani
+ba,Bashkir
+be,Belarusian
+bg,Bulgarian
+bh,Bihari languages
+bi,Bislama
+bm,Bambara
+bn,Bengali
+bo,Tibetan
+bo,Tibetan
+br,Breton
+bs,Bosnian
+ca,Catalan; Valencian
+ce,Chechen
+ch,Chamorro
+co,Corsican
+cr,Cree
+cs,Czech
+cs,Czech
+cu,Old Slavonic
+cv,Chuvash
+cy,Welsh
+cy,Welsh
+da,Danish
+de,German
+de,German
+dv,Divehi; Dhivehi; Maldivian
+dz,Dzongkha
+ee,Ewe
+el,"Greek, Modern (1453-)"
+el,"Greek, Modern (1453-)"
+en,English
+eo,Esperanto
+es,Spanish; Castilian
+et,Estonian
+eu,Basque
+eu,Basque
+fa,Persian
+fa,Persian
+ff,Fulah
+fi,Finnish
+fj,Fijian
+fo,Faroese
+fr,French
+fr,French
+fy,Western Frisian
+ga,Irish
+gd,Gaelic
+gl,Galician
+gn,Guarani
+gu,Gujarati
+gv,Manx
+ha,Hausa
+he,Hebrew
+hi,Hindi
+ho,Hiri Motu
+hr,Croatian
+ht,Haitian
+hu,Hungarian
+hy,Armenian
+hy,Armenian
+hz,Herero
+ia,Interlingua (International Auxiliary Language Association)
+id,Indonesian
+ie,Interlingue
+ig,Igbo
+ii,Sichuan Yi
+ik,Inupiaq
+io,Ido
+is,Icelandic
+is,Icelandic
+it,Italian
+iu,Inuktitut
+ja,Japanese
+jv,Javanese
+ka,Georgian
+ka,Georgian
+kg,Kongo
+ki,Kikuyu
+kj,Kuanyama
+kk,Kazakh
+kl,Kalaallisut; Greenlandic
+km,Central Khmer
+kn,Kannada
+ko,Korean
+kr,Kanuri
+ks,Kashmiri
+ku,Kurdish
+kv,Komi
+kw,Cornish
+ky,Kirghiz
+la,Latin
+lb,Luxembourgish
+lg,Ganda
+li,Limburgan
+ln,Lingala
+lo,Lao
+lt,Lithuanian
+lu,Luba-Katanga
+lv,Latvian
+mg,Malagasy
+mh,Marshallese
+mi,Maori
+mi,Maori
+mk,Macedonian
+mk,Macedonian
+ml,Malayalam
+mn,Mongolian
+mr,Marathi
+ms,Malay
+ms,Malay
+mt,Maltese
+my,Burmese
+my,Burmese
+na,Nauru
+nb,"Bokmål, Norwegian"
+nd,"Ndebele, North"
+ne,Nepali
+ng,Ndonga
+nl,Flemish
+nl,Flemish
+nn,Norwegian Nynorsk
+no,Norwegian
+nr,"Ndebele, South; South Ndebele"
+nv,Navajo; Navaho
+ny,Chichewa; Chewa; Nyanja
+oc,Occitan (post 1500)
+oj,Ojibwa
+om,Oromo
+or,Oriya
+os,Ossetian; Ossetic
+pa,Panjabi; Punjabi
+pi,Pali
+pl,Polish
+ps,Pushto; Pashto
+pt,Portuguese
+qu,Quechua
+rm,Romansh
+rn,Rundi
+ro,Romanian; Moldavian; Moldovan
+ro,Romanian; Moldavian; Moldovan
+ru,Russian
+rw,Kinyarwanda
+sa,Sanskrit
+sc,Sardinian
+sd,Sindhi
+se,Northern Sami
+sg,Sango
+si,Sinhala; Sinhalese
+sk,Slovak
+sk,Slovak
+sl,Slovenian
+sm,Samoan
+sn,Shona
+so,Somali
+sq,Albanian
+sq,Albanian
+sr,Serbian
+ss,Swati
+st,"Sotho, Southern"
+su,Sundanese
+sv,Swedish
+sw,Swahili
+ta,Tamil
+te,Telugu
+tg,Tajik
+th,Thai
+ti,Tigrinya
+tk,Turkmen
+tl,Tagalog
+tn,Tswana
+to,Tonga (Tonga Islands)
+tr,Turkish
+ts,Tsonga
+tt,Tatar
+tw,Twi
+ty,Tahitian
+ug,Uighur; Uyghur
+uk,Ukrainian
+ur,Urdu
+uz,Uzbek
+ve,Venda
+vi,Vietnamese
+vo,Volapük
+wa,Walloon
+wo,Wolof
+xh,Xhosa
+yi,Yiddish
+yo,Yoruba
+za,Zhuang; Chuang
+zh,Chinese
+zh,Chinese
+zu,Zulu

--- a/src/main/resources/languages/iso639-3.csv
+++ b/src/main/resources/languages/iso639-3.csv
@@ -1890,7 +1890,6 @@ emx,Erromintxela
 emy,Epigraphic Mayan
 ena,Apali
 enb,Markweeta
-enc,En
 end,Ende
 enf,Forest Enets
 eng,English

--- a/src/main/scala/dpla/ingestion3/enrichments/LanguageEnrichment.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/LanguageEnrichment.scala
@@ -12,6 +12,7 @@ class LanguageEnrichment extends FileLoader with VocabEnrichment[SkosConcept] {
   private val fileList = Seq(
     "/languages/iso639-2.csv",
     "/languages/iso639-3.csv",
+    "/languages/iso639-1.csv",
     "/languages/dpla-lang.csv"
   )
 

--- a/src/test/scala/dpla/ingestion3/enrichments/LanguageEnrichmentTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/LanguageEnrichmentTest.scala
@@ -17,6 +17,16 @@ class LanguageEnrichmentTest extends FlatSpec with BeforeAndAfter {
     )
     assert(languageEnrichment.enrichLanguage(originalValue) === expectedValue)
   }
+  it should "return an enriched SkosConcept for 'en'" in {
+    val originalValue = SkosConcept(
+      providedLabel = Some("en")
+    )
+    val expectedValue = SkosConcept(
+      providedLabel = Some("en"),
+      concept = Some("English")
+    )
+    assert(languageEnrichment.enrichLanguage(originalValue) === expectedValue)
+  }
   it should "return the original SkosConcept when given a invalid language code" in {
     val originalValue = SkosConcept(providedLabel = Option("b__"))
     assert(languageEnrichment.enrichLanguage(originalValue) === originalValue)


### PR DESCRIPTION
* Add language resource file for iso-639-1 language codes
* Add test for iso-639 value
* Add ISO-639-1 to the default language enrichment lookup values
* Remove `enc,En` language code from iso639-3 resource file. Was able to consistently replicate behavior where a providedLabel code `en` would match iso639 code`enc`. I was also able to replicate the same bad matching on `env`, `enp`, and `enx` but not `enz`.  From my data review it appears that this was the only code creating bad data for Wisconsin. 