### PR TITLE
Jsonl output

### DIFF
--- a/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
+++ b/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
@@ -84,7 +84,7 @@ class CmdArgs(arguments: Seq[String]) extends ScallopConf(arguments) {
 
   val configFile: ScallopOption[String] = opt[String](
     "conf",
-    required = true,
+    required = false,
     noshort = true,
     validate = _.endsWith(".conf"),
     descr = "Configuration file must end with .conf"

--- a/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
@@ -46,7 +46,6 @@ object IngestRemap extends MappingExecutor
 
     logger.info(s"Using harvest data from $harvestDataOut")
 
-    val jsonlDataOut = baseDataOut+"/"+shortName+"/json-l"
     val baseRptOut = baseDataOut+"/"+shortName+"/reports"
 
 
@@ -63,7 +62,6 @@ object IngestRemap extends MappingExecutor
       .set("spark.kryoserializer.buffer.max", "200")
       .setMaster(sparkMaster)
 
-    Utils.deleteRecursively(new File(jsonlDataOut))
     Utils.deleteRecursively(new File(baseRptOut))
 
     // TODO These processes should return some flag or metric to help determine whether to proceed
@@ -76,7 +74,7 @@ object IngestRemap extends MappingExecutor
       executeEnrichment(sparkConf, mapDataOut, baseDataOut, shortName, logger, conf)
 
     // Json-l
-    executeJsonl(sparkConf, enrichDataOut, jsonlDataOut, logger)
+    executeJsonl(sparkConf, enrichDataOut, baseDataOut, shortName, logger)
 
     // Reports
     executeAllReports(sparkConf, enrichDataOut, baseRptOut, logger)

--- a/src/main/scala/dpla/ingestion3/entries/ingest/JsonlEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/JsonlEntry.scala
@@ -11,8 +11,8 @@ import org.apache.spark.SparkConf
   * Elasticsearch 0.90
   *
   * Expects three parameters:
-  * 1) a path to the harvested data
-  * 2) a path to output the mapped data
+  * 1) a path to the mapped/enriched data
+  * 2) a path to output the jsonl data
   * 3) provider short name (e.g. 'mdl', 'cdl', 'harvard')
   *
   * Usage

--- a/src/main/scala/dpla/ingestion3/entries/ingest/JsonlEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/JsonlEntry.scala
@@ -39,6 +39,6 @@ object JsonlEntry extends JsonlExecutor {
       .setAppName("jsonl")
       .setMaster("local[*]")
 
-    executeJsonl(sparkConf, shortName, dataIn, dataOut, Utils.createLogger("jsonl"))
+    executeJsonl(sparkConf, dataIn, dataOut, shortName, Utils.createLogger("jsonl"))
   }
 }

--- a/src/main/scala/dpla/ingestion3/entries/ingest/JsonlEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/JsonlEntry.scala
@@ -1,5 +1,6 @@
 package dpla.ingestion3.entries.ingest
 
+import dpla.ingestion3.confs.CmdArgs
 import dpla.ingestion3.executors.JsonlExecutor
 import dpla.ingestion3.utils.Utils
 import org.apache.spark.SparkConf
@@ -9,32 +10,35 @@ import org.apache.spark.SparkConf
   * JSONL text, which can be bulk loaded into a DPLA Ingestion1 index, in
   * Elasticsearch 0.90
   *
-  * Arguments:
-  *   1) The path or URL to the mapped / enriched data (file, directory, or s3
-  *      URI)
-  *   2) The path or URL to the output (directory or s3 "folder")
+  * Expects three parameters:
+  * 1) a path to the harvested data
+  * 2) a path to output the mapped data
+  * 3) provider short name (e.g. 'mdl', 'cdl', 'harvard')
   *
-  * The output directory will contain one file named "part-*" that constitutes
-  * the JSONL.
-  *
-  *   Usage
-  *   -----
-  *   To invoke via sbt:
-  *     sbt "run-main dpla.ingestion3.entries.JsonlEntry /input/path /output/path"
-  *
+  * Usage
+  * -----
+  * To invoke via sbt:
+  * sbt "run-main dpla.ingestion3.JsonlEntry
+  *       --input=/input/path/to/enriched/
+  *       --output=/output/path/to/jsonl/
+  *       --name=shortName"
   */
 object JsonlEntry extends JsonlExecutor {
 
   def main(args: Array[String]): Unit = {
 
-    val inputName = args(0)
-    val outputName = args(1)
+    // Read in command line args.
+    val cmdArgs = new CmdArgs(args)
+
+    val dataIn = cmdArgs.getInput()
+    val dataOut = cmdArgs.getOutput()
+    val shortName = cmdArgs.getProviderName()
 
     val sparkConf =
       new SparkConf()
       .setAppName("jsonl")
       .setMaster("local[*]")
 
-    executeJsonl(sparkConf, inputName, outputName, Utils.createLogger("jsonl"))
+    executeJsonl(sparkConf, shortName, dataIn, dataOut, Utils.createLogger("jsonl"))
   }
 }

--- a/src/main/scala/dpla/ingestion3/entries/ingest/JsonlEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/JsonlEntry.scala
@@ -1,7 +1,5 @@
 package dpla.ingestion3.entries.ingest
 
-import java.io.File
-
 import dpla.ingestion3.executors.JsonlExecutor
 import dpla.ingestion3.utils.Utils
 import org.apache.spark.SparkConf
@@ -36,8 +34,6 @@ object JsonlEntry extends JsonlExecutor {
       new SparkConf()
       .setAppName("jsonl")
       .setMaster("local[*]")
-
-    Utils.deleteRecursively(new File(outputName))
 
     executeJsonl(sparkConf, inputName, outputName, Utils.createLogger("jsonl"))
   }

--- a/src/main/scala/dpla/ingestion3/executors/JsonlExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/JsonlExecutor.scala
@@ -1,12 +1,14 @@
 package dpla.ingestion3.executors
 
-import java.io.File
+import java.time.LocalDateTime
 
 import dpla.ingestion3.model.{ModelConverter, jsonlRecord}
-import dpla.ingestion3.utils.Utils
+import dpla.ingestion3.utils.OutputHelper
 import org.apache.log4j.Logger
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{Dataset, SparkSession}
+
+import scala.util.{Failure, Success}
 
 trait JsonlExecutor extends Serializable {
 
@@ -17,9 +19,18 @@ trait JsonlExecutor extends Serializable {
     * @param dataOut Location to save JSON-L
     */
   def executeJsonl(sparkConf: SparkConf,
-              dataIn: String,
-              dataOut: String,
-              logger: Logger): Unit = {
+                   shortName: String,
+                   dataIn: String,
+                   dataOut: String,
+                   logger: Logger): String = {
+
+    // This start time is used for documentation and output file naming.
+    val startDateTime: LocalDateTime = LocalDateTime.now
+
+    val outputHelper: OutputHelper =
+      new OutputHelper(dataOut, shortName, "jsonl", startDateTime)
+
+    val outputPath: String = outputHelper.outputPath
 
     logger.info("Starting JSON-L export")
 
@@ -46,9 +57,27 @@ trait JsonlExecutor extends Serializable {
     // This should always write out as #text() because if we use #json() then the
     // data will be written out inside a JSON object (e.g. {'value': <doc>}) which is
     // invalid for our use
-    indexRecords.coalesce(1).write.text(dataOut)
+    indexRecords.coalesce(1).write.text(outputPath)
+
+    // Create and write manifest.
+
+    val manifestOpts: Map[String, String] = Map(
+      "Activity" -> "JSON-L",
+      "Provider" -> shortName,
+      "Record count" -> indexRecords.count.toString,
+      "Input" -> dataIn
+    )
+
+    outputHelper.writeManifest(manifestOpts) match {
+      case Success(s) => logger.info(s"Mainifest written to $s")
+      case Failure(f) => logger.warn(s"Manifest failed to write: $f")
+    }
+
     sc.stop()
 
     logger.info("JSON-L export complete")
+
+    // Return output path of jsonl files.
+    outputPath
   }
 }

--- a/src/main/scala/dpla/ingestion3/executors/JsonlExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/JsonlExecutor.scala
@@ -19,9 +19,9 @@ trait JsonlExecutor extends Serializable {
     * @param dataOut Location to save JSON-L
     */
   def executeJsonl(sparkConf: SparkConf,
-                   shortName: String,
                    dataIn: String,
                    dataOut: String,
+                   shortName: String,
                    logger: Logger): String = {
 
     // This start time is used for documentation and output file naming.

--- a/src/main/scala/dpla/ingestion3/executors/JsonlExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/JsonlExecutor.scala
@@ -69,7 +69,7 @@ trait JsonlExecutor extends Serializable {
     )
 
     outputHelper.writeManifest(manifestOpts) match {
-      case Success(s) => logger.info(s"Mainifest written to $s")
+      case Success(s) => logger.info(s"Manifest written to $s")
       case Failure(f) => logger.warn(s"Manifest failed to write: $f")
     }
 


### PR DESCRIPTION
This standardizes output for jsonl (i.e. indexing) jobs.

Some of the changes I made in this PR may warrant further discussion.

One issue I encountered was that the indexing job needs to be aware of the provider `shortName` in order to create the correct filepath.  Before, the indexer was blissfully ignorant of the provider `shortName`.  

This PR also changes `JsonlEntry` to accept named parameters, which brings it in line with all the other `Entry`s.  Please let me know if there is a reason I am unaware of that makes this change undesirable.  Also, in using the existing `CmdArgs`, I had to change the `conf` parameter from required to optional b/c `JsonlEntry` does not need a `conf`.  Again, this may not be desirable. 

This has been tested locally and on EC2. 