### PR TITLE
Most recent harvest s3

### DIFF
--- a/src/main/scala/dpla/ingestion3/dataStorage/DataStorage.scala
+++ b/src/main/scala/dpla/ingestion3/dataStorage/DataStorage.scala
@@ -8,17 +8,23 @@ package object dataStorage {
 
   lazy val s3client: AmazonS3Client = new AmazonS3Client
 
+  /**
+    *
+    *
+    * @param protocol one of ["s3", "s3n", "s3a"]
+    * @param bucket
+    * @param prefix
+    */
   case class S3Address(protocol: String,
                        bucket: String,
-                       prefix: Option[String],
-                       suffix: Option[String] = None)
+                       prefix: Option[String])
 
   object S3Address {
-    def key(address: S3Address): String =
-      List(address.prefix, address.suffix).flatten.mkString("/")
-
+    // Get full S3 path. For sanity, handle leading/trailing slashes.
     def fullPath(address: S3Address): String =
-      address.protocol + "://" + address.bucket + "/" + S3Address.key(address)
+      address.protocol + "://" +
+        address.bucket.stripPrefix("/").stripSuffix("/") + "/" +
+        address.prefix.getOrElse("").stripPrefix("/").stripSuffix("/")
   }
 
   /**

--- a/src/main/scala/dpla/ingestion3/dataStorage/DataStorage.scala
+++ b/src/main/scala/dpla/ingestion3/dataStorage/DataStorage.scala
@@ -9,11 +9,11 @@ package object dataStorage {
   lazy val s3client: AmazonS3Client = new AmazonS3Client
 
   /**
+    * Component parts of an S3 address.
     *
-    *
-    * @param protocol one of ["s3", "s3n", "s3a"]
-    * @param bucket
-    * @param prefix
+    * @param protocol One of ["s3", "s3n", "s3a"]
+    * @param bucket   The name of the S3 bucket
+    * @param prefix   Nested folder(s) beneath the bucket
     */
   case class S3Address(protocol: String,
                        bucket: String,
@@ -28,9 +28,10 @@ package object dataStorage {
   }
 
   /**
-    *
-    * @param path
-    * @return
+    * Parse an S3 address from a given String.
+    * 
+    * @param path Path to an S3 folder
+    * @return     The component parts of an S3 address
     *
     * @throws RuntimeException if unable to parse valid S3 address.
     */

--- a/src/main/scala/dpla/ingestion3/dataStorage/DataStorage.scala
+++ b/src/main/scala/dpla/ingestion3/dataStorage/DataStorage.scala
@@ -29,7 +29,7 @@ package object dataStorage {
 
   /**
     * Parse an S3 address from a given String.
-    * 
+    *
     * @param path Path to an S3 folder
     * @return     The component parts of an S3 address
     *

--- a/src/main/scala/dpla/ingestion3/dataStorage/DataStorage.scala
+++ b/src/main/scala/dpla/ingestion3/dataStorage/DataStorage.scala
@@ -6,8 +6,6 @@ package object dataStorage {
 
   lazy val s3Protocols: List[String] = List("s3", "s3a", "s3n")
 
-  lazy val validS3Protocols: List[String] = List("s3a")
-
   lazy val s3client: AmazonS3Client = new AmazonS3Client
 
   case class S3Address(protocol: String,
@@ -34,7 +32,7 @@ package object dataStorage {
     val protocol: String = path.split("://").headOption.getOrElse("")
 
     if (!s3Protocols.contains(protocol))
-      throw new RuntimeException(s"Unable to parse S3 protocol from $path")
+      throw new RuntimeException(s"Unable to parse S3 protocol from $path.")
 
     val bucket: String = path.split("/").lift(2) match {
       case Some(x) => x.stripSuffix("/")

--- a/src/main/scala/dpla/ingestion3/dataStorage/DataStorage.scala
+++ b/src/main/scala/dpla/ingestion3/dataStorage/DataStorage.scala
@@ -1,10 +1,14 @@
 package dpla.ingestion3
 
+import com.amazonaws.services.s3.AmazonS3Client
+
 package object dataStorage {
 
-  val s3Protocols: List[String] = List("s3", "s3a", "s3n")
+  lazy val s3Protocols: List[String] = List("s3", "s3a", "s3n")
 
-  val validS3Protocols: List[String] = List("s3a")
+  lazy val validS3Protocols: List[String] = List("s3a")
+
+  lazy val s3client: AmazonS3Client = new AmazonS3Client
 
   case class S3Address(protocol: String,
                        bucket: String,
@@ -23,6 +27,8 @@ package object dataStorage {
     *
     * @param path
     * @return
+    *
+    * @throws RuntimeException if unable to parse valid S3 address.
     */
   def parseS3Address(path: String): S3Address = {
     val protocol: String = path.split("://").headOption.getOrElse("")

--- a/src/main/scala/dpla/ingestion3/dataStorage/InputHelper.scala
+++ b/src/main/scala/dpla/ingestion3/dataStorage/InputHelper.scala
@@ -57,7 +57,7 @@ object InputHelper {
 
     // Get the folder directly under the given address.
     val folder: Option[String] =
-      lastKey.stripPrefix(prefix).split("/").headOption
+      lastKey.stripPrefix(prefix).stripPrefix("/").split("/").headOption
 
     // Return the full S3 path.
     folder match {

--- a/src/main/scala/dpla/ingestion3/dataStorage/InputHelper.scala
+++ b/src/main/scala/dpla/ingestion3/dataStorage/InputHelper.scala
@@ -1,0 +1,5 @@
+package dpla.ingestion3.dataStorage
+
+object InputHelper {
+
+}

--- a/src/main/scala/dpla/ingestion3/dataStorage/InputHelper.scala
+++ b/src/main/scala/dpla/ingestion3/dataStorage/InputHelper.scala
@@ -11,7 +11,8 @@ import scala.util.{Failure, Success, Try}
 object InputHelper {
 
   /**
-    * Check if a given path is a valid activity path.
+    * Check if a given local or S3 path is a valid activity path.
+    * An activity is a harvest, mapping, etc.
     *
     * A valid path will match the following pattern:
     *   8 digits (year month day)
@@ -23,8 +24,8 @@ object InputHelper {
     *   0-n characters (not "/") (schema)
     *   0-1 "/"
     *
-    * @param path
-    * @return Boolean
+    * @param path Local or S3 path that may or may not be an activity.
+    * @return     True if the path matches the pattern for an activity.
     */
   def isActivityPath(path: String): Boolean = {
     val activityPath: Regex = """\d{8}_\d{6}-[A-Za-z]*-[^/]*/?$""".r.unanchored
@@ -36,9 +37,11 @@ object InputHelper {
   }
 
   /**
+    * Get the most recent activity contained within a given local or S3 folder.
+    * The activity must be the immediate child of the given folder.
     *
-    * @param path
-    * @return
+    * @param path Path to a local or S3 folder.
+    * @return     Path to the most recent activity.
     */
   def mostRecent(path: String): Option[String] = {
     Try(parseS3Address(path)) match {
@@ -48,11 +51,11 @@ object InputHelper {
   }
 
   /**
-    * Sorts the contents of the given path to find the most recent folder
+    * Sorts the contents of the given path to find the most recent folder.
     * within the provided path that is a valid activity path.
+    * The activity must be the immediate child of the given folder.
     *
-    * @return Option[String] Absolute path to the most recent data within folder
-    *
+    * @return Option[String] Absolute path to the most recent activity.
     */
   private def mostRecentLocal(path: String): Option[String] = {
     val rootFile = new File(path)
@@ -66,9 +69,10 @@ object InputHelper {
   }
 
   /**
+    * Get the most recent activity from an S3 folder.
     *
-    * @param address
-    * @return
+    * @param address  The address of the S3 folder.
+    * @return         The full path of the most recent activity.
     */
   private def mostRecentS3(address: S3Address): Option[String] = {
 
@@ -97,6 +101,12 @@ object InputHelper {
     }
   }
 
+  /**
+    * Get the last page of results from an S3 object listing.
+    *
+    * @param ol The first ObjectListing (result of an s3client listObject request)
+    * @return   The last ObjectListing
+    */
   // TODO: Handle network errors?
   @tailrec
   private def fetchLastS3Batch(ol: ObjectListing): ObjectListing = {

--- a/src/main/scala/dpla/ingestion3/dataStorage/InputHelper.scala
+++ b/src/main/scala/dpla/ingestion3/dataStorage/InputHelper.scala
@@ -5,9 +5,35 @@ import java.io.File
 import com.amazonaws.services.s3.model.{ObjectListing, S3ObjectSummary}
 
 import scala.annotation.tailrec
+import scala.util.matching.Regex
 import scala.util.{Failure, Success, Try}
 
 object InputHelper {
+
+  /**
+    * Check if a given path is a valid activity path.
+    *
+    * A valid path will match the following pattern:
+    *   8 digits (year month day)
+    *   underscore
+    *   6 digits (time)
+    *   dash
+    *   0-n letters (provider short name)
+    *   dash
+    *   0-n characters (not "/") (schema)
+    *   0-1 "/"
+    *
+    * @param path
+    * @return Boolean
+    */
+  def isActivityPath(path: String): Boolean = {
+    val activityPath: Regex = """\d{8}_\d{6}-[A-Za-z]*-[^/]*/?$""".r.unanchored
+
+    path match {
+      case activityPath() => true
+      case _ => false
+    }
+  }
 
   def mostRecent(path: String): Option[String] = {
     Try(parseS3Address(path)) match {

--- a/src/main/scala/dpla/ingestion3/dataStorage/InputHelper.scala
+++ b/src/main/scala/dpla/ingestion3/dataStorage/InputHelper.scala
@@ -1,5 +1,75 @@
 package dpla.ingestion3.dataStorage
 
+import java.io.File
+
+import com.amazonaws.services.s3.model.{ObjectListing, S3ObjectSummary}
+
+import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
+
 object InputHelper {
 
+  def mostRecent(path: String): Option[String] = {
+    Try(parseS3Address(path)) match {
+      case Success(address) => mostRecentS3(address)
+      case Failure(_) => mostRecentLocal(path)
+    }
+  }
+
+  /**
+    * Sorts the contents of the given path to find the most recent folder
+    * within the provided path that ends with '.avro'
+    *
+    * @return Option[String] Absolute path to the most recent data within folder
+    *
+    */
+  private def mostRecentLocal(path: String): Option[String] = {
+    val rootFile = new File(path)
+
+    rootFile
+      .listFiles()
+      .filter(f => f.getName.endsWith(".avro"))
+      .map(f => f.getAbsolutePath)
+      .sorted
+      .lastOption
+  }
+
+  /**
+    * This assumes that the given address only contains properly formatted
+    * activity files.
+    *
+    * @param address
+    * @return
+    */
+  private def mostRecentS3(address: S3Address): Option[String] = {
+
+    val bucket = address.bucket
+    val prefix = address.prefix.getOrElse("")
+
+    // Given that `listObjects' returns results in alphabetical order,
+    // and files are timestamped,
+    // we can assume the last item on the last page of results
+    // will be from the most recent activity.
+    val firstBatch: ObjectListing =  s3client.listObjects(bucket, prefix)
+    val lastBatch: ObjectListing = fetchLastS3Batch(firstBatch)
+    val objectSummaries: java.util.List[S3ObjectSummary] = lastBatch.getObjectSummaries
+    val lastKey = objectSummaries.get(objectSummaries.size - 1).getKey
+
+    // Get the folder directly under the given address.
+    val folder: Option[String] =
+      lastKey.stripPrefix(prefix).split("/").headOption
+
+    // Return the full S3 path.
+    folder match {
+      case Some(f) => Some(S3Address.fullPath(address) + s"/$f")
+      case None => None
+    }
+  }
+
+  // TODO: Handle network errors?
+  @tailrec
+  private def fetchLastS3Batch(ol: ObjectListing): ObjectListing = {
+    if (ol.isTruncated) fetchLastS3Batch(s3client.listNextBatchOfObjects(ol))
+    else ol
+  }
 }

--- a/src/main/scala/dpla/ingestion3/dataStorage/InputHelper.scala
+++ b/src/main/scala/dpla/ingestion3/dataStorage/InputHelper.scala
@@ -86,7 +86,7 @@ object InputHelper {
 
     // Get the folder directly under the given address.
     val folder: String =
-      lastKey.stripPrefix(prefix).stripPrefix("/").split("/")("")
+      lastKey.stripPrefix(prefix).stripPrefix("/").split("/")(0)
 
     val fullPath = S3Address.fullPath(address) + s"/$folder"
 

--- a/src/main/scala/dpla/ingestion3/dataStorage/S3Address.scala
+++ b/src/main/scala/dpla/ingestion3/dataStorage/S3Address.scala
@@ -1,0 +1,47 @@
+package dpla.ingestion3
+
+package object dataStorage {
+
+  val s3Protocols: List[String] = List("s3", "s3a", "s3n")
+
+  val validS3Protocols: List[String] = List("s3a")
+
+  case class S3Address(protocol: String,
+                       bucket: String,
+                       prefix: Option[String],
+                       suffix: Option[String] = None)
+
+  object S3Address {
+    def key(address: S3Address): String =
+      List(address.prefix, address.suffix).flatten.mkString("/")
+
+    def fullPath(address: S3Address): String =
+      address.protocol + "://" + address.bucket + "/" + S3Address.key(address)
+  }
+
+  /**
+    *
+    * @param path
+    * @return
+    */
+  def parseS3Address(path: String): S3Address = {
+    val protocol: String = path.split("://").headOption.getOrElse("")
+
+    if (!s3Protocols.contains(protocol))
+      throw new RuntimeException(s"Unable to parse S3 protocol from $path")
+
+    val bucket: String = path.split("/").lift(2) match {
+      case Some(x) => x.stripSuffix("/")
+      case None =>
+        throw new RuntimeException(s"Unable to parse S3 bucket from $path.")
+    }
+
+    val prefixString: String = path.stripPrefix(protocol).stripPrefix("://")
+      .stripPrefix(bucket).stripPrefix("/").stripSuffix("/")
+
+    val prefix: Option[String] =
+      if (prefixString.isEmpty) None else Some(prefixString)
+
+    S3Address(protocol=protocol, bucket=bucket, prefix=prefix)
+  }
+}

--- a/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
@@ -39,8 +39,9 @@ object IngestRemap extends MappingExecutor
     // TODO: get most recent S3 data.
     val harvestDataOut = if (!input.startsWith("s3a://")) {
       Utils.getMostRecent(input)
-        .getOrElse(throw new RuntimeException("Unable to load harvest data"))
-    } else input
+    } else {
+      Utils.mostRecentS3(input)
+    }.getOrElse(throw new RuntimeException("Unable to load harvest data"))
 
     logger.info(s"Using harvest data from $harvestDataOut")
 

--- a/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
@@ -37,11 +37,12 @@ object IngestRemap extends MappingExecutor
     // If harvest data is NOT on S3, get most recent data.
     // Else, use the given S3 input filepath.
     // TODO: get most recent S3 data.
-    val harvestDataOut = if (!input.startsWith("s3a://")) {
-      Utils.getMostRecent(input)
-    } else {
-      Utils.mostRecentS3(input)
-    }.getOrElse(throw new RuntimeException("Unable to load harvest data"))
+//    val harvestDataOut = if (!input.startsWith("s3a://")) {
+    //    ////      Utils.getMostRecent(input)
+    //    ////    } else {
+    //    ////      Utils.mostRecentS3(input)
+    //    ////    }.getOrElse(throw new RuntimeException("Unable to load harvest data"))
+    val harvestDataOut = input
 
     logger.info(s"Using harvest data from $harvestDataOut")
 

--- a/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
@@ -1,7 +1,7 @@
 package dpla.ingestion3.entries.ingest
 
 import dpla.ingestion3.confs.{CmdArgs, Ingestion3Conf}
-import dpla.ingestion3.dataStorage._
+import dpla.ingestion3.dataStorage.InputHelper
 import dpla.ingestion3.executors.{EnrichExecutor, JsonlExecutor, MappingExecutor}
 import dpla.ingestion3.entries.reports.ReporterMain._
 import dpla.ingestion3.utils.Utils
@@ -46,32 +46,32 @@ object IngestRemap extends MappingExecutor
 
     logger.info(s"Using harvest data from $harvestData")
 
-//    // Load configuration from file.
-//    val i3Conf = new Ingestion3Conf(confFile, Some(shortName))
-//    val conf = i3Conf.load()
-//
-//    // Read spark master property from conf, default to 'local[1]' if not set
-//    val sparkMaster = conf.spark.sparkMaster.getOrElse("local[1]")
-//
-//    val sparkConf = new SparkConf()
-//      .setAppName(s"Mapping: $shortName")
-//      .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-//      .set("spark.kryoserializer.buffer.max", "200")
-//      .setMaster(sparkMaster)
-//
-//    // TODO These processes should return some flag or metric to help determine whether to proceed
-//    // Mapping
-//    val mapDataOut: String =
-//      executeMapping(sparkConf, harvestData, baseDataOut, shortName, logger)
-//
-//    // Enrichment
-//    val enrichDataOut: String =
-//      executeEnrichment(sparkConf, mapDataOut, baseDataOut, shortName, logger, conf)
-//
-//    // Json-l
-//    executeJsonl(sparkConf, enrichDataOut, baseDataOut, shortName, logger)
-//
-//    // Reports
-//    executeAllReports(sparkConf, enrichDataOut, baseDataOut, shortName, logger)
+    // Load configuration from file.
+    val i3Conf = new Ingestion3Conf(confFile, Some(shortName))
+    val conf = i3Conf.load()
+
+    // Read spark master property from conf, default to 'local[1]' if not set
+    val sparkMaster = conf.spark.sparkMaster.getOrElse("local[1]")
+
+    val sparkConf = new SparkConf()
+      .setAppName(s"Mapping: $shortName")
+      .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+      .set("spark.kryoserializer.buffer.max", "200")
+      .setMaster(sparkMaster)
+
+    // TODO These processes should return some flag or metric to help determine whether to proceed
+    // Mapping
+    val mapDataOut: String =
+      executeMapping(sparkConf, harvestData, baseDataOut, shortName, logger)
+
+    // Enrichment
+    val enrichDataOut: String =
+      executeEnrichment(sparkConf, mapDataOut, baseDataOut, shortName, logger, conf)
+
+    // Json-l
+    executeJsonl(sparkConf, enrichDataOut, baseDataOut, shortName, logger)
+
+    // Reports
+    executeAllReports(sparkConf, enrichDataOut, baseDataOut, shortName, logger)
   }
 }

--- a/src/main/scala/dpla/ingestion3/utils/Utils.scala
+++ b/src/main/scala/dpla/ingestion3/utils/Utils.scala
@@ -176,12 +176,14 @@ object Utils {
 
     // Given that `listObjects' returns results in alphabetical order,
     // and files are timestamped,
-    // we can assume the last result will be from the most recent activity.
+    // we can assume the last item on the last page of results
+    // will be from the most recent activity.
     val firstBatch: ObjectListing = s3client.listObjects(bucketName, prefix)
     val lastBatch: ObjectListing = getLastBatch(firstBatch)
     val objectSummaries: java.util.List[S3ObjectSummary] = lastBatch.getObjectSummaries
     val lastKey = objectSummaries.get(objectSummaries.size - 1).getKey
 
+    // Get the timestamped "folder" name, e.g. "20181003_171648-mdl-OriginalRecord.avro"
     val suffix: String = lastKey.stripPrefix(prefix).stripPrefix("/").split("/")(0)
 
     path.stripSuffix("/") + "/" + suffix

--- a/src/main/scala/dpla/ingestion3/utils/Utils.scala
+++ b/src/main/scala/dpla/ingestion3/utils/Utils.scala
@@ -18,8 +18,6 @@ import scala.concurrent.duration._
 import scala.util.Try
 import scala.xml.NodeSeq
 
-
-
 object Utils {
 
   /**

--- a/src/main/scala/dpla/ingestion3/utils/Utils.scala
+++ b/src/main/scala/dpla/ingestion3/utils/Utils.scala
@@ -178,8 +178,8 @@ object Utils {
     // and files are timestamped,
     // we can assume the last result will be from the most recent activity.
     val firstBatch: ObjectListing = s3client.listObjects(bucketName, prefix)
-    val objectListing: ObjectListing = lastBatch(firstBatch)
-    val objectSummaries: java.util.List[S3ObjectSummary] = objectListing.getObjectSummaries
+    val lastBatch: ObjectListing = getLastBatch(firstBatch)
+    val objectSummaries: java.util.List[S3ObjectSummary] = lastBatch.getObjectSummaries
     val lastKey = objectSummaries.get(objectSummaries.size - 1).getKey
 
     val suffix: String = lastKey.stripPrefix(prefix).stripPrefix("/").split("/")(0)
@@ -189,8 +189,8 @@ object Utils {
 
   // TODO: Handle network errors?
   @tailrec
-  def lastBatch(ol: ObjectListing): ObjectListing = {
-    if (ol.isTruncated) lastBatch(s3client.listNextBatchOfObjects(ol))
+  def getLastBatch(ol: ObjectListing): ObjectListing = {
+    if (ol.isTruncated) getLastBatch(s3client.listNextBatchOfObjects(ol))
     else ol
   }
 

--- a/src/test/scala/dpla/ingestion3/dataStorage/DataStorageTest.scala
+++ b/src/test/scala/dpla/ingestion3/dataStorage/DataStorageTest.scala
@@ -28,4 +28,14 @@ class DataStorageTest extends FlatSpec {
     val badPath = "s3a://"
     assertThrows[RuntimeException](parseS3Address(badPath))
   }
+
+  "S3Address.fullPath" should "compose full path" in {
+    val address = S3Address("s3a", "my-bucket", Some("prefix"))
+    assert(S3Address.fullPath(address) == "s3a://my-bucket/prefix")
+  }
+
+  "S3Address.fullPath" should "handle leading/trailing slashes" in {
+    val address = S3Address("s3a", "my-bucket/", Some("/prefix/"))
+    assert(S3Address.fullPath(address) == "s3a://my-bucket/prefix")
+  }
 }

--- a/src/test/scala/dpla/ingestion3/dataStorage/DataStorageTest.scala
+++ b/src/test/scala/dpla/ingestion3/dataStorage/DataStorageTest.scala
@@ -4,17 +4,18 @@ import org.scalatest._
 
 class DataStorageTest extends FlatSpec {
 
-  val path = "s3a://my-bucket/foo/bar/"
-
   "parseS3Address" should "correctly parse an S3 protocol" in {
+    val path = "s3a://my-bucket/foo/bar/"
     assert(parseS3Address(path).protocol == "s3a")
   }
 
   "parseS3Address" should "correctly parse an S3 bucket" in {
+    val path = "s3a://my-bucket/foo/bar/"
     assert(parseS3Address(path).bucket == "my-bucket")
   }
 
   "parseS3Address" should "correctly parse an S3 prefix" in {
+    val path = "s3a://my-bucket/foo/bar/"
     assert(parseS3Address(path).prefix == Some("foo/bar"))
   }
 

--- a/src/test/scala/dpla/ingestion3/dataStorage/DataStorageTest.scala
+++ b/src/test/scala/dpla/ingestion3/dataStorage/DataStorageTest.scala
@@ -1,0 +1,30 @@
+package dpla.ingestion3.dataStorage
+
+import org.scalatest._
+
+class DataStorageTest extends FlatSpec {
+
+  val path = "s3a://my-bucket/foo/bar/"
+
+  "parseS3Address" should "correctly parse an S3 protocol" in {
+    assert(parseS3Address(path).protocol == "s3a")
+  }
+
+  "parseS3Address" should "correctly parse an S3 bucket" in {
+    assert(parseS3Address(path).bucket == "my-bucket")
+  }
+
+  "parseS3Address" should "correctly parse an S3 prefix" in {
+    assert(parseS3Address(path).prefix == Some("foo/bar"))
+  }
+
+  "parseS3Address" should "throw exception in absence of s3 protocol" in {
+    val badPath = "/foo/bar"
+    assertThrows[RuntimeException](parseS3Address(badPath))
+  }
+
+  "parseS3Address" should "throw exception in absence of bucket" in {
+    val badPath = "s3a://"
+    assertThrows[RuntimeException](parseS3Address(badPath))
+  }
+}

--- a/src/test/scala/dpla/ingestion3/dataStorage/InputHelperTest.scala
+++ b/src/test/scala/dpla/ingestion3/dataStorage/InputHelperTest.scala
@@ -1,0 +1,16 @@
+package dpla.ingestion3.dataStorage
+
+import org.scalatest._
+
+class InputHelperTest extends FlatSpec {
+
+  "isActivityPath" should "return true if given valid activity path" in {
+    val path = "s3a://my-bucket/esdn/enrichment/20181003_215135-esdn-MAP4_0.EnrichRecord.avro/"
+    assert(InputHelper.isActivityPath(path) == true)
+  }
+
+  "isActivityPath" should "return false if given invalid activity path" in {
+    val path = "s3a://my-bucket/esdn/enrichment/"
+    assert(InputHelper.isActivityPath(path) == false)
+  }
+}


### PR DESCRIPTION
This adds the ability to find the most recent harvest on S3.  Before, this was implemented only for local files.

Workflow when running `IngestRemap`:
* If the given `--input` is a recognizable activity folder (see `InputHelper.isActivityPath`), then it will be used as-is.
* If not, the code will look inside the given folder to find the most recent activity.

I've created a new package, `dataStorage`.  I plan to move the existing `OutputHelper` into the `dataStorage` package (its currently in `Utils`), but I left it out here b/c I didn't want to overload this PR.  My intention is for `dataStorage` to hold all logic specifically related to our data persistence layer.  I made some package methods in anticipation of their being more generally useful to future members of the package.

I moved the logic to distinguish between an S3 path and a local path to the `InputHelper` so that the `IngestRemap` entry doesn't have to worry about it anymore.

This has been tested with local and S3 input paths.