### PR TITLE
Use FlatFileIO to write local manifest

### DIFF
--- a/src/main/scala/dpla/ingestion3/executors/HarvestExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/HarvestExecutor.scala
@@ -86,7 +86,7 @@ trait HarvestExecutor {
           "Record count" -> recordCount.toString
         )
         outputHelper.writeManifest(manifestOpts) match {
-          case Success(s) => logger.info(s"Manifest written.")
+          case Success(s) => logger.info(s"Manifest written to $s.")
           case Failure(f) => logger.warn(s"Manifest failed to write: $f")
         }
 

--- a/src/main/scala/dpla/ingestion3/utils/FileIO.scala
+++ b/src/main/scala/dpla/ingestion3/utils/FileIO.scala
@@ -21,10 +21,12 @@ class FlatFileIO extends FileIO {
     *
     * @param record String
     * @param outputFile String
+    *
+    * @return String representation of the file path
     */
-  def writeFile(record: String, outputFile: String): Unit = {
+  def writeFile(record: String, outputFile: String): String = {
     val outFile = new File(outputFile).toPath
-    Files.write(outFile, record.getBytes("utf8"), CREATE, TRUNCATE_EXISTING)
+    Files.write(outFile, record.getBytes("utf8"), CREATE, TRUNCATE_EXISTING).toString
   }
 
   /**
@@ -87,5 +89,5 @@ object AvroUtils {
   *
   */
 trait FileIO {
-  def writeFile(record: String, outputFile: String): Unit
+  def writeFile(record: String, outputFile: String): String
 }


### PR DESCRIPTION
This uses the existing `FlatFileIO.writeFile` method to write a local manifest.  Before, the `OutputHelper` was rolling its own local write method, which was redundant.  In order to make this work, I changed the `FlatFileIO.writeFile` return type from `Unit` to `String`, so it now returns a `String` representation of the file path.  I reviewed all the places in which `FlatFileIO.writeFile` is implemented, and none of the them use the return value at all, so it shouldn't cause problems elsewhere in the system.  

The return value itself isn't so important for the manifest writer, only that is has to return something that can be encapsulated in a `Try`, and it has to be the same return type as the `OutputHelper.writeS3File`.  Instead of a `String`, they could each return `Unit`, but it seemed like a `String` confirming the path of the output file might be more useful for logging.  Let me know if you have a different idea.