### PR TITLE
Manifest writer

### DIFF
--- a/src/main/scala/dpla/ingestion3/executors/HarvestExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/HarvestExecutor.scala
@@ -87,7 +87,10 @@ trait HarvestExecutor {
           "Provider" -> shortName,
           "Record count" -> recordCount.toString
         )
-        outputHelper.writeManifest(manifestOpts)
+        outputHelper.writeManifest(manifestOpts) match {
+          case Success(s) => logger.info(s"Manifest written.")
+          case Failure(f) => logger.warn(s"Manifest failed to write: $f")
+        }
 
         Success(recordCount)
       case Failure(f) => Failure(f)
@@ -122,5 +125,4 @@ trait HarvestExecutor {
         throw new RuntimeException(msg)
     }
   }
-
 }

--- a/src/main/scala/dpla/ingestion3/executors/HarvestExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/HarvestExecutor.scala
@@ -1,5 +1,7 @@
 package dpla.ingestion3.executors
 
+import java.time.LocalDateTime
+
 import com.databricks.spark.avro._
 import dpla.ingestion3.confs.i3Conf
 import dpla.ingestion3.harvesters.Harvester
@@ -36,8 +38,6 @@ trait HarvestExecutor {
     logger.info(s"Harvest initiated")
     logger.info(s"Provider short name: $shortName")
 
-    val outputDir: String = OutputHelper.outputPath(dataOut, shortName, "harvest")
-
     //todo build spark here
     val spark = SparkSession.builder()
       .config(sparkConf)
@@ -47,31 +47,48 @@ trait HarvestExecutor {
     val harvestType = conf.harvest.harvestType
       .getOrElse(throw new RuntimeException("No harvest type specified."))
     logger.info(s"Harvest type: $harvestType")
+
     val harvester = buildHarvester(spark, shortName, conf, logger, harvestType)
 
+    // This start time is used for documentation and output file naming.
+    val startDateTime = LocalDateTime.now
+
+    val outputHelper: OutputHelper =
+      new OutputHelper(dataOut, shortName, "harvest", startDateTime)
+
+    // This start time is used to measure the duration of harvest.
     val start = System.currentTimeMillis()
 
     // Call local implementation of runHarvest()
-    val result = Try {
+    val result: Try[Long] = Try {
       // Calls the local implementation
       val harvestData: DataFrame = harvester.harvest
+      val outputPath = outputHelper.outputPath
 
       // Write harvested data to output file.
       harvestData
         .write
         .format("com.databricks.spark.avro")
         .option("avroSchema", harvestData.schema.toString)
-        .avro(outputDir)
+        .avro(outputPath)
 
-      logger.info(s"Saving to $outputDir")
+      logger.info(s"Saving to $outputPath")
 
       // Reads the saved avro file back
-      spark.read.avro(outputDir)
+      spark.read.avro(outputPath)
     } match {
       case Success(df) =>
         Harvester.validateSchema(df)
         val recordCount = df.count()
         logger.info(Utils.harvestSummary(System.currentTimeMillis() - start, recordCount))
+
+        val manifestOpts: Map[String, String] = Map(
+          "Activity" -> "Harvest",
+          "Provider" -> shortName,
+          "Record count" -> recordCount.toString
+        )
+        outputHelper.writeManifest(manifestOpts)
+
         Success(recordCount)
       case Failure(f) => Failure(f)
     }

--- a/src/main/scala/dpla/ingestion3/utils/OutputHelper.scala
+++ b/src/main/scala/dpla/ingestion3/utils/OutputHelper.scala
@@ -1,38 +1,173 @@
 package dpla.ingestion3.utils
 
-import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.time.LocalDateTime
+import java.io.{BufferedWriter, File, FileWriter}
 
-object OutputHelper {
+import com.amazonaws.services.s3.model.{PutObjectRequest, PutObjectResult}
+import com.amazonaws.services.s3.AmazonS3Client
+
+import scala.util.Try
+
+/*
+ * @param root: Root directory or AWS S3 bucket.
+ *              If `root' is an AWS S3 bucket, it should start with "s3a://".
+ * @param shortName: Provider short name
+ * @param activity: "harvest", "mapping", "enrichment", etc.
+ * @param startDateTime: start dateTime of the activity
+ *
+ * @throws IllegalArgumentException
+ *
+ * @see https://digitalpubliclibraryofamerica.atlassian.net/wiki/spaces/TECH/pages/84512319/Ingestion+3+Storage+Specification
+ *      for details on file naming conventions
+ *
+ */
+class OutputHelper(root: String,
+                   shortName: String,
+                   activity: String,
+                   startDateTime: LocalDateTime) {
 
   /*
-   * Get output path for a harvest, mapping, enrichment, or indexing activity.
-   *
-   * @example:
-   *   outputPath("s3://dpla-master-dataset", "cdl", "harvest") =>
-   *   "s3://dpla-master-dataset/cdl/harvest/20170209_104428-cdl-OriginalRecord.avro"
-   *
-   * @see https://digitalpubliclibraryofamerica.atlassian.net/wiki/spaces/TECH/pages/84512319/Ingestion+3+Storage+Specification
+   * If root is an S3 bucket, ensure that s3a protocol is being used and not
+   * s3 or s3n.
    */
-  def outputPath(directory: String, shortName: String, activity: String): String = {
+  require(!root.startsWith("s3://") && !root.startsWith("s3n://"),
+    "s3a protocol required for writing output")
+
+  /*
+   * File name for a harvest, mapping, enrichment, indexing (etc.) activity.
+   * For full output path, including root directory/bucket, use `outputPath'
+   * Does not include starting "/"
+   *
+   * Evaluate on instantiation so that invalid `activity' is caught immediately.
+   */
+  val fileKey: String = {
 
     val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")
-    val timestamp: String = LocalDateTime.now.format(formatter)
+
+    val timestamp: String = startDateTime.format(formatter)
 
     // TODO: handle "reports" case
     // TODO: handle "logs" case
-    val schema = activity match {
+    // TODO: make schema configurable?
+    val schema: String = activity match {
       case "harvest" => "OriginalRecord"
-      case "mapping" => "MAP4_0.MAPRecord"
-      case "enrichment" => "MAP4_0.EnrichRecord"
+      case "map" => "MAP4_0.MAPRecord"
+      case "enrich" => "MAP4_0.EnrichRecord"
       case "jsonl" => "MAP3_1.IndexRecord"
-      case _ => throw new RuntimeException(s"Activity '$activity' not recognized")
+      case _ => throw new IllegalArgumentException(s"Activity '$activity' not recognized")
     }
 
-    val fileType = if (activity == "jsonl") "jsonl" else "avro"
+    val fileType: String = if (activity == "jsonl") "jsonl" else "avro"
 
-    val dirWithSlash = if (directory.endsWith("/")) directory else s"$directory/"
+    s"$shortName/$activity/$timestamp-$shortName-$schema.$fileType"
+  }
 
-    s"$dirWithSlash$shortName/$activity/$timestamp-$shortName-$schema.$fileType"
+  /*
+   * S3 bucket or root directory for output.
+   * Includes trailing slash.
+   * If S3 bucket, includes "s3a://" prefix.
+   */
+  lazy val directory: String = if (root.endsWith("/")) root else s"$root/"
+
+  /*
+   * Full output path for a harvest, mapping, enrichment, indexing (etc.) activity.
+   * For just the file name, use `fileName'
+   *
+   * @example:
+   *   OutputHelper("s3a://dpla-master-dataset", "cdl", "harvest").outputPath =>
+   *   "s3a://dpla-master-dataset/cdl/harvest/20170209_104428-cdl-OriginalRecord.avro"
+   */
+  lazy val outputPath: String = s"$directory$fileKey"
+
+  /*
+   * Parse S3 bucket name from given `root'.
+   * Does not include trailing slash or "s3a://" prefix.
+   * Returns empty string if unable to parse bucket name.
+   */
+  lazy val bucketName: String = Try{ directory.split("/")(2) }.getOrElse("")
+
+  /*
+   * Get path to manifest file, not including local root directory or s3 bucket.
+   * Manifest will be in the same directory as activity output files.
+   * Does not include starting "/".
+   */
+  lazy val manifestKey: String = s"$fileKey/_MANIFEST"
+
+  /*
+   * Get path to manifest with local root directory.
+   */
+  lazy val manifestLocalOutPath: String = s"$directory$manifestKey"
+
+  /*
+   * Get directory for temporary files.
+   * If system property is not set, uses "/tmp" as default.
+   * TODO: Move to more general File IO Util
+   */
+  lazy val tempDirectory: String = System.getProperty("java.io.tmpdir", "/tmp")
+
+  // TODO Move to more general File IO Util
+  lazy val s3client: AmazonS3Client = new AmazonS3Client()
+
+  /*
+   * Write a manifest file in the given outputPath directory.
+   *
+   * @param outputPath: The directory in which the manifest file is to be written.
+   * @param opts: Optional data points to be included in the manifest file.
+   */
+  def writeManifest(opts: Map[String, String]): Unit = {
+
+    val text: String = manifestText(opts)
+
+    if (outputPath.startsWith("s3a://"))
+      writeS3File(bucketName, manifestKey, text)
+    else
+      writeLocalFile(manifestLocalOutPath, text)
+  }
+
+  /*
+   * Create text for a manifest file.
+   *
+   * @param opts: Optional data points to be included in the manifest file.
+   *              This is intentionally open-ended so that individual executors
+   *              can include whatever data points are relevant to their activity.
+   */
+  val manifestText: Map[String, String] => String = (opts: Map[String, String]) => {
+
+    val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+
+    // Add date/time to given `opts'
+    val data: Map[String, String] =
+      opts + ("Start date/time" -> startDateTime.format(formatter))
+
+    data.map{ case(k, v) => s"$k: $v" }.mkString("\n")
+  }
+
+  // Write a String to a local file.
+  // TODO: Move to more general FileIO Util
+  def writeLocalFile(outPath: String, text: String): File = {
+    val file: File = new File(outPath)
+    file.getParentFile.mkdirs
+    val bw: BufferedWriter = new BufferedWriter(new FileWriter(file))
+    bw.write(text)
+    bw.close()
+    file
+  }
+
+  // Write a String to an S3 file.
+  // TODO: Move to a more general FileIO Util
+  def writeS3File(bucket: String, key: String, text: String): PutObjectResult = {
+    // Write to a temporary local file
+    val tempOut: String = s"$tempDirectory/$key"
+    val tempFile: File = writeLocalFile(tempOut, text)
+
+    // Upload temporary file to s3
+    val putObjectResult: PutObjectResult =
+      s3client.putObject(new PutObjectRequest(bucket, key, tempFile))
+
+    // Delete temporary file
+    tempFile.delete
+
+    putObjectResult
   }
 }

--- a/src/test/scala/dpla/ingestion3/utils/OutputHelperTest.scala
+++ b/src/test/scala/dpla/ingestion3/utils/OutputHelperTest.scala
@@ -1,0 +1,80 @@
+package dpla.ingestion3.utils
+
+import java.time.LocalDateTime
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class OutputHelperTest extends FlatSpec {
+
+  val root = "s3a://my-bucket"
+  val shortName = "foo"
+  val activity = "harvest"
+  val dateTime = LocalDateTime.of(2018, 9, 10, 9, 57, 2)
+
+  val outputHelper = new OutputHelper(root, shortName, activity, dateTime)
+
+  it should "throw exception if s3 protocol is tried" in {
+    assertThrows[IllegalArgumentException](
+      new OutputHelper("s3://my-bucket", shortName, activity, dateTime)
+    )
+  }
+
+  it should "throw exception if s3n protocol is tried" in {
+    assertThrows[IllegalArgumentException](
+      new OutputHelper("s3n://my-bucket", shortName, activity, dateTime)
+    )
+  }
+
+  it should "throw exception if activity not recognized" in {
+    assertThrows[IllegalArgumentException](
+      new OutputHelper(root, shortName, "oops", dateTime)
+    )
+  }
+
+  "outputPath" should "create correct harvest output path" in {
+    val path = "s3a://my-bucket/foo/harvest/20180910_095702-foo-OriginalRecord.avro"
+    assert(outputHelper.outputPath === path)
+  }
+
+  "outputPath" should "create correct map output path" in {
+    val helper = new OutputHelper(root, shortName, "map", dateTime)
+    val path = "s3a://my-bucket/foo/map/20180910_095702-foo-MAP4_0.MAPRecord.avro"
+    assert(helper.outputPath === path)
+  }
+
+  "outputPath" should "create correct enrich output path" in {
+    val helper = new OutputHelper(root, shortName, "enrich", dateTime)
+    val path = "s3a://my-bucket/foo/enrich/20180910_095702-foo-MAP4_0.EnrichRecord.avro"
+    assert(helper.outputPath === path)
+  }
+
+  "outputPath" should "create correct jsonl output path" in {
+    val helper = new OutputHelper(root, shortName, "jsonl", dateTime)
+    val path = "s3a://my-bucket/foo/jsonl/20180910_095702-foo-MAP3_1.IndexRecord.jsonl"
+    assert(helper.outputPath === path)
+  }
+
+  "outputPath" should "create correct local output path" in {
+    val localRoot = "/path/to/local"
+    val helper = new OutputHelper(localRoot, shortName, activity, dateTime)
+    val path = "/path/to/local/foo/harvest/20180910_095702-foo-OriginalRecord.avro"
+    assert(helper.outputPath === path)
+  }
+
+  "bucketName" should "parse s3 bucket from given root" in {
+    val bucket = "my-bucket"
+    assert(outputHelper.bucketName === bucket)
+  }
+
+  "manifestKey" should "create correct manifest key" in {
+    val key = "foo/harvest/20180910_095702-foo-OriginalRecord.avro/_MANIFEST"
+    assert(outputHelper.manifestKey === key)
+  }
+
+  "manifestLocalOutPath" should "create correct local output path for manifest" in {
+    val localRoot = "/path/to/local/"
+    val helper = new OutputHelper(localRoot, shortName, activity, dateTime)
+    val path = "/path/to/local/foo/harvest/20180910_095702-foo-OriginalRecord.avro/_MANIFEST"
+    assert(helper.manifestLocalOutPath === path)
+  }
+}


### PR DESCRIPTION
This adds a manifest writing capabilities to the `OutputHelper` and implements them for harvests only.  It also adds some unit tests.

Out of scope for this PR is moving FileIO functionality to more general utils, or making use of what utils already exist.  This will be the next PR.

I tested this writing locally and to s3.  Here is an example manifest file:

```
Activity: Harvest
Provider: esdn
Record count: 2163
Start date/time: 2018-09-10 14:34:18
```