### PR TITLE
Refactor harvester writes

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/Harvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/Harvester.scala
@@ -86,6 +86,7 @@ abstract class LocalHarvester(
   // Instead, they are written to this temp path,
   //   then loaded into a spark DataFrame,
   //   then written to their final destination.
+  // TODO: make tmp path configurable rather than hard-coded
   val tmpOutStr = s"/tmp/$shortName"
 
   // Delete temporary output directory and files if they already exist.

--- a/src/main/scala/dpla/ingestion3/harvesters/Harvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/Harvester.scala
@@ -1,11 +1,13 @@
 package dpla.ingestion3.harvesters
 
+import java.io.File
+
 import com.databricks.spark.avro._
 import dpla.ingestion3.confs.i3Conf
 import dpla.ingestion3.utils.{FlatFileIO, Utils}
 import org.apache.avro.Schema
 import org.apache.avro.file.DataFileWriter
-import org.apache.avro.generic.{GenericRecord}
+import org.apache.avro.generic.GenericRecord
 import org.apache.log4j.Logger
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -86,6 +88,9 @@ abstract class LocalHarvester(
   //   then written to their final destination.
   val tmpOutStr = s"/tmp/$shortName"
 
+  // Delete temporary output directory and files if they already exist.
+  Utils.deleteRecursively(new File(tmpOutStr))
+
   private val avroWriter: DataFileWriter[GenericRecord] =
     AvroHelper.avroWriter(shortName, tmpOutStr, Harvester.schema)
 
@@ -94,7 +99,7 @@ abstract class LocalHarvester(
   override def cleanUp(): Unit = {
     avroWriter.close()
     // Delete temporary output directory and files.
-    new FlatFileIO().deletePathContents(tmpOutStr)
+    Utils.deleteRecursively(new File(tmpOutStr))
   }
 }
 

--- a/src/main/scala/dpla/ingestion3/harvesters/Harvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/Harvester.scala
@@ -35,7 +35,7 @@ abstract class Harvester(spark: SparkSession,
       logger.info(s"Saving to $outStr")
       cleanUp()
 
-      // Read the saved avro file back
+      // Reads the saved avro file back
       spark.read.avro(outStr)
     } match {
       case Success(df) =>
@@ -93,6 +93,7 @@ abstract class LocalHarvester(
 
   override def cleanUp(): Unit = {
     avroWriter.close()
+    // Delete temporary output directory and files.
     new FlatFileIO().deletePathContents(tmpOutStr)
   }
 }

--- a/src/main/scala/dpla/ingestion3/harvesters/Harvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/Harvester.scala
@@ -1,19 +1,14 @@
 package dpla.ingestion3.harvesters
 
-import java.io.File
-import java.net.URL
-
 import com.databricks.spark.avro._
 import dpla.ingestion3.confs.i3Conf
-import dpla.ingestion3.harvesters.api.{ApiError, ApiRecord, ApiResponse}
-import dpla.ingestion3.utils.{AvroUtils, AwsUtils, FlatFileIO, Utils}
+import dpla.ingestion3.utils.{FlatFileIO, Utils}
 import org.apache.avro.Schema
 import org.apache.avro.file.DataFileWriter
-import org.apache.avro.generic.{GenericData, GenericRecord}
+import org.apache.avro.generic.{GenericRecord}
 import org.apache.log4j.Logger
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.apache.spark.{SparkConf, SparkContext}
 
 import scala.util.{Failure, Success, Try}
 
@@ -28,10 +23,19 @@ abstract class Harvester(spark: SparkSession,
     // Call local implementation of runHarvest()
     Try {
       // Calls the local implementation
-      localHarvest()
+      val harvestData: DataFrame = localHarvest()
+
+      // Write harvested data to output file.
+      harvestData
+        .write
+        .format("com.databricks.spark.avro")
+        .option("avroSchema", harvestData.schema.toString)
+        .avro(outStr)
+
       logger.info(s"Saving to $outStr")
       cleanUp()
-      // Reads the saved avro file back
+
+      // Read the saved avro file back
       spark.read.avro(outStr)
     } match {
       case Success(df) =>
@@ -45,7 +49,7 @@ abstract class Harvester(spark: SparkSession,
 
   def mimeType: String
 
-  def localHarvest(): Unit
+  def localHarvest(): DataFrame
 
   def cleanUp(): Unit = Unit
 
@@ -75,13 +79,22 @@ abstract class LocalHarvester(
                                logger: Logger)
   extends Harvester(spark, shortName, conf, outStr, logger) {
 
+  // Temporary output path.
+  // Harvests that use AvroWriter cannot be written directly to S3.
+  // Instead, they are written to this temp path,
+  //   then loaded into a spark DataFrame,
+  //   then written to their final destination.
+  val tmpOutStr = s"/tmp/$shortName"
+
   private val avroWriter: DataFileWriter[GenericRecord] =
-    AvroHelper.avroWriter(shortName, outStr, Harvester.schema)
+    AvroHelper.avroWriter(shortName, tmpOutStr, Harvester.schema)
 
   def getAvroWriter: DataFileWriter[GenericRecord] = avroWriter
 
-  override def cleanUp(): Unit = avroWriter.close()
-
+  override def cleanUp(): Unit = {
+    avroWriter.close()
+    new FlatFileIO().deletePathContents(tmpOutStr)
+  }
 }
 
 object Harvester {

--- a/src/main/scala/dpla/ingestion3/harvesters/api/CdlHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/CdlHarvester.scala
@@ -7,9 +7,10 @@ import dpla.ingestion3.confs.i3Conf
 import dpla.ingestion3.utils.HttpUtils
 import org.apache.http.client.utils.URIBuilder
 import org.apache.log4j.Logger
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.json4s.DefaultFormats
 import org.json4s.jackson.JsonMethods._
+import com.databricks.spark.avro._
 
 import scala.util.{Failure, Success}
 
@@ -35,7 +36,7 @@ class CdlHarvester(spark: SparkSession,
     "api_key" -> conf.harvest.apiKey
   ).collect{ case (key, Some(value)) => key -> value } // remove None values
 
-  override def localHarvest: Unit = {
+  override def localHarvest: DataFrame = {
     implicit val formats = DefaultFormats
 
     // Mutable vars for controlling harvest loop
@@ -84,6 +85,8 @@ class CdlHarvester(spark: SparkSession,
             continueHarvest = false
         }
     }
+    // Read harvested data into Spark DataFrame and return.
+    spark.read.avro(tmpOutStr)
   }
 
   /**

--- a/src/main/scala/dpla/ingestion3/harvesters/api/LocHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/LocHarvester.scala
@@ -6,13 +6,14 @@ import dpla.ingestion3.confs.i3Conf
 import dpla.ingestion3.utils.HttpUtils
 import org.apache.http.client.utils.URIBuilder
 import org.apache.log4j.Logger
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.json4s.DefaultFormats
 import org.json4s.jackson.JsonMethods._
 
 import scala.collection.mutable.ListBuffer
 import scala.util.{Failure, Success, Try}
 import scala.xml.XML
+import com.databricks.spark.avro._
 
 /**
   * Class for harvesting records from the Library of Congress's API
@@ -38,7 +39,7 @@ class LocHarvester(spark: SparkSession,
   /**
     * Entry method for invoking LC harvest
     */
-  override def localHarvest: Unit = {
+  override def localHarvest: DataFrame = {
     implicit val formats = DefaultFormats
     // Get sets from conf
     val collections = conf.harvest.setlist
@@ -90,6 +91,9 @@ class LocHarvester(spark: SparkSession,
 
     // @see ApiHarvester
     saveOutAll(locFetched)
+
+    // Read harvested data into Spark DataFrame and return.
+    spark.read.avro(tmpOutStr)
   }
 
   /**

--- a/src/main/scala/dpla/ingestion3/harvesters/api/MdlHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/MdlHarvester.scala
@@ -7,10 +7,10 @@ import dpla.ingestion3.confs.i3Conf
 import dpla.ingestion3.utils.HttpUtils
 import org.apache.http.client.utils.URIBuilder
 import org.apache.log4j.Logger
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.json4s.DefaultFormats
 import org.json4s.jackson.JsonMethods._
+import com.databricks.spark.avro._
 
 import scala.util.{Failure, Success}
 
@@ -28,7 +28,7 @@ class MdlHarvester(spark: SparkSession,
     "rows" -> conf.harvest.rows.getOrElse("10")
   )
 
-  override def localHarvest: Unit = {
+  override def localHarvest: DataFrame = {
     implicit val formats = DefaultFormats
 
     // Mutable vars for controlling harvest loop
@@ -70,6 +70,9 @@ class MdlHarvester(spark: SparkSession,
         harvestLogger.error("Harvest returned None")
         continueHarvest = false
     }
+
+    // Read harvested data into Spark DataFrame and return.
+    spark.read.avro(tmpOutStr)
   }
 
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/FileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/FileHarvester.scala
@@ -1,7 +1,7 @@
 package dpla.ingestion3.harvesters.file
 
 import dpla.ingestion3.confs.i3Conf
-import dpla.ingestion3.harvesters.{AvroHelper, Harvester, LocalHarvester}
+import dpla.ingestion3.harvesters.{Harvester, LocalHarvester}
 import org.apache.avro.generic.GenericData
 import org.apache.log4j.Logger
 import org.apache.spark.sql.SparkSession

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NaraFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NaraFileHarvester.scala
@@ -4,13 +4,12 @@ import java.io.{File, FileInputStream}
 import java.util.zip.GZIPInputStream
 
 import dpla.ingestion3.confs.i3Conf
-import org.apache.avro.generic.GenericData
 import org.apache.commons.io.IOUtils
 import org.apache.log4j.Logger
-import org.apache.spark.SparkConf
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.tools.bzip2.CBZip2InputStream
 import org.apache.tools.tar.TarInputStream
+import com.databricks.spark.avro._
 
 import scala.util.{Failure, Success, Try}
 import scala.xml.{MinimizeMode, Node, Utility, XML}
@@ -129,7 +128,7 @@ class NaraFileHarvester(
   /**
     * Executes the plains2peaks harvest
     */
-  override def localHarvest(): Unit = {
+  override def localHarvest(): DataFrame = {
     val harvestTime = System.currentTimeMillis()
     val unixEpoch = harvestTime  / 1000L
     val inFile = new File(conf.harvest.endpoint.getOrElse("in"))
@@ -140,6 +139,8 @@ class NaraFileHarvester(
     else
       harvestFile(inFile, unixEpoch)
 
+    // Read harvested data into Spark DataFrame and return.
+    spark.read.avro(tmpOutStr)
   }
 
   private def harvestFile(file: File, unixEpoch: Long): Unit = {

--- a/src/main/scala/dpla/ingestion3/harvesters/file/P2PFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/P2PFileHarvester.scala
@@ -7,10 +7,10 @@ import dpla.ingestion3.confs.i3Conf
 import dpla.ingestion3.mappers.utils.JsonExtractor
 import org.apache.commons.io.IOUtils
 import org.apache.log4j.Logger
-import org.apache.spark.SparkConf
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.json4s.jackson.JsonMethods._
 import org.json4s.{JValue, _}
+import com.databricks.spark.avro._
 
 import scala.util.{Failure, Success, Try}
 
@@ -118,7 +118,7 @@ class P2PFileHarvester(spark: SparkSession,
   /**
     * Executes the plains2peaks harvest
     */
-  override def localHarvest(): Unit = {
+  override def localHarvest(): DataFrame = {
     val harvestTime = System.currentTimeMillis()
     val unixEpoch = harvestTime / 1000L
     val inFiles = new File(conf.harvest.endpoint.getOrElse("in"))
@@ -137,6 +137,9 @@ class P2PFileHarvester(spark: SparkSession,
       }).sum
       IOUtils.closeQuietly(inputStream)
     })
+
+    // Read harvested data into Spark DataFrame and return.
+    spark.read.avro(tmpOutStr)
   }
 }
 

--- a/src/main/scala/dpla/ingestion3/harvesters/pss/PssHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/pss/PssHarvester.scala
@@ -5,10 +5,6 @@ import dpla.ingestion3.harvesters.Harvester
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.log4j.Logger
 import org.apache.spark.sql.functions._
-import com.databricks.spark.avro._
-import org.apache.spark.SparkConf
-
-import scala.util.Try
 
 class PssHarvester(spark: SparkSession,
                    shortName: String,
@@ -19,7 +15,7 @@ class PssHarvester(spark: SparkSession,
 
   override def mimeType: String = "application_json"
 
-  override def localHarvest: Unit = Try{
+  override def localHarvest: DataFrame = {
 
     val endpoint = conf.harvest.endpoint
       .getOrElse(throw new RuntimeException("No endpoint specified."))
@@ -32,16 +28,11 @@ class PssHarvester(spark: SparkSession,
     val startTime = System.currentTimeMillis()
     val unixEpoch = startTime / 1000L
 
-    val finalData: DataFrame = harvestedData
+    // Return DataFrame
+    harvestedData
       .withColumn("ingestDate", lit(unixEpoch))
       .withColumn("provider", lit(shortName))
       .withColumn("mimetype", lit(mimeType))
-
-    // Write harvested data to file.
-    finalData.write
-      .format("com.databricks.spark.avro")
-      .option("avroSchema", finalData.schema.toString)
-      .avro(outputDir)
   }
 
   override def cleanUp(): Unit = Unit

--- a/src/main/scala/dpla/ingestion3/utils/OutputHelper.scala
+++ b/src/main/scala/dpla/ingestion3/utils/OutputHelper.scala
@@ -1,5 +1,0 @@
-package dpla.ingestion3.utils
-
-class OutputHelper {
-
-}

--- a/src/main/scala/dpla/ingestion3/utils/OutputHelper.scala
+++ b/src/main/scala/dpla/ingestion3/utils/OutputHelper.scala
@@ -1,0 +1,5 @@
+package dpla.ingestion3.utils
+
+class OutputHelper {
+
+}


### PR DESCRIPTION
This refactors harvester writes, making them more consistent across different harvest types.  This is groundwork for the larger project of making consistent S3 writes across ingestion3.

Summary of changes:
* The `localHarvest` method in all harvesters returns a `DataFrame` of the harvested data.  Before, they were returning `Unit`.
* Writing to the given `outStr` path is handled by the main `harvest` method in the abstract `Harvester` class.  Before, each individual harvester handled its own writes to `outStr`.  This will work whether `outStr` is a local filepath or an S3 bucket.
* Centralized harvesters that use the `AvroWriter` write data to a `/tmp` file, then load data from the `/tmp` file into a spark `DataFrame`.  Then, the data is written to its final destination, be it a local filepath or S3.  Before, they were writing to a local filepath.  This system would have gotten quite complicated with the introduction of S3, since the `AvroWriter` cannot write directly to S3. 

Pros of new system:
* The harvester does not need to know whether the `outStr` is local or S3.
* We can rely on the Spark Avro interface to write files to S3 in all cases.
* More consistency across harvesters.

Cons of new system:
* A small inefficiency is introduced when when writing centralized harvests to local files b/c they will first be written to a local `tmp/` path and then be written to a different final output path.