### PR TITLE
Log file overrun in MappingSummary report

### DIFF
--- a/src/main/scala/dpla/ingestion3/reports/summary/ReportFormattingUtils.scala
+++ b/src/main/scala/dpla/ingestion3/reports/summary/ReportFormattingUtils.scala
@@ -3,12 +3,47 @@ package dpla.ingestion3.reports.summary
 import org.apache.commons.lang.StringUtils
 
 /**
+  * Provides utility functions for formatting strings in a report of
+  * ingestion operations.
   *
   */
 object ReportFormattingUtils {
-  def centerPad(a: String, b: String, seperator: String = ".", width: Int = 80) =
-    s"$a${seperator*(80-a.length-b.length)}$b"
+  /**
+    * Pads two strings with a delimiter out to the specified width (default is 80)
+    * If length of (a + b + 2) > width then the b string is truncated down to a
+    * length such that a + 2 + b = width
+    *
+    * Ex.
+    * errors......./Users/scott/i3/cdl/mapping/20181004_93223/_LOGS/mapping-errors.log
+    * warnings..ers/scott/i3/cdl/mapping/20181004_93223/_LOGS/mapping-cdl-warnings.log
+    *
+    * @param a First string
+    * @param b Second string
+    * @param separator Character to separate strings a and b with
+    * @param width Max string width
+    * @return
+    */
+  def centerPad(a: String, b: String, separator: String = ".", width: Int = 80): String = {
+    val limit = if (a.length + b.length + 2 > width) {
+      width - (a.length + 2) // limit string b
+    } else {
+      b.length // show all of string b
+    }
+    s"$a${separator*(width-a.length-limit)}${b.takeRight(limit)}"
+  }
 
+  /**
+    * Returns a new String with the provided value centered using
+    * whitespace (by default)
+    *
+    * Ex. If given 'Errors' it will return:
+    * '                                     Errors                                     '
+    *
+    * @param a String to center
+    * @param seperator Value to add before and after the string, default ' '
+    * @param width With to center on, default 80
+    * @return String with the provided string centered
+    */
   def center(a: String, seperator: String = " ",width: Int = 80): String =
     StringUtils.leftPad(a, (width+a.length)/2, seperator)
 }


### PR DESCRIPTION
- Add truncation of second value to `ReportFormattingUtils.centerPad` that will limit the second string so that both concatenated values fit within the specified width.
- Add documentation to`ReportFormattingUtils`

```
                                   Log Files

all..scott/dpla/i3/mt/mapping/20181004_151809-mt-MAP4_0.MAPRecord.avro/_LOGS/all
errors..dpla/i3/mt/mapping/20181004_151809-mt-MAP4_0.MAPRecord.avro/_LOGS/errors
warnings../i3/mt/mapping/20181004_151809-mt-MAP4_0.MAPRecord.avro/_LOGS/warnings
exceptions..mt/mapping/20181004_151809-mt-MAP4_0.MAPRecord.avro/_LOGS/exceptions
```