### PR TITLE
Fix/api save out

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/api/ApiHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/ApiHarvester.scala
@@ -22,6 +22,7 @@ abstract class ApiHarvester(spark: SparkSession,
   // Abstract method queryParams should set base query parameters for API call.
   protected val queryParams: Map[String, String]
 
+  override def cleanUp(): Unit = Unit
 
   /**
     * Writes errors and documents to log file and avro file respectively

--- a/src/main/scala/dpla/ingestion3/utils/Utils.scala
+++ b/src/main/scala/dpla/ingestion3/utils/Utils.scala
@@ -170,10 +170,11 @@ object Utils {
     * @param runtime     Runtime in milliseconds
     * @param recordCount Number of records output
     */
-  def harvestSummary(runtime: Long, recordCount: Long): String = {
+  def harvestSummary(out: String, runtime: Long, recordCount: Long): String = {
     val recordsPerSecond: Long = recordCount / (runtime / 1000)
 
-    s"\n\nRecord count: ${Utils.formatNumber(recordCount)}\n" +
+    s"\n\nSaved to: $out\n" +
+      s"Record count: ${Utils.formatNumber(recordCount)}\n" +
       s"Runtime: ${formatRuntime(runtime)}\n" +
       s"Throughput: ${Utils.formatNumber(recordsPerSecond)} records per second"
   }


### PR DESCRIPTION
- Fix bug where the output from API harvests was being prematurely deleted.

- `HarvestExecutor.execute()` handles all logging and error handling. Previously, errors were bubbling up to `HarvestEntry` but were not handled and failing silently.

- Remove unused imports