### PR TITLE
Enrich output

### DIFF
--- a/src/main/scala/dpla/ingestion3/entries/ingest/EnrichEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/EnrichEntry.scala
@@ -1,7 +1,5 @@
 package dpla.ingestion3.entries.ingest
 
-import java.io.File
-
 import dpla.ingestion3.confs.{CmdArgs, Ingestion3Conf, i3Conf}
 import dpla.ingestion3.executors.EnrichExecutor
 import dpla.ingestion3.utils.Utils
@@ -48,8 +46,6 @@ object EnrichEntry extends EnrichExecutor {
       .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
       .set("spark.kryoserializer.buffer.max", "200")
       .setMaster(i3Conf.spark.sparkMaster.getOrElse("local[*]"))
-
-    Utils.deleteRecursively(new File(dataOut))
 
     executeEnrichment(sparkConf, dataIn, dataOut, shortName, enrichLogger, i3Conf)
   }

--- a/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
@@ -68,10 +68,12 @@ object IngestRemap extends MappingExecutor
 
     // TODO These processes should return some flag or metric to help determine whether to proceed
     // Mapping
-    val mapDataOut = executeMapping(sparkConf, harvestDataOut, baseDataOut, shortName, logger)
+    val mapDataOut: String =
+      executeMapping(sparkConf, harvestDataOut, baseDataOut, shortName, logger)
 
     // Enrichment
-    val enrichDataOut = executeEnrichment(sparkConf, mapDataOut, baseDataOut, shortName, logger, conf)
+    val enrichDataOut: String =
+      executeEnrichment(sparkConf, mapDataOut, baseDataOut, shortName, logger, conf)
 
     // Json-l
     executeJsonl(sparkConf, enrichDataOut, jsonlDataOut, logger)

--- a/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
@@ -44,8 +44,7 @@ object IngestRemap extends MappingExecutor
     } else cmdArgs.getInput
 
     logger.info(s"Using harvest data from $harvestDataOut")
-    
-    val enrichDataOut = baseDataOut+"/"+shortName+"/enriched"
+
     val jsonlDataOut = baseDataOut+"/"+shortName+"/json-l"
     val baseRptOut = baseDataOut+"/"+shortName+"/reports"
 
@@ -63,7 +62,6 @@ object IngestRemap extends MappingExecutor
       .set("spark.kryoserializer.buffer.max", "200")
       .setMaster(sparkMaster)
 
-    Utils.deleteRecursively(new File(enrichDataOut))
     Utils.deleteRecursively(new File(jsonlDataOut))
     Utils.deleteRecursively(new File(baseRptOut))
 
@@ -72,7 +70,7 @@ object IngestRemap extends MappingExecutor
     val mapDataOut = executeMapping(sparkConf, harvestDataOut, baseDataOut, shortName, logger)
 
     // Enrichment
-    executeEnrichment(sparkConf, mapDataOut, enrichDataOut, shortName, logger, conf)
+    val enrichDataOut = executeEnrichment(sparkConf, mapDataOut, baseDataOut, shortName, logger, conf)
 
     // Json-l
     executeJsonl(sparkConf, enrichDataOut, jsonlDataOut, logger)

--- a/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
@@ -29,6 +29,7 @@ object IngestRemap extends MappingExecutor
     val baseDataOut = cmdArgs.getOutput()
     val confFile = cmdArgs.getConfigFile()
     val shortName = cmdArgs.getProviderName()
+    val input = cmdArgs.getInput()
 
     // Get logger
     val logger = Utils.createLogger("ingest", shortName)
@@ -38,10 +39,10 @@ object IngestRemap extends MappingExecutor
     // If harvest data is NOT on S3, get most recent data.
     // Else, use the given S3 input filepath.
     // TODO: get most recent S3 data.
-    val harvestDataOut = if (!baseDataOut.startsWith("s3a://")) {
-      Utils.getMostRecent( cmdArgs.getInput )
+    val harvestDataOut = if (!input.startsWith("s3a://")) {
+      Utils.getMostRecent(input)
         .getOrElse(throw new RuntimeException("Unable to load harvest data"))
-    } else cmdArgs.getInput
+    } else input
 
     logger.info(s"Using harvest data from $harvestDataOut")
 

--- a/src/main/scala/dpla/ingestion3/executors/EnrichExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/EnrichExecutor.scala
@@ -133,7 +133,7 @@ trait EnrichExecutor extends Serializable {
 
     val logFileSeq = logEnrichedFields.map {
       case (name: String, data: Dataset[_]) => {
-        val path = outputHelper.logsBasePath+"/"+name
+        val path = outputHelper.logsBasePath+"s/$shortName-$endTime-map-$name"
         data match {
           case dr: Dataset[Row] => Utils.writeLogsAsCsv(path, name, dr, shortName)
         }

--- a/src/main/scala/dpla/ingestion3/executors/EnrichExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/EnrichExecutor.scala
@@ -59,10 +59,6 @@ trait EnrichExecutor extends Serializable {
 
     val sc = spark.sparkContext
     val improvedCount: LongAccumulator = sc.longAccumulator("Improved Record Count")
-    val typeImprovedCount: LongAccumulator = sc.longAccumulator("Improved Type Count")
-    val lamgImprovedCount: LongAccumulator = sc.longAccumulator("Improved Language Count")
-    val dateImprovedCount: LongAccumulator = sc.longAccumulator("Improved Date Count")
-    val placeImprovedCount: LongAccumulator = sc.longAccumulator("Improved Place Count")
 
     // Need to keep this here despite what IntelliJ and Codacy say
     import spark.implicits._

--- a/src/main/scala/dpla/ingestion3/executors/EnrichExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/EnrichExecutor.scala
@@ -179,8 +179,8 @@ trait EnrichExecutor extends Serializable {
     // Log error messages.
     failures.foreach(logger.error(_))
 
-    // TODO: Return correct string
-    ""
+    // Return output destination of enriched records.
+    outputPath
   }
 
   private def enrich(dplaMapData: OreAggregation,

--- a/src/main/scala/dpla/ingestion3/executors/EnrichExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/EnrichExecutor.scala
@@ -129,7 +129,7 @@ trait EnrichExecutor extends Serializable {
 
     val logFileSeq = logEnrichedFields.map {
       case (name: String, data: Dataset[_]) => {
-        val path = outputHelper.logsBasePath+"s/$shortName-$endTime-map-$name"
+        val path = outputHelper.logsBasePath+s"$shortName-$endTime-map-$name"
         data match {
           case dr: Dataset[Row] => Utils.writeLogsAsCsv(path, name, dr, shortName)
         }

--- a/src/main/scala/dpla/ingestion3/executors/EnrichExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/EnrichExecutor.scala
@@ -99,6 +99,8 @@ trait EnrichExecutor extends Serializable {
       .format("com.databricks.spark.avro")
       .save(outputPath)
 
+    // Create and write manifest.
+
     val manifestOpts: Map[String, String] = Map(
       "Activity" -> "Enrichment",
       "Provider" -> shortName,
@@ -110,6 +112,8 @@ trait EnrichExecutor extends Serializable {
       case Success(s) => logger.info(s"Manifest written to $s.")
       case Failure(f) => logger.warn(s"Manifest failed to write: $f")
     }
+
+    // Write logs and summary reports.
 
     val endTime = System.currentTimeMillis()
 
@@ -129,7 +133,7 @@ trait EnrichExecutor extends Serializable {
 
     val logFileSeq = logEnrichedFields.map {
       case (name: String, data: Dataset[_]) => {
-        val path = outputHelper.logsBasePath+s"$shortName-$endTime-map-$name"
+        val path = outputHelper.logsBasePath+s"$shortName-$endTime-enrich-$name"
         data match {
           case dr: Dataset[Row] => Utils.writeLogsAsCsv(path, name, dr, shortName)
         }

--- a/src/main/scala/dpla/ingestion3/executors/EnrichExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/EnrichExecutor.scala
@@ -1,6 +1,7 @@
 package dpla.ingestion3.executors
 
 import java.io.File
+import java.time.LocalDateTime
 
 import com.databricks.spark.avro._
 import dpla.ingestion3.confs.i3Conf
@@ -8,12 +9,9 @@ import dpla.ingestion3.enrichments.EnrichmentDriver
 import dpla.ingestion3.messages._
 import dpla.ingestion3.model
 import dpla.ingestion3.model.{ModelConverter, OreAggregation, RowConverter}
-
 import dpla.ingestion3.reports.PrepareEnrichmentReport
-
 import dpla.ingestion3.reports.summary._
-
-import dpla.ingestion3.utils.{HttpUtils, Utils}
+import dpla.ingestion3.utils.{OutputHelper, Utils}
 import org.apache.log4j.Logger
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
@@ -38,12 +36,21 @@ trait EnrichExecutor extends Serializable {
                         dataOut: String,
                         shortName: String,
                         logger: Logger,
-                        i3conf: i3Conf): Unit = {
+                        i3conf: i3Conf): String = {
 
     // Verify that twofishes is reachable
     // Utils.pingTwofishes(i3conf)
 
+    // This start time is used for documentation and output file naming.
+    val startDateTime = LocalDateTime.now
+
+    // This start time is used to measure the duration of enrichment.
     val startTime = System.currentTimeMillis()
+
+    val outputHelper =
+      new OutputHelper(dataOut, shortName, "enrichment", startDateTime)
+
+    val outputPath = outputHelper.outputPath
 
     implicit val spark = SparkSession.builder()
       .config(sparkConf)
@@ -94,7 +101,19 @@ trait EnrichExecutor extends Serializable {
     // Save mapped records out to Avro file
     successResults.toDF().write
       .format("com.databricks.spark.avro")
-      .save(dataOut)
+      .save(outputPath)
+
+    val manifestOpts: Map[String, String] = Map(
+      "Activity" -> "Enrichment",
+      "Provider" -> shortName,
+      "Record count" -> successResults.count.toString,
+      "Input" -> dataIn
+    )
+
+    outputHelper.writeManifest(manifestOpts) match {
+      case Success(s) => logger.info(s"Manifest written to $s.")
+      case Failure(f) => logger.warn(s"Manifest failed to write: $f")
+    }
 
     val endTime = System.currentTimeMillis()
 
@@ -114,11 +133,13 @@ trait EnrichExecutor extends Serializable {
 
     val logFileSeq = logEnrichedFields.map {
       case (name: String, data: Dataset[_]) => {
-        val path = dataOut + "/../logs/"+ s"$shortName-$endTime-enrich-$name"
+        val path = outputHelper.logsBasePath+"/"+name
         data match {
           case dr: Dataset[Row] => Utils.writeLogsAsCsv(path, name, dr, shortName)
         }
-        ReportFormattingUtils.centerPad(name, new File(path).getCanonicalPath)
+        val canonicalPath = if (path.startsWith("s3a://")) path else
+          new File(path).getCanonicalPath
+        ReportFormattingUtils.centerPad(name, canonicalPath)
       }
     }
 
@@ -157,6 +178,9 @@ trait EnrichExecutor extends Serializable {
 
     // Log error messages.
     failures.foreach(logger.error(_))
+
+    // TODO: Return correct string
+    ""
   }
 
   private def enrich(dplaMapData: OreAggregation,

--- a/src/main/scala/dpla/ingestion3/executors/EnrichExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/EnrichExecutor.scala
@@ -133,7 +133,7 @@ trait EnrichExecutor extends Serializable {
 
     val logFileSeq = logEnrichedFields.map {
       case (name: String, data: Dataset[_]) => {
-        val path = outputHelper.logsBasePath+s"$shortName-$endTime-enrich-$name"
+        val path = outputHelper.logsBasePath + s"$shortName-$endTime-enrich-$name"
         data match {
           case dr: Dataset[Row] => Utils.writeLogsAsCsv(path, name, dr, shortName)
         }


### PR DESCRIPTION
This standardized output for enrichments.  It works whether reading/writing files locally or on S3.  

It has been tested locally and on and EC2 cluster. 

This also fixes a bug in `IngestRemap` introduced in a recent PR - the logic to find the most recent harvested record was incorrect.

Please note that Enrich and IngestRemap jobs write a log file which duplicates information printed out to the console.  This file is written to a top-level directory either on the local file system or on the EC2 cluster.  I have written a separate ticket to handle this file: https://digitalpubliclibraryofamerica.atlassian.net/browse/IN-565