### PR TITLE
_SUMMARY

### DIFF
--- a/src/main/scala/dpla/ingestion3/messages/EnrichmentSummary.scala
+++ b/src/main/scala/dpla/ingestion3/messages/EnrichmentSummary.scala
@@ -18,7 +18,6 @@ object EnrichmentSummary {
     val langImproved = Utils.formatNumber(data.enrichmentOpSummary.langImproved)
     val placeImproved = Utils.formatNumber(data.enrichmentOpSummary.placeImprove)
 
-    val failedCountStr = Utils.formatNumber(data.operationSummary.recordsFailed)
     val lineBreak = "-"*80
 
     s"""


### PR DESCRIPTION
Write summary messages generated by MappingExecutor and EnrichExecutor to _SUMMARY files alongside _MANIFEST files. This is some of the precursor work for sending summary emails which will be implemented in a future PR. 

- Add `writeSummary` to `OutputHelper.scala`
- Remove 'all' from log file output for both mapping and enrichment (redundant) 
- Change file naming conventions of log files removing redundant information (provider, endtime, operation)

This has been tested on both s3 and local.
```
➜  ingestion3 git:(in-569/summary-files) ✗ s3cmd ls s3:///dpla-sw/ingestion3/mt/enrichment/20181016_164637-mt-MAP4_0.EnrichRecord.avro/
                       DIR   s3://dpla-sw/ingestion3/mt/enrichment/20181016_164637-mt-MAP4_0.EnrichRecord.avro/_LOGS/
2018-10-16 20:55       174   s3://dpla-sw/ingestion3/mt/enrichment/20181016_164637-mt-MAP4_0.EnrichRecord.avro/_MANIFEST
2018-10-16 20:55         0   s3://dpla-sw/ingestion3/mt/enrichment/20181016_164637-mt-MAP4_0.EnrichRecord.avro/_SUCCESS
2018-10-16 20:57      1422   s3://dpla-sw/ingestion3/mt/enrichment/20181016_164637-mt-MAP4_0.EnrichRecord.avro/_SUMMARY
2018-10-16 20:54   1996091   s3://dpla-sw/ingestion3/mt/enrichment/20181016_164637-mt-MAP4_0.EnrichRecord.avro/part-00000-f135fb6a-7952-4023-81d3-1ef89b96da99-c000.avro
```
Example console output for mapping and enrichment on S3
```
                                Mapping Summary

Provider......................................................................MT
Start date...................................................10/17/2018 12:17:38
Runtime.............................................................00:37:33.114

Attempted.................................................................69,769
Successful................................................................69,766
Failed.........................................................................3


                              Errors and Warnings

Messages
- Errors.......................................................................4
- Warnings.................................................................1,429

Records
- Errors.......................................................................3
- Warnings.................................................................1,429

                                Message Summary
Warnings
- Duplicate, rights and edmRights..........................................1,429
- Total....................................................................1,429
Errors
- Missing required field, dataProvider.........................................2
- Missing required field, rights or edmRights..................................2
- Total........................................................................4

                                   Log Files

s3a://dpla-sw/ingestion3/mt/mapping/20181017_121738-mt-MAP4_0.MAPRecord.avro/_LOGS/errors
s3a://dpla-sw/ingestion3/mt/mapping/20181017_121738-mt-MAP4_0.MAPRecord.avro/_LOGS/warnings
INFO  2018-10-17 13:06:42,950 [EnrichExecutor.scala:113]:  Manifest written to dpla-sw/ingestion3/mt/enrichment/20181017_125724-mt-MAP4_0.EnrichRecord.avro/_MANIFEST.
INFO  2018-10-17 13:09:02,279 [EnrichExecutor.scala:176]:  Summary written to dpla-sw/ingestion3/mt/enrichment/20181017_125724-mt-MAP4_0.EnrichRecord.avro/_SUMMARY.
INFO  2018-10-17 13:09:02,282 [EnrichExecutor.scala:180]:  

                               Enrichment Summary

Provider......................................................................MT
Start date...................................................10/17/2018 12:57:24
Runtime.............................................................00:09:18.125

Attempted.................................................................69,766
Improved..................................................................69,387
Unimproved...................................................................379

                               Field Improvements
Type......................................................................64,265
- Enriched value..........................................................47,095
- Original value..........................................................17,170
Language.......................................................................0


Place..........................................................................0
Date...........................................................................0

                                   Log Files
s3a://dpla-sw/ingestion3/mt/enrichment/20181017_125724-mt-MAP4_0.EnrichRecord.avro/_LOGS/type
```

Sample console output running locally
```
INFO  2018-10-17 13:28:45,214 [IngestRemap.scala:47]:  Using harvest data from /Users/scott/dpla/i3/mt/harvest/20181004_111602-mt-OriginalRecord.avro
INFO  2018-10-17 13:30:04,807 [MappingExecutor.scala:108]:  Manifest written to /Users/scott/dpla/i3/mt/mapping/20181017_132845-mt-MAP4_0.MAPRecord.avro/_MANIFEST.
INFO  2018-10-17 13:31:57,269 [MappingExecutor.scala:122]:  Summary written to /Users/scott/dpla/i3/mt/mapping/20181017_132845-mt-MAP4_0.MAPRecord.avro/_SUMMARY.
INFO  2018-10-17 13:31:57,270 [MappingExecutor.scala:126]:  --------------------------------------------------------------------------------
                                Mapping Summary

Provider......................................................................MT
Start date...................................................10/17/2018 13:28:45
Runtime.............................................................00:01:19.332

Attempted.................................................................69,769
Successful................................................................69,766
Failed.........................................................................3


                              Errors and Warnings

Messages
- Errors.......................................................................4
- Warnings.................................................................1,429

Records
- Errors.......................................................................3
- Warnings.................................................................1,429

                                Message Summary
Warnings
- Duplicate, rights and edmRights..........................................1,429
- Total....................................................................1,429
Errors
- Missing required field, dataProvider.........................................2
- Missing required field, rights or edmRights..................................2
- Total........................................................................4

                                   Log Files

/Users/scott/dpla/i3/mt/mapping/20181017_132845-mt-MAP4_0.MAPRecord.avro/_LOGS/errors
/Users/scott/dpla/i3/mt/mapping/20181017_132845-mt-MAP4_0.MAPRecord.avro/_LOGS/warnings
```
