### PR TITLE
IngestRemap to use most recent harvested data for mapping and enrichment

### DIFF
--- a/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
@@ -30,15 +30,19 @@ object IngestRemap extends MappingExecutor
     val confFile = cmdArgs.getConfigFile()
     val shortName = cmdArgs.getProviderName()
 
+    // Get logger
+    val logger = Utils.createLogger("ingest", shortName)
+
     // Outputs
-    val harvestDataOut = cmdArgs.getInput()
+    val harvestDataOut = Utils.getMostRecent(  cmdArgs.getInput() )
+      .getOrElse(throw new RuntimeException("Unable to load harvest data"))
+
+    logger.info(s"Using harvest data from $harvestDataOut")
+
     val mapDataOut = baseDataOut+"/mapped"
     val enrichDataOut = baseDataOut+"/enriched"
     val jsonlDataOut = baseDataOut+"/json-l"
     val baseRptOut = baseDataOut+"/reports"
-
-    // Get logger
-    val logger = Utils.createLogger("ingest", shortName)
 
     // Load configuration from file.
     val i3Conf = new Ingestion3Conf(confFile, Some(shortName))

--- a/src/main/scala/dpla/ingestion3/utils/Utils.scala
+++ b/src/main/scala/dpla/ingestion3/utils/Utils.scala
@@ -157,6 +157,24 @@ object Utils {
       true)
   }
 
+  /**
+    * Sorts the contents of the given path to find the most recent folder
+    * within the provided path that ends with '.avro'
+    *
+    * @return Option[String] Absolute path to the most recent data within folder
+    *
+    */
+  def getMostRecent(path: String): Option[String] = {
+    val rootFile = new File(path)
+
+    rootFile
+      .listFiles()
+      .filter(f => f.getName.endsWith(".avro"))
+      .map(f => f.getAbsolutePath)
+      .sorted
+      .lastOption
+  }
+
   // TODO These *Summary methods should be refactored and normalized when we fixup logging
   /**
     * Print the results of an activity


### PR DESCRIPTION
Add method getMostRecent(path: String) to Utils which will return the absolute path to the most recent data folder
IngestRemap uses getMostRecent() to select data to map and enrich