### PR TITLE
MWDL Primo Harvester

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/api/MwdlHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/MwdlHarvester.scala
@@ -1,0 +1,47 @@
+
+package dpla.ingestion3.harvesters.api
+
+import java.net.URL
+
+import com.databricks.spark.avro._
+import dpla.ingestion3.confs.i3Conf
+import dpla.ingestion3.utils.{HttpUtils, Utils}
+import org.apache.http.client.utils.URIBuilder
+import org.apache.log4j.Logger
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.json4s.DefaultFormats
+
+import scala.util.{Failure, Success}
+import scala.xml.XML
+
+/**
+  * Class for harvesting records from the MWDL Primo endpoint
+  *
+  */
+class MwdlHarvester(spark: SparkSession,
+                    shortName: String,
+                    conf: i3Conf,
+                    harvestLogger: Logger)
+  extends PrimoHarvester(spark, shortName, conf, harvestLogger) {
+
+  /**
+    * Constructs the URL for MWDL Primo API requests
+    *
+    * @param params URL parameters
+    * @return URL
+    */
+  override def buildUrl(params: Map[String, String]): URL =
+    new URIBuilder()
+      .setScheme("http")
+      .setHost("utah-primoprod.hosted.exlibrisgroup.com")
+      .setPath("/PrimoWebServices/xservice/search/brief")
+      .setParameter("indx", params.getOrElse("indx", "1")) // pagination value
+      .setParameter("bulkSize", params.getOrElse("rows", "10"))
+      .setParameter("institution", "MWDL")
+      .setParameter("loc", "local,scope:(mw)")
+      .setParameter("query", params.getOrElse("query", throw new RuntimeException("No query parameter provided")))
+      .setParameter("query_exec", "facet_rtype,exact,collections")
+      .setParameter("query_exec", "facet_scope,exact,dd")
+      .build()
+      .toURL
+}

--- a/src/main/scala/dpla/ingestion3/harvesters/api/MwdlHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/MwdlHarvester.scala
@@ -3,16 +3,10 @@ package dpla.ingestion3.harvesters.api
 
 import java.net.URL
 
-import com.databricks.spark.avro._
 import dpla.ingestion3.confs.i3Conf
-import dpla.ingestion3.utils.{HttpUtils, Utils}
 import org.apache.http.client.utils.URIBuilder
 import org.apache.log4j.Logger
-import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.json4s.DefaultFormats
-
-import scala.util.{Failure, Success}
-import scala.xml.XML
+import org.apache.spark.sql.SparkSession
 
 /**
   * Class for harvesting records from the MWDL Primo endpoint
@@ -35,8 +29,8 @@ class MwdlHarvester(spark: SparkSession,
       .setScheme("http")
       .setHost("utah-primoprod.hosted.exlibrisgroup.com")
       .setPath("/PrimoWebServices/xservice/search/brief")
-      .setParameter("indx", params.getOrElse("indx", "1")) // pagination value
-      .setParameter("bulkSize", params.getOrElse("rows", "10"))
+      .setParameter("indx", params.getOrElse("indx", "1")) // record offset
+      .setParameter("bulkSize", params.getOrElse("rows", "10")) // records per page
       .setParameter("institution", "MWDL")
       .setParameter("loc", "local,scope:(mw)")
       .setParameter("query", params.getOrElse("query", throw new RuntimeException("No query parameter provided")))

--- a/src/main/scala/dpla/ingestion3/harvesters/api/PrimoHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/PrimoHarvester.scala
@@ -5,40 +5,22 @@ import java.net.URL
 
 import com.databricks.spark.avro._
 import dpla.ingestion3.confs.i3Conf
-import dpla.ingestion3.utils.HttpUtils
-import org.apache.http.client.utils.URIBuilder
+import dpla.ingestion3.utils.{HttpUtils, Utils}
 import org.apache.log4j.Logger
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.json4s.DefaultFormats
-import org.json4s.jackson.JsonMethods._
 
 import scala.util.{Failure, Success}
+import scala.xml.XML
 
 /**
   * Class for harvesting records from Primo endpoints
   *
-  *
-    "name": "mwdl",
-    "type": "mwdl",
-    "endpoint_url": "http://utah-primoprod.hosted.exlibrisgroup.com/PrimoWebServices/xservice/search/brief",
-
-    "endpoint_url_params": {
-        "indx": 1,
-        "bulkSize": 100,
-        "institution": "MWDL",
-        "loc": "local,scope:(mw)",
-        "query": "facet_tlevel,exact,online_resources",
-        "query_exc": [
-            "facet_rtype,exact,collections",
-            "facet_scope,exact,dd"
-        ]
-    }
-
   */
-class PrimoHarvester(spark: SparkSession,
-                     shortName: String,
-                     conf: i3Conf,
-                     harvestLogger: Logger)
+abstract class PrimoHarvester(spark: SparkSession,
+                              shortName: String,
+                              conf: i3Conf,
+                              harvestLogger: Logger)
   extends ApiHarvester(spark, shortName, conf, harvestLogger) {
 
   def mimeType: String = "application_xml"
@@ -46,20 +28,21 @@ class PrimoHarvester(spark: SparkSession,
   override protected val queryParams: Map[String, String] = Map(
     "query" -> conf.harvest.query,
     "rows" -> conf.harvest.rows,
-    "api_key" -> conf.harvest.apiKey
+    "indx" -> Some("1")
   ).collect{ case (key, Some(value)) => key -> value } // remove None values
 
   override def localHarvest: DataFrame = {
-    implicit val formats = DefaultFormats
+    implicit val formats: DefaultFormats.type = DefaultFormats
 
     // Mutable vars for controlling harvest loop
     var continueHarvest = true
-    var cursorMark = "*"
+    var indx = "1"
+    var totalRecords = ""
 
     // Runtime tracking
     val startTime = System.currentTimeMillis()
 
-    while(continueHarvest) getSinglePage(cursorMark) match {
+    while(continueHarvest) getSinglePage(indx) match {
       // Handle errors
       case error: ApiError with ApiResponse =>
         harvestLogger.error("Error returned by request %s\n%s\n%s".format(
@@ -72,23 +55,26 @@ class PrimoHarvester(spark: SparkSession,
       case src: ApiSource with ApiResponse =>
         src.text match {
           case Some(docs) =>
-            val json = parse(docs)
-            val cdlRecords = (json \\ "docs").children.map(doc => {
-              ApiRecord((doc \\ "identifier").toString, compact(render(doc)))
-            })
+            val xml = XML.loadString(docs)
+            // FIXME add sear namespace to selection
+            val primoRecords = (xml \\ "SEGMENTS" \"JAGROOT" \ "RESULT" \ "DOCSET" \ "DOC")
+              .map(doc => ApiRecord((doc \\ "PrimoNMBib" \ "record" \ "control" \ "recordid").toString, Utils.formatXml(doc)))
+              .toList
 
             // @see ApiHarvester
-            saveOutRecords(cdlRecords)
+            saveOutRecords(primoRecords)
 
             // Loop control
-            cursorMark = (json \\ "cursorMark").extract[String]
-            val nextCursorMark = (json \\ "nextCursorMark").extract[String]
+            val nextIndx = (primoRecords.size + indx.toInt).toString
+            totalRecords = if (totalRecords.isEmpty)
+              (xml \\ "SEGMENTS" \ "JAGROOT" \ "RESULT" \ "DOCSET" \ "@TOTALHITS").text
+            else totalRecords
 
-            if (cursorMark.matches(nextCursorMark)) {
+            harvestLogger.info(s"Fetched ${Utils.formatNumber(indx.toLong)} of ${Utils.formatNumber(totalRecords.toLong)}")
+
+            if (indx.toInt >= totalRecords.toInt) {
               continueHarvest = false
-            } else {
-              cursorMark = nextCursorMark
-            }
+            } else indx = nextIndx
 
           case _ =>
             harvestLogger.error(s"Response body is empty.\n" +
@@ -103,21 +89,18 @@ class PrimoHarvester(spark: SparkSession,
   }
 
   /**
-    * Get a single-page, un-parsed response from the CDL feed, or an error if
+    * Get a single-page, un-parsed response from the MWDL Primo feed, or an error if
     * one occurs.
     *
-    * @param cursorMark Uses cursor and not start/offset to paginate. Used to work around Solr
-    *                   deep-paging performance issues.
+    * @param indx Record offset
     * @return ApiSource or ApiError
     */
-  private def getSinglePage(cursorMark: String): ApiResponse = {
-    val apiKey = queryParams.getOrElse("api_key", "")
-    val headers = Some(Map("X-Authentication-Token" -> apiKey))
-    val url = buildUrl(queryParams.updated("cursorMark", cursorMark))
+  private def getSinglePage(indx: String): ApiResponse = {
+    val url = buildUrl(queryParams.updated("indx", indx))
 
     harvestLogger.info(s"Requesting ${url.toString}")
 
-    HttpUtils.makeGetRequest(url, headers) match {
+    HttpUtils.makeGetRequest(url) match {
       case Failure(e) =>
         ApiError(e.toString, ApiSource(queryParams, Some(url.toString)))
       case Success(response) => response.isEmpty match {
@@ -128,20 +111,11 @@ class PrimoHarvester(spark: SparkSession,
   }
 
   /**
-    * Constructs the URL for CDL API requests
+    * Constructs the URL for Primo API requests, should be
+    * defined in provider implementation of PrimoHarvester
     *
     * @param params URL parameters
     * @return
     */
-  def buildUrl(params: Map[String, String]): URL =
-    new URIBuilder()
-      .setScheme("https")
-      .setHost("solr.calisphere.org")
-      .setPath("/solr/query")
-      .setParameter("q", params.getOrElse("query", "*:*"))
-      .setParameter("cursorMark", params.getOrElse("cursorMark", "*"))
-      .setParameter("rows", params.getOrElse("rows", "10"))
-      .setParameter("sort", "id desc")
-      .build()
-      .toURL
+  def buildUrl(params: Map[String, String]): URL
 }

--- a/src/main/scala/dpla/ingestion3/harvesters/api/PrimoHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/PrimoHarvester.scala
@@ -1,0 +1,147 @@
+
+package dpla.ingestion3.harvesters.api
+
+import java.net.URL
+
+import com.databricks.spark.avro._
+import dpla.ingestion3.confs.i3Conf
+import dpla.ingestion3.utils.HttpUtils
+import org.apache.http.client.utils.URIBuilder
+import org.apache.log4j.Logger
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.json4s.DefaultFormats
+import org.json4s.jackson.JsonMethods._
+
+import scala.util.{Failure, Success}
+
+/**
+  * Class for harvesting records from Primo endpoints
+  *
+  *
+    "name": "mwdl",
+    "type": "mwdl",
+    "endpoint_url": "http://utah-primoprod.hosted.exlibrisgroup.com/PrimoWebServices/xservice/search/brief",
+
+    "endpoint_url_params": {
+        "indx": 1,
+        "bulkSize": 100,
+        "institution": "MWDL",
+        "loc": "local,scope:(mw)",
+        "query": "facet_tlevel,exact,online_resources",
+        "query_exc": [
+            "facet_rtype,exact,collections",
+            "facet_scope,exact,dd"
+        ]
+    }
+
+  */
+class PrimoHarvester(spark: SparkSession,
+                     shortName: String,
+                     conf: i3Conf,
+                     harvestLogger: Logger)
+  extends ApiHarvester(spark, shortName, conf, harvestLogger) {
+
+  def mimeType: String = "application_xml"
+
+  override protected val queryParams: Map[String, String] = Map(
+    "query" -> conf.harvest.query,
+    "rows" -> conf.harvest.rows,
+    "api_key" -> conf.harvest.apiKey
+  ).collect{ case (key, Some(value)) => key -> value } // remove None values
+
+  override def localHarvest: DataFrame = {
+    implicit val formats = DefaultFormats
+
+    // Mutable vars for controlling harvest loop
+    var continueHarvest = true
+    var cursorMark = "*"
+
+    // Runtime tracking
+    val startTime = System.currentTimeMillis()
+
+    while(continueHarvest) getSinglePage(cursorMark) match {
+      // Handle errors
+      case error: ApiError with ApiResponse =>
+        harvestLogger.error("Error returned by request %s\n%s\n%s".format(
+          error.errorSource.url.getOrElse("Undefined url"),
+          error.errorSource.queryParams,
+          error.message
+        ))
+        continueHarvest = false
+      // Handle a successful response
+      case src: ApiSource with ApiResponse =>
+        src.text match {
+          case Some(docs) =>
+            val json = parse(docs)
+            val cdlRecords = (json \\ "docs").children.map(doc => {
+              ApiRecord((doc \\ "identifier").toString, compact(render(doc)))
+            })
+
+            // @see ApiHarvester
+            saveOutRecords(cdlRecords)
+
+            // Loop control
+            cursorMark = (json \\ "cursorMark").extract[String]
+            val nextCursorMark = (json \\ "nextCursorMark").extract[String]
+
+            if (cursorMark.matches(nextCursorMark)) {
+              continueHarvest = false
+            } else {
+              cursorMark = nextCursorMark
+            }
+
+          case _ =>
+            harvestLogger.error(s"Response body is empty.\n" +
+              s"URL: ${src.url.getOrElse("!!! URL not set !!!")}\n" +
+              s"Params: ${src.queryParams}\n" +
+              s"Body: ${src.text}")
+            continueHarvest = false
+        }
+    }
+    // Read harvested data into Spark DataFrame and return.
+    spark.read.avro(tmpOutStr)
+  }
+
+  /**
+    * Get a single-page, un-parsed response from the CDL feed, or an error if
+    * one occurs.
+    *
+    * @param cursorMark Uses cursor and not start/offset to paginate. Used to work around Solr
+    *                   deep-paging performance issues.
+    * @return ApiSource or ApiError
+    */
+  private def getSinglePage(cursorMark: String): ApiResponse = {
+    val apiKey = queryParams.getOrElse("api_key", "")
+    val headers = Some(Map("X-Authentication-Token" -> apiKey))
+    val url = buildUrl(queryParams.updated("cursorMark", cursorMark))
+
+    harvestLogger.info(s"Requesting ${url.toString}")
+
+    HttpUtils.makeGetRequest(url, headers) match {
+      case Failure(e) =>
+        ApiError(e.toString, ApiSource(queryParams, Some(url.toString)))
+      case Success(response) => response.isEmpty match {
+        case true => ApiError("Response body is empty", ApiSource(queryParams, Some(url.toString)))
+        case false => ApiSource(queryParams, Some(url.toString), Some(response))
+      }
+    }
+  }
+
+  /**
+    * Constructs the URL for CDL API requests
+    *
+    * @param params URL parameters
+    * @return
+    */
+  def buildUrl(params: Map[String, String]): URL =
+    new URIBuilder()
+      .setScheme("https")
+      .setHost("solr.calisphere.org")
+      .setPath("/solr/query")
+      .setParameter("q", params.getOrElse("query", "*:*"))
+      .setParameter("cursorMark", params.getOrElse("cursorMark", "*"))
+      .setParameter("rows", params.getOrElse("rows", "10"))
+      .setParameter("sort", "id desc")
+      .build()
+      .toURL
+}

--- a/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
+++ b/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
@@ -1,7 +1,7 @@
 package dpla.ingestion3.profiles
 
 import dpla.ingestion3.harvesters.Harvester
-import dpla.ingestion3.harvesters.api.{CdlHarvester, IaHarvester, LocHarvester, MdlHarvester}
+import dpla.ingestion3.harvesters.api._
 import dpla.ingestion3.harvesters.file.{NaraFileHarvester, P2PFileHarvester}
 import dpla.ingestion3.harvesters.oai.OaiHarvester
 import dpla.ingestion3.mappers.providers._
@@ -75,6 +75,17 @@ class MtProfile extends XmlProfile {
   override def getHarvester: Class[_ <: Harvester] = classOf[OaiHarvester]
   override def getMapping = new MtMapping
 }
+
+/**
+  * Mountain West Digital Library
+  */
+class MwdlProfile extends XmlProfile {
+  type Mapping = MtMapping // FIXME When MWDL mapping implemented
+
+  override def getHarvester: Class[_ <: Harvester] = classOf[MwdlHarvester]
+  override def getMapping = new MtMapping  // FIXME When mapping implemented
+}
+
 
 
 /**

--- a/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
+++ b/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
@@ -50,6 +50,7 @@ object ProviderRegistry {
     "loc" -> Register(profile = new LocProfile),
     "mdl" -> Register(profile = new MdlProfile),
     "mt" -> Register(profile = new MtProfile),
+    "mwdl" -> Register(profile = new MwdlProfile),
     "nara" -> Register(profile = new NaraProfile),
     "ohio" -> Register(profile = new OhioProfile),
     "p2p" -> Register(profile = new P2PProfile), // plains2peaks


### PR DESCRIPTION
- Adds MWDL to `ProviderRegistry` and `ProfivderProfiles` (with placeholder Mapping definitions) 
- Adds a base abstract class for harvesting from Primo endpoints. 
- Add a specific implementation of that abstract class, `PrimoHarvest` for MWDL that defines the specific query URL and parameters. 

This harvester and/or endpoint is pretty inefficient and for MWDL will take ~6 hours to harvest ~1M records. By comparison the CDL harvester can rip through more than 1M records in less than then minutes. Additionally, the ingestion1 Priomo harvester was much faster than this six hours as well and there was no parallelization in use there. Improvements to performance could be sought along a number of fronts if deemed necessary. 