### PR TITLE
Mapping output

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,16 +12,16 @@ lazy val root = (project in file("."))
       "org.scalatest" %% "scalatest" % "3.0.1" % "it,test",
 
       /**
-        * @sw I updated spark core and spark sql from 2.0.1 to 2.1.0 to
-        *     resovle the bulid issues I was having (couldn't resolve
-        *    org.arpache.spark.Schema)
-        *
-        *     TODO test with 2.0.1 on someone else's machine during PR review?
+        * The following dependencies enable S3 file writes:
+        *   spark 2.3.1
+        *   spark-avro 4.0.0
+        *   aws-java-sdk 1.7.4
+        *   hadoop-aws 2.7.6
         */
-      "org.apache.spark" %% "spark-core" % "2.1.0" exclude("org.scalatest", "scalatest_2.11"),
-      "org.apache.spark" %% "spark-sql" % "2.1.0" exclude("org.scalatest", "scalatest_2.11"),
+      "org.apache.spark" %% "spark-core" % "2.3.1" exclude("org.scalatest", "scalatest_2.11"),
+      "org.apache.spark" %% "spark-sql" % "2.3.1" exclude("org.scalatest", "scalatest_2.11"),
       "org.apache.ant" % "ant" % "1.10.1",
-      "com.databricks" %% "spark-avro" % "3.2.0",
+      "com.databricks" %% "spark-avro" % "4.0.0",
       "org.json4s" %% "json4s-core" % "3.2.11" % "provided",
       "org.json4s" %% "json4s-jackson" % "3.2.11" % "provided",
       "org.eclipse.rdf4j" % "rdf4j" % "2.2",
@@ -46,8 +46,8 @@ lazy val root = (project in file("."))
       "org.scalamock" %% "scalamock" % "4.0.0" % "test",
       "com.holdenkarau" %% "spark-testing-base" % "2.1.0_0.8.0" % "test",
       "com.typesafe" % "config" % "1.3.1",
-      "com.amazonaws" % "aws-java-sdk-s3" % "1.10.6",
-      "org.apache.hadoop" % "hadoop-aws" % "2.8.1",
+      "com.amazonaws" % "aws-java-sdk" % "1.7.4",
+      "org.apache.hadoop" % "hadoop-aws" % "2.7.6",
       "com.squareup.okhttp3" % "okhttp" % "3.8.0",
       "com.opencsv" % "opencsv" % "3.7"
     )

--- a/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
@@ -40,9 +40,10 @@ object IngestRemap extends MappingExecutor
 
     logger.info(s"Using harvest data from $harvestDataOut")
     
-    val enrichDataOut = baseDataOut+"/enriched"
-    val jsonlDataOut = baseDataOut+"/json-l"
-    val baseRptOut = baseDataOut+"/reports"
+    val enrichDataOut = baseDataOut+"/"+shortName+"/enriched"
+    val jsonlDataOut = baseDataOut+"/"+shortName+"/json-l"
+    val baseRptOut = baseDataOut+"/"+shortName+"/reports"
+
 
     // Load configuration from file.
     val i3Conf = new Ingestion3Conf(confFile, Some(shortName))
@@ -56,7 +57,6 @@ object IngestRemap extends MappingExecutor
       .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
       .set("spark.kryoserializer.buffer.max", "200")
       .setMaster(sparkMaster)
-
 
     Utils.deleteRecursively(new File(enrichDataOut))
     Utils.deleteRecursively(new File(jsonlDataOut))

--- a/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
@@ -35,8 +35,13 @@ object IngestRemap extends MappingExecutor
 
     // Outputs
 
-    val harvestDataOut = Utils.getMostRecent(  cmdArgs.getInput() )
-      .getOrElse(throw new RuntimeException("Unable to load harvest data"))
+    // If harvest data is NOT on S3, get most recent data.
+    // Else, use the given S3 input filepath.
+    // TODO: get most recent S3 data.
+    val harvestDataOut = if (!baseDataOut.startsWith("s3a://")) {
+      Utils.getMostRecent( cmdArgs.getInput )
+        .getOrElse(throw new RuntimeException("Unable to load harvest data"))
+    } else cmdArgs.getInput
 
     logger.info(s"Using harvest data from $harvestDataOut")
     

--- a/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
@@ -34,12 +34,12 @@ object IngestRemap extends MappingExecutor
     val logger = Utils.createLogger("ingest", shortName)
 
     // Outputs
+
     val harvestDataOut = Utils.getMostRecent(  cmdArgs.getInput() )
       .getOrElse(throw new RuntimeException("Unable to load harvest data"))
 
     logger.info(s"Using harvest data from $harvestDataOut")
-
-    val mapDataOut = baseDataOut+"/mapped"
+    
     val enrichDataOut = baseDataOut+"/enriched"
     val jsonlDataOut = baseDataOut+"/json-l"
     val baseRptOut = baseDataOut+"/reports"
@@ -58,14 +58,13 @@ object IngestRemap extends MappingExecutor
       .setMaster(sparkMaster)
 
 
-    Utils.deleteRecursively(new File(mapDataOut))
     Utils.deleteRecursively(new File(enrichDataOut))
     Utils.deleteRecursively(new File(jsonlDataOut))
     Utils.deleteRecursively(new File(baseRptOut))
 
     // TODO These processes should return some flag or metric to help determine whether to proceed
     // Mapping
-    executeMapping(sparkConf, harvestDataOut, mapDataOut, shortName, logger)
+    val mapDataOut = executeMapping(sparkConf, harvestDataOut, baseDataOut, shortName, logger)
 
     // Enrichment
     executeEnrichment(sparkConf, mapDataOut, enrichDataOut, shortName, logger, conf)

--- a/src/main/scala/dpla/ingestion3/entries/ingest/MappingEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/MappingEntry.scala
@@ -47,7 +47,6 @@ object MappingEntry extends MappingExecutor {
     val sparkConf = new SparkConf()
       .setAppName(s"Mapping: $shortName")
       .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-      .set("spark.hadoop.mapreduce.fileoutputcommitter.algorithm.version", "2")
       .setMaster(sparkMaster)
 
     // Log config file location and provider short name.

--- a/src/main/scala/dpla/ingestion3/entries/ingest/MappingEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/MappingEntry.scala
@@ -51,8 +51,6 @@ object MappingEntry extends MappingExecutor {
       .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
       .setMaster(sparkMaster)
 
-    Utils.deleteRecursively(new File(dataOut))
-
     // Log config file location and provider short name.
     executeMapping(sparkConf, dataIn, dataOut, shortName, logger)
   }

--- a/src/main/scala/dpla/ingestion3/entries/ingest/MappingEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/MappingEntry.scala
@@ -1,7 +1,5 @@
 package dpla.ingestion3.entries.ingest
 
-import java.io.File
-
 import dpla.ingestion3.confs.{CmdArgs, Ingestion3Conf, i3Conf}
 import dpla.ingestion3.executors.MappingExecutor
 import dpla.ingestion3.utils.Utils

--- a/src/main/scala/dpla/ingestion3/entries/ingest/MappingEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/MappingEntry.scala
@@ -47,6 +47,7 @@ object MappingEntry extends MappingExecutor {
     val sparkConf = new SparkConf()
       .setAppName(s"Mapping: $shortName")
       .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+      .set("spark.hadoop.mapreduce.fileoutputcommitter.algorithm.version", "2")
       .setMaster(sparkMaster)
 
     // Log config file location and provider short name.

--- a/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
@@ -93,15 +93,6 @@ trait MappingExecutor extends Serializable {
     // already existing, and will fail to write.
     successResults.where("size(messages.level) == 0").toDF().write.avro(outputPath)
 
-//    val endTime = System.currentTimeMillis()
-
-//    val logsBasePath = outputHelper.logsBasePath
-
-//    // Collect the values needed to generate the report
-//    val finalReport = buildFinalReport(successResults, mappingResults, shortName, logsBasePath, startTime, endTime)(spark)
-//    // Format the summary report and write it log file
-//    logger.info(MappingSummary.getSummary(finalReport))
-
     val manifestOpts: Map[String, String] = Map(
       "Activity" -> "Mapping",
       "Provider" -> shortName,
@@ -112,6 +103,15 @@ trait MappingExecutor extends Serializable {
       case Success(s) => logger.info(s"Manifest written to $s.")
       case Failure(f) => logger.warn(s"Manifest failed to write: $f")
     }
+
+    val endTime = System.currentTimeMillis()
+
+    val logsBasePath = outputHelper.logsBasePath
+
+    // Collect the values needed to generate the report
+    val finalReport = buildFinalReport(successResults, mappingResults, shortName, logsBasePath, startTime, endTime)(spark)
+    // Format the summary report and write it log file
+    logger.info(MappingSummary.getSummary(finalReport))
 
     spark.stop()
   }

--- a/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
@@ -99,6 +99,17 @@ trait MappingExecutor extends Serializable {
 
     successResults.where("size(messages.level) == 0").toDF().write.avro(outputPath)
 
+    val manifestOpts: Map[String, String] = Map(
+      "Activity" -> "Mapping",
+      "Provider" -> shortName,
+      "Record count" -> successResults.count.toString,
+      "Input" -> dataIn
+    )
+    outputHelper.writeManifest(manifestOpts) match {
+      case Success(s) => logger.info(s"Manifest written to $s.")
+      case Failure(f) => logger.warn(s"Manifest failed to write: $f")
+    }
+
     spark.stop()
   }
 

--- a/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
@@ -92,10 +92,10 @@ trait MappingExecutor extends Serializable {
 
     val endTime = System.currentTimeMillis()
 
-    val reportsBasePath = outputHelper.reportsBasePath
+    val logsBasePath = outputHelper.logsBasePath
 
     // Collect the values needed to generate the report
-    val finalReport = buildFinalReport(successResults, mappingResults, shortName, reportsBasePath, startTime, endTime)(spark)
+    val finalReport = buildFinalReport(successResults, mappingResults, shortName, logsBasePath, startTime, endTime)(spark)
     // Format the summary report and write it log file
     logger.info(MappingSummary.getSummary(finalReport))
 
@@ -127,7 +127,7 @@ trait MappingExecutor extends Serializable {
   def buildFinalReport(successResults: Dataset[Row],
                        mappingResults: Dataset[(Row, String)],
                        shortName: String,
-                       reportsBasePath: String,
+                       logsBasePath: String,
                        startTime: Long,
                        endTime: Long)(implicit spark: SparkSession): MappingSummaryData = {
     import spark.implicits._
@@ -172,7 +172,7 @@ trait MappingExecutor extends Serializable {
 
     val logFileSeq = logFileList.map {
       case (name: String, data: Dataset[_]) => {
-        val path = s"$reportsBasePath$name"
+        val path = s"$logsBasePath$name"
         data match {
           case dr: Dataset[Row] => Utils.writeLogsAsCsv(path, name, dr, shortName)
           case ds: Dataset[String] => Utils.writeLogsAsTxt(path, name, ds, shortName)

--- a/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
@@ -172,7 +172,7 @@ trait MappingExecutor extends Serializable {
       "errors" -> errors,
       "warnings" -> warnings,
       "exceptions" -> exceptionsDS
-    )//.filter { case (_, data: Dataset[_]) => data.count() > 0 }
+    )
 
     val logFileSeq = logFileList.map {
       case (name: String, data: Dataset[_]) => {

--- a/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
@@ -46,8 +46,6 @@ trait MappingExecutor extends Serializable {
 
     val outputPath = outputHelper.outputPath
 
-    logger.info(outputPath)
-
     // @michael Any issues with making SparkSession implicit?
     implicit val spark: SparkSession = SparkSession.builder()
       .config(sparkConf)

--- a/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
@@ -33,7 +33,7 @@ trait MappingExecutor extends Serializable {
                       dataIn: String,
                       dataOut: String,
                       shortName: String,
-                      logger: Logger): Unit = {
+                      logger: Logger): String = {
 
     // This start time is used for documentation and output file naming.
     val startDateTime = LocalDateTime.now
@@ -114,6 +114,9 @@ trait MappingExecutor extends Serializable {
     logger.info(MappingSummary.getSummary(finalReport))
 
     spark.stop()
+
+    // Return output destination of mapped records
+    outputPath
   }
 
   /**

--- a/src/main/scala/dpla/ingestion3/utils/OutputHelper.scala
+++ b/src/main/scala/dpla/ingestion3/utils/OutputHelper.scala
@@ -159,13 +159,13 @@ class OutputHelper(root: String,
    * @param key: S3 file key
    * @param text: Text string to be written to S3 file
    *
-   * @return: Try[String] ETag (HTTP entity tag).
+   * @return: Try[String] Path of written file.
    *          Identifier for specific version of the resource just written.
    */
   def writeS3File(bucket: String, key: String, text: String): Try[String] = Try {
     val in = new ByteArrayInputStream(text.getBytes("utf-8"))
-    val putObjectResult: PutObjectResult =
-      s3client.putObject(new PutObjectRequest(bucket, key, in, new ObjectMetadata))
-    putObjectResult.getETag
+    s3client.putObject(new PutObjectRequest(bucket, key, in, new ObjectMetadata))
+    // Return filepath
+    s"$bucket/$key"
   }
 }

--- a/src/main/scala/dpla/ingestion3/utils/OutputHelper.scala
+++ b/src/main/scala/dpla/ingestion3/utils/OutputHelper.scala
@@ -46,7 +46,6 @@ class OutputHelper(root: String,
   val fileKey: String = {
 
     // TODO: handle "reports" case
-    // TODO: handle "logs" case
     // TODO: make schema configurable - could use sealed case classes for activities
     val schema: String = activity match {
       case "harvest" => "OriginalRecord"

--- a/src/main/scala/dpla/ingestion3/utils/OutputHelper.scala
+++ b/src/main/scala/dpla/ingestion3/utils/OutputHelper.scala
@@ -87,6 +87,15 @@ class OutputHelper(root: String,
   lazy val bucketName: String = Try{ directory.split("/")(2) }.getOrElse("")
 
   /*
+   * Parse any directories nested under an S3 bucket.
+   * Does not include leading slash.
+   * Includes trailing slash.
+   * @example if `root' = "s3://foo/bar/bat/" then `bucketNestedDir' = "bar/bat"
+   */
+  lazy val bucketNestedDir: String = directory.stripPrefix("s3a://")
+    .stripPrefix(bucketName).stripPrefix("/")
+
+  /*
    * Get path to manifest file, not including local root directory or s3 bucket.
    * Manifest will be in the same directory as activity output files.
    * Does not include starting "/".
@@ -118,7 +127,7 @@ class OutputHelper(root: String,
     val text: String = manifestText(opts)
 
     if (outputPath.startsWith("s3a://"))
-      writeS3File(bucketName, manifestKey, text)
+      writeS3File(bucketName, s"$bucketNestedDir$manifestKey", text)
     else
       writeLocalFile(manifestLocalOutPath, text)
   }

--- a/src/main/scala/dpla/ingestion3/utils/OutputHelper.scala
+++ b/src/main/scala/dpla/ingestion3/utils/OutputHelper.scala
@@ -21,6 +21,8 @@ import scala.util.Try
  * @see https://digitalpubliclibraryofamerica.atlassian.net/wiki/spaces/TECH/pages/84512319/Ingestion+3+Storage+Specification
  *      for details on file naming conventions
  *
+ * The convention in this class is that methods with "path" in the name include
+ * the root bucket/directory while methods with "key" do not.
  */
 class OutputHelper(root: String,
                    shortName: String,
@@ -49,15 +51,15 @@ class OutputHelper(root: String,
     // TODO: make schema configurable - could use sealed case classes for activities
     val schema: String = activity match {
       case "harvest" => "OriginalRecord"
-      case "map" => "MAP4_0.MAPRecord"
-      case "enrich" => "MAP4_0.EnrichRecord"
+      case "mapping" => "MAP4_0.MAPRecord"
+      case "enrichment" => "MAP4_0.EnrichRecord"
       case "jsonl" => "MAP3_1.IndexRecord"
       case _ => throw new IllegalArgumentException(s"Activity '$activity' not recognized")
     }
 
     val fileType: String = if (activity == "jsonl") "jsonl" else "avro"
 
-    s"$shortName/$activity/$timestamp/$schema.$fileType"
+    s"$shortName/$activity/$timestamp-$shortName-$schema.$fileType"
   }
 
   /*
@@ -100,7 +102,7 @@ class OutputHelper(root: String,
    * Get path to reports directory.
    * Include root bucket/directory and trailing "/".
    */
-  lazy val logsBasePath: String = s"$directory$shortName/$activity/$timestamp/logs/"
+  lazy val logsBasePath: String = s"$directory$fileKey/_LOGS/"
 
   lazy val s3client: AmazonS3Client = new AmazonS3Client
   lazy val flatFileIO: FlatFileIO = new FlatFileIO

--- a/src/main/scala/dpla/ingestion3/utils/OutputHelper.scala
+++ b/src/main/scala/dpla/ingestion3/utils/OutputHelper.scala
@@ -101,7 +101,7 @@ class OutputHelper(root: String,
    * Get path to reports directory.
    * Include root bucket/directory and trailing "/".
    */
-  lazy val reportsBasePath: String = s"$directory$shortName/$activity/$timestamp/reports/"
+  lazy val logsBasePath: String = s"$directory$shortName/$activity/$timestamp/logs/"
 
   lazy val s3client: AmazonS3Client = new AmazonS3Client
   lazy val flatFileIO: FlatFileIO = new FlatFileIO

--- a/src/test/scala/dpla/ingestion3/utils/OutputHelperTest.scala
+++ b/src/test/scala/dpla/ingestion3/utils/OutputHelperTest.scala
@@ -66,6 +66,13 @@ class OutputHelperTest extends FlatSpec {
     assert(outputHelper.bucketName === bucket)
   }
 
+  "bucketNestedDir" should "parse s3 nested directory from given root" in {
+    val nestedRoot = "s3a://foo/bar/bat/"
+    val nestedDir = "bar/bat/"
+    val helper = new OutputHelper(nestedRoot, shortName, activity, dateTime)
+    assert(helper.bucketNestedDir === nestedDir)
+  }
+
   "manifestKey" should "create correct manifest key" in {
     val key = "foo/harvest/20180910_095702-foo-OriginalRecord.avro/_MANIFEST"
     assert(outputHelper.manifestKey === key)

--- a/src/test/scala/dpla/ingestion3/utils/OutputHelperTest.scala
+++ b/src/test/scala/dpla/ingestion3/utils/OutputHelperTest.scala
@@ -32,32 +32,32 @@ class OutputHelperTest extends FlatSpec {
   }
 
   "outputPath" should "create correct harvest output path" in {
-    val path = "s3a://my-bucket/foo/harvest/20180910_095702/OriginalRecord.avro"
+    val path = "s3a://my-bucket/foo/harvest/20180910_095702-foo-OriginalRecord.avro"
     assert(outputHelper.outputPath === path)
   }
 
-  "outputPath" should "create correct map output path" in {
-    val helper = new OutputHelper(root, shortName, "map", dateTime)
-    val path = "s3a://my-bucket/foo/map/20180910_095702/MAP4_0.MAPRecord.avro"
+  "outputPath" should "create correct mapping output path" in {
+    val helper = new OutputHelper(root, shortName, "mapping", dateTime)
+    val path = "s3a://my-bucket/foo/mapping/20180910_095702-foo-MAP4_0.MAPRecord.avro"
     assert(helper.outputPath === path)
   }
 
-  "outputPath" should "create correct enrich output path" in {
-    val helper = new OutputHelper(root, shortName, "enrich", dateTime)
-    val path = "s3a://my-bucket/foo/enrich/20180910_095702/MAP4_0.EnrichRecord.avro"
+  "outputPath" should "create correct enrichment output path" in {
+    val helper = new OutputHelper(root, shortName, "enrichment", dateTime)
+    val path = "s3a://my-bucket/foo/enrichment/20180910_095702-foo-MAP4_0.EnrichRecord.avro"
     assert(helper.outputPath === path)
   }
 
   "outputPath" should "create correct jsonl output path" in {
     val helper = new OutputHelper(root, shortName, "jsonl", dateTime)
-    val path = "s3a://my-bucket/foo/jsonl/20180910_095702/MAP3_1.IndexRecord.jsonl"
+    val path = "s3a://my-bucket/foo/jsonl/20180910_095702-foo-MAP3_1.IndexRecord.jsonl"
     assert(helper.outputPath === path)
   }
 
   "outputPath" should "create correct local output path" in {
     val localRoot = "/path/to/local"
     val helper = new OutputHelper(localRoot, shortName, activity, dateTime)
-    val path = "/path/to/local/foo/harvest/20180910_095702/OriginalRecord.avro"
+    val path = "/path/to/local/foo/harvest/20180910_095702-foo-OriginalRecord.avro"
     assert(helper.outputPath === path)
   }
 
@@ -67,19 +67,19 @@ class OutputHelperTest extends FlatSpec {
   }
 
   "manifestKey" should "create correct manifest key" in {
-    val key = "foo/harvest/20180910_095702/OriginalRecord.avro/_MANIFEST"
+    val key = "foo/harvest/20180910_095702-foo-OriginalRecord.avro/_MANIFEST"
     assert(outputHelper.manifestKey === key)
   }
 
   "manifestLocalOutPath" should "create correct local output path for manifest" in {
     val localRoot = "/path/to/local/"
     val helper = new OutputHelper(localRoot, shortName, activity, dateTime)
-    val path = "/path/to/local/foo/harvest/20180910_095702/OriginalRecord.avro/_MANIFEST"
+    val path = "/path/to/local/foo/harvest/20180910_095702-foo-OriginalRecord.avro/_MANIFEST"
     assert(helper.manifestLocalOutPath === path)
   }
 
   "logsBasePath" should "create correct base path for reports" in {
-    val basePath = "s3a://my-bucket/foo/harvest/20180910_095702/logs/"
+    val basePath = "s3a://my-bucket/foo/harvest/20180910_095702-foo-OriginalRecord.avro/_LOGS/"
     assert(outputHelper.logsBasePath === basePath)
   }
 }

--- a/src/test/scala/dpla/ingestion3/utils/OutputHelperTest.scala
+++ b/src/test/scala/dpla/ingestion3/utils/OutputHelperTest.scala
@@ -2,7 +2,7 @@ package dpla.ingestion3.utils
 
 import java.time.LocalDateTime
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.FlatSpec
 
 class OutputHelperTest extends FlatSpec {
 

--- a/src/test/scala/dpla/ingestion3/utils/OutputHelperTest.scala
+++ b/src/test/scala/dpla/ingestion3/utils/OutputHelperTest.scala
@@ -32,32 +32,32 @@ class OutputHelperTest extends FlatSpec {
   }
 
   "outputPath" should "create correct harvest output path" in {
-    val path = "s3a://my-bucket/foo/harvest/20180910_095702-foo-OriginalRecord.avro"
+    val path = "s3a://my-bucket/foo/harvest/20180910_095702/OriginalRecord.avro"
     assert(outputHelper.outputPath === path)
   }
 
   "outputPath" should "create correct map output path" in {
     val helper = new OutputHelper(root, shortName, "map", dateTime)
-    val path = "s3a://my-bucket/foo/map/20180910_095702-foo-MAP4_0.MAPRecord.avro"
+    val path = "s3a://my-bucket/foo/map/20180910_095702/MAP4_0.MAPRecord.avro"
     assert(helper.outputPath === path)
   }
 
   "outputPath" should "create correct enrich output path" in {
     val helper = new OutputHelper(root, shortName, "enrich", dateTime)
-    val path = "s3a://my-bucket/foo/enrich/20180910_095702-foo-MAP4_0.EnrichRecord.avro"
+    val path = "s3a://my-bucket/foo/enrich/20180910_095702/MAP4_0.EnrichRecord.avro"
     assert(helper.outputPath === path)
   }
 
   "outputPath" should "create correct jsonl output path" in {
     val helper = new OutputHelper(root, shortName, "jsonl", dateTime)
-    val path = "s3a://my-bucket/foo/jsonl/20180910_095702-foo-MAP3_1.IndexRecord.jsonl"
+    val path = "s3a://my-bucket/foo/jsonl/20180910_095702/MAP3_1.IndexRecord.jsonl"
     assert(helper.outputPath === path)
   }
 
   "outputPath" should "create correct local output path" in {
     val localRoot = "/path/to/local"
     val helper = new OutputHelper(localRoot, shortName, activity, dateTime)
-    val path = "/path/to/local/foo/harvest/20180910_095702-foo-OriginalRecord.avro"
+    val path = "/path/to/local/foo/harvest/20180910_095702/OriginalRecord.avro"
     assert(helper.outputPath === path)
   }
 
@@ -67,14 +67,19 @@ class OutputHelperTest extends FlatSpec {
   }
 
   "manifestKey" should "create correct manifest key" in {
-    val key = "foo/harvest/20180910_095702-foo-OriginalRecord.avro/_MANIFEST"
+    val key = "foo/harvest/20180910_095702/OriginalRecord.avro/_MANIFEST"
     assert(outputHelper.manifestKey === key)
   }
 
   "manifestLocalOutPath" should "create correct local output path for manifest" in {
     val localRoot = "/path/to/local/"
     val helper = new OutputHelper(localRoot, shortName, activity, dateTime)
-    val path = "/path/to/local/foo/harvest/20180910_095702-foo-OriginalRecord.avro/_MANIFEST"
+    val path = "/path/to/local/foo/harvest/20180910_095702/OriginalRecord.avro/_MANIFEST"
     assert(helper.manifestLocalOutPath === path)
+  }
+
+  "reportsBasePath" should "create correct base path for reports" in {
+    val basePath = "s3a://my-bucket/foo/harvest/20180910_095702/reports/"
+    assert(outputHelper.reportsBasePath === basePath)
   }
 }

--- a/src/test/scala/dpla/ingestion3/utils/OutputHelperTest.scala
+++ b/src/test/scala/dpla/ingestion3/utils/OutputHelperTest.scala
@@ -78,8 +78,8 @@ class OutputHelperTest extends FlatSpec {
     assert(helper.manifestLocalOutPath === path)
   }
 
-  "reportsBasePath" should "create correct base path for reports" in {
-    val basePath = "s3a://my-bucket/foo/harvest/20180910_095702/reports/"
-    assert(outputHelper.reportsBasePath === basePath)
+  "logsBasePath" should "create correct base path for reports" in {
+    val basePath = "s3a://my-bucket/foo/harvest/20180910_095702/logs/"
+    assert(outputHelper.logsBasePath === basePath)
   }
 }


### PR DESCRIPTION
This implements `OutputHelper` for the `MappingExecutor`, automating the writing of mapped records and logs.

This makes some small changes to the output file paths.  The new system has two main advantages: 
1. It allows logs to be located alongside their related output.
2. It information is no longer repeated in the path.   I believe the repetition was intended to preserve information in case directories got separated from their parents, but now that we have `_MANIFEST` files, we can preserve information there instead.  Plus, in the S3 environment, it's not an issue since a file's key includes all its "directories".

However, please let me know if you have other ideas about the output paths.

BEFORE:
```
root-directory-or-bucket
    esdn
        harvest
            20180911_143130-esdn-OriginalRecord.avro
                _MANIFEST
                _SUCCESS
                {...}
        map
            20180911_143550-esdn-MAP4_0.MAPRecord.avro
                _MANIFEST
                _SUCCESS
                {...}
logs
     esdn-1536687027343-map-all
     esdn-1536687027343-map-errors
     esdn-1536687027343-map-exceptions
     esdn-1536687027343-map-warnings 
```

AFTER
```
root-directory-or-bucket
    esdn
        harvest
            20180911_143130
                OriginalRecord.avro
                    _MANIFEST
                    _SUCCESS
                    {...}
        map
            20180911_143550
                logs
                    all
                    errors
                    exceptions
                    warnings
                MAP4_0.MAPRecord.avro
                    _MANIFEST
                    _SUCCESS
                   {...}
```