### PR TITLE
Write harvests in executor

### DIFF
--- a/src/main/scala/dpla/ingestion3/entries/ingest/HarvestEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/HarvestEntry.scala
@@ -1,7 +1,5 @@
 package dpla.ingestion3.entries.ingest
 
-import java.io.File
-
 import dpla.ingestion3.confs.{CmdArgs, Ingestion3Conf, i3Conf}
 import dpla.ingestion3.executors.HarvestExecutor
 import dpla.ingestion3.utils.Utils
@@ -22,7 +20,7 @@ object HarvestEntry extends HarvestExecutor {
     // Read in command line args.
     val cmdArgs = new CmdArgs(args)
 
-    val outputDir = cmdArgs.getOutput()
+    val dataOut = cmdArgs.getOutput()
     val confFile = cmdArgs.getConfigFile()
     val shortName = cmdArgs.getProviderName()
 
@@ -32,8 +30,6 @@ object HarvestEntry extends HarvestExecutor {
     // Load configuration from file.
     val i3Conf = new Ingestion3Conf(confFile, Some(shortName))
     val providerConf: i3Conf = i3Conf.load()
-
-    val dataOut: String = Utils.outputPath(outputDir, shortName, "harvest")
 
     val sparkConf = new SparkConf()
       .setAppName("Harvest")

--- a/src/main/scala/dpla/ingestion3/executors/HarvestExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/HarvestExecutor.scala
@@ -1,15 +1,15 @@
 package dpla.ingestion3.executors
 
+import com.databricks.spark.avro._
 import dpla.ingestion3.confs.i3Conf
 import dpla.ingestion3.harvesters.Harvester
-import dpla.ingestion3.harvesters.file.FileHarvester
 import dpla.ingestion3.harvesters.oai.OaiHarvester
 import dpla.ingestion3.harvesters.pss.PssHarvester
 import dpla.ingestion3.harvesters.resourceSync.RsHarvester
-import dpla.ingestion3.utils.ProviderRegistry
+import dpla.ingestion3.utils.{OutputHelper, ProviderRegistry, Utils}
 import org.apache.log4j.Logger
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{DataFrame, SparkSession}
 
 import scala.util.{Failure, Success, Try}
 
@@ -28,13 +28,15 @@ trait HarvestExecutor {
     */
   def execute(sparkConf: SparkConf,
               shortName: String,
-              outputDir: String,
+              dataOut: String,
               conf: i3Conf,
               logger: Logger): Try[Long] = {
 
     // Log config file location and provider short name.
     logger.info(s"Harvest initiated")
     logger.info(s"Provider short name: $shortName")
+
+    val outputDir: String = OutputHelper.outputPath(dataOut, shortName, "harvest")
 
     //todo build spark here
     val spark = SparkSession.builder()
@@ -45,20 +47,47 @@ trait HarvestExecutor {
     val harvestType = conf.harvest.harvestType
       .getOrElse(throw new RuntimeException("No harvest type specified."))
     logger.info(s"Harvest type: $harvestType")
-    val harvester = buildHarvester(spark, shortName, outputDir, conf, logger, harvestType)
-    val result = harvester.harvest
+    val harvester = buildHarvester(spark, shortName, conf, logger, harvestType)
+
+    val start = System.currentTimeMillis()
+
+    // Call local implementation of runHarvest()
+    val result = Try {
+      // Calls the local implementation
+      val harvestData: DataFrame = harvester.harvest
+
+      // Write harvested data to output file.
+      harvestData
+        .write
+        .format("com.databricks.spark.avro")
+        .option("avroSchema", harvestData.schema.toString)
+        .avro(outputDir)
+
+      logger.info(s"Saving to $outputDir")
+
+      // Reads the saved avro file back
+      spark.read.avro(outputDir)
+    } match {
+      case Success(df) =>
+        Harvester.validateSchema(df)
+        val recordCount = df.count()
+        logger.info(Utils.harvestSummary(System.currentTimeMillis() - start, recordCount))
+        Success(recordCount)
+      case Failure(f) => Failure(f)
+    }
+
     spark.stop()
     result
   }
 
-  private def buildHarvester(spark: SparkSession, shortName: String, outputDir: String, conf: i3Conf, logger: Logger, harvestType: String) = {
+  private def buildHarvester(spark: SparkSession, shortName: String, conf: i3Conf, logger: Logger, harvestType: String) = {
     harvestType match {
       case "oai" =>
-        new OaiHarvester(spark, shortName, conf, outputDir, logger)
+        new OaiHarvester(spark, shortName, conf, logger)
       case "pss" =>
-        new PssHarvester(spark, shortName, conf, outputDir, logger)
+        new PssHarvester(spark, shortName, conf, logger)
       case "rs" =>
-        new RsHarvester(spark, shortName, conf, outputDir, logger)
+        new RsHarvester(spark, shortName, conf, logger)
       case "api" | "file" =>
         val harvesterClass = ProviderRegistry.lookupHarvesterClass(shortName) match {
           case Success(harvClass) => harvClass
@@ -67,8 +96,8 @@ trait HarvestExecutor {
             throw e
         }
         harvesterClass
-          .getConstructor(classOf[SparkSession], classOf[String], classOf[i3Conf], classOf[String], classOf[Logger])
-          .newInstance(spark, shortName, conf, outputDir, logger)
+          .getConstructor(classOf[SparkSession], classOf[String], classOf[i3Conf], classOf[Logger])
+          .newInstance(spark, shortName, conf, logger)
 
       case _ =>
         val msg = s"Harvest type not recognized."
@@ -76,4 +105,5 @@ trait HarvestExecutor {
         throw new RuntimeException(msg)
     }
   }
+
 }

--- a/src/main/scala/dpla/ingestion3/harvesters/api/ApiHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/ApiHarvester.scala
@@ -17,9 +17,8 @@ import org.apache.spark.sql.SparkSession
 abstract class ApiHarvester(spark: SparkSession,
                             shortName: String,
                             conf: i3Conf,
-                            outputDir: String,
                             logger: Logger)
-  extends LocalHarvester(spark, shortName, conf, outputDir, logger) {
+  extends LocalHarvester(spark, shortName, conf, logger) {
 
   // Abstract method queryParams should set base query parameters for API call.
   protected val queryParams: Map[String, String]

--- a/src/main/scala/dpla/ingestion3/harvesters/api/CdlHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/CdlHarvester.scala
@@ -24,9 +24,8 @@ import scala.util.{Failure, Success}
 class CdlHarvester(spark: SparkSession,
                    shortName: String,
                    conf: i3Conf,
-                   outputDir: String,
                    harvestLogger: Logger)
-  extends ApiHarvester(spark, shortName, conf, outputDir, harvestLogger) {
+  extends ApiHarvester(spark, shortName, conf, harvestLogger) {
 
   def mimeType: String = "application_json"
 

--- a/src/main/scala/dpla/ingestion3/harvesters/api/LocHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/LocHarvester.scala
@@ -25,9 +25,8 @@ import com.databricks.spark.avro._
 class LocHarvester(spark: SparkSession,
                    shortName: String,
                    conf: i3Conf,
-                   outputDir: String,
                    harvestLogger: Logger)
-  extends ApiHarvester(spark, shortName, conf, outputDir, harvestLogger) {
+  extends ApiHarvester(spark, shortName, conf, harvestLogger) {
 
   def mimeType: String = "application_json"
 

--- a/src/main/scala/dpla/ingestion3/harvesters/api/MdlHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/MdlHarvester.scala
@@ -17,9 +17,8 @@ import scala.util.{Failure, Success}
 class MdlHarvester(spark: SparkSession,
                    shortName: String,
                    conf: i3Conf,
-                   outputDir: String,
                    harvestLogger: Logger)
-  extends ApiHarvester(spark, shortName, conf, outputDir, harvestLogger) {
+  extends ApiHarvester(spark, shortName, conf, harvestLogger) {
 
   def mimeType: String = "application_json"
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/FileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/FileHarvester.scala
@@ -20,9 +20,8 @@ import scala.util.Try
 abstract class FileHarvester(spark: SparkSession,
                              shortName: String,
                              conf: i3Conf,
-                             outputDir: String,
                              logger: Logger)
-  extends LocalHarvester(spark, shortName, conf, outputDir, logger) {
+  extends LocalHarvester(spark, shortName, conf, logger) {
 
 
   /**

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NaraFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NaraFileHarvester.scala
@@ -19,9 +19,8 @@ class NaraFileHarvester(
                          spark: SparkSession,
                          shortName: String,
                          conf: i3Conf,
-                         outputDir: String,
                          logger: Logger)
-  extends FileHarvester(spark, shortName, conf, outputDir, logger) {
+  extends FileHarvester(spark, shortName, conf, logger) {
 
   def mimeType: String = "application_xml"
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/P2PFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/P2PFileHarvester.scala
@@ -26,9 +26,8 @@ class P2PFileExtractor extends JsonExtractor
 class P2PFileHarvester(spark: SparkSession,
                        shortName: String,
                        conf: i3Conf,
-                       outputDir: String,
                        logger: Logger)
-  extends FileHarvester(spark, shortName, conf, outputDir, logger) {
+  extends FileHarvester(spark, shortName, conf, logger) {
 
   def mimeType: String = "application_json"
 

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/OaiHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/OaiHarvester.scala
@@ -11,9 +11,8 @@ import org.apache.spark.storage.StorageLevel
 class OaiHarvester(spark: SparkSession,
                    shortName: String,
                    conf: i3Conf,
-                   outputDir: String,
                    harvestLogger: Logger)
-  extends Harvester(spark, shortName, conf, outputDir, harvestLogger) {
+  extends Harvester(spark, shortName, conf, harvestLogger) {
 
   override def mimeType: String = "application_xml"
 

--- a/src/main/scala/dpla/ingestion3/harvesters/pss/PssHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/pss/PssHarvester.scala
@@ -9,9 +9,8 @@ import org.apache.spark.sql.functions._
 class PssHarvester(spark: SparkSession,
                    shortName: String,
                    conf: i3Conf,
-                   outputDir: String,
                    harvestLogger: Logger)
-  extends Harvester(spark, shortName, conf, outputDir, harvestLogger) {
+  extends Harvester(spark, shortName, conf, harvestLogger) {
 
   override def mimeType: String = "application_json"
 

--- a/src/main/scala/dpla/ingestion3/harvesters/resourceSync/RsHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/resourceSync/RsHarvester.scala
@@ -9,9 +9,8 @@ import org.apache.spark.sql.functions.lit
 class RsHarvester(spark: SparkSession,
                   shortName: String,
                   conf: i3Conf,
-                  outputDir: String,
                   harvestLogger: Logger)
-  extends Harvester(spark, shortName, conf, outputDir, harvestLogger) {
+  extends Harvester(spark, shortName, conf, harvestLogger) {
 
   // TODO Do all RS enpoints support JSON?
   override def mimeType: String = "application_json"

--- a/src/main/scala/dpla/ingestion3/utils/OutputHelper.scala
+++ b/src/main/scala/dpla/ingestion3/utils/OutputHelper.scala
@@ -1,0 +1,38 @@
+package dpla.ingestion3.utils
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+object OutputHelper {
+
+  /*
+   * Get output path for a harvest, mapping, enrichment, or indexing activity.
+   *
+   * @example:
+   *   outputPath("s3://dpla-master-dataset", "cdl", "harvest") =>
+   *   "s3://dpla-master-dataset/cdl/harvest/20170209_104428-cdl-OriginalRecord.avro"
+   *
+   * @see https://digitalpubliclibraryofamerica.atlassian.net/wiki/spaces/TECH/pages/84512319/Ingestion+3+Storage+Specification
+   */
+  def outputPath(directory: String, shortName: String, activity: String): String = {
+
+    val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")
+    val timestamp: String = LocalDateTime.now.format(formatter)
+
+    // TODO: handle "reports" case
+    // TODO: handle "logs" case
+    val schema = activity match {
+      case "harvest" => "OriginalRecord"
+      case "mapping" => "MAP4_0.MAPRecord"
+      case "enrichment" => "MAP4_0.EnrichRecord"
+      case "jsonl" => "MAP3_1.IndexRecord"
+      case _ => throw new RuntimeException(s"Activity '$activity' not recognized")
+    }
+
+    val fileType = if (activity == "jsonl") "jsonl" else "avro"
+
+    val dirWithSlash = if (directory.endsWith("/")) directory else s"$directory/"
+
+    s"$dirWithSlash$shortName/$activity/$timestamp-$shortName-$schema.$fileType"
+  }
+}


### PR DESCRIPTION
This does one more round of refactoring on writing harvests to output files.  It makes writing files the responsibility of `HarvestExecutor` rather than `Harvester`.  This brings harvesters in line with the rest of the app - `Executor`s are responsible for file writing for mapping, enrichments, and reports.  This also saves `Harvester`s from needing to know anything about writing output files. 

This also moves the `outputPath` method out of the `Utils` package and into a `OutputHelper` package, per suggestion by @mdellabitta.  The `OutputHelper` package will be added to in future PRs.

Also, it appears that a bunch of auto-formatting has crept into `Utils`.