### PR TITLE
Add Getty Primo harvester

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/api/GettyHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/GettyHarvester.scala
@@ -1,0 +1,39 @@
+
+package dpla.ingestion3.harvesters.api
+
+import java.net.URL
+
+import dpla.ingestion3.confs.i3Conf
+import org.apache.http.client.utils.URIBuilder
+import org.apache.log4j.Logger
+import org.apache.spark.sql.SparkSession
+
+/**
+  * Class for harvesting records from the Getty Primo endpoint
+  *
+  */
+class GettyHarvester(spark: SparkSession,
+                     shortName: String,
+                     conf: i3Conf,
+                     harvestLogger: Logger)
+  extends PrimoHarvester(spark, shortName, conf, harvestLogger) {
+
+  /**
+    * Constructs the URL for Getty Primo API requests
+    *
+    * @param params URL parameters
+    * @return URL
+    */
+  override def buildUrl(params: Map[String, String]): URL =
+    new URIBuilder()
+      .setScheme("http")
+      .setHost("primo.getty.edu/")
+      .setPath("/PrimoWebServices/xservice/search/brief")
+      .setParameter("indx", params.getOrElse("indx", "1")) // record offset
+      .setParameter("bulkSize", params.getOrElse("rows", "500")) // records per page
+      .setParameter("institution", "01GRI")
+      .setParameter("loc", "local,scope:(GETTY_OCP,GETTY_ROSETTA)")
+      .setParameter("query", params.getOrElse("query", throw new RuntimeException("No query parameter provided")))
+      .build()
+      .toURL
+}

--- a/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
+++ b/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
@@ -37,6 +37,16 @@ class EsdnProfile extends XmlProfile {
 }
 
 /**
+  * J. Paul Getty Trust
+  */
+class GettyProfile extends XmlProfile {
+  type Mapping = EsdnMapping // FIXME when mapping implemented
+
+  override def getHarvester = classOf[GettyHarvester]
+  override def getMapping = new EsdnMapping // FIXME when mapping implemented
+}
+
+/**
   * Internet Archive
   */
 class IaProfile extends JsonProfile {

--- a/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
+++ b/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
@@ -46,6 +46,7 @@ object ProviderRegistry {
     "cdl" -> Register(profile = new CdlProfile),
     "dc" -> Register(profile = new DcProfile),
     "esdn" -> Register(profile = new EsdnProfile),
+    "getty" -> Register(profile = new GettyProfile),
     "ia" -> Register(profile = new IaProfile),
     "loc" -> Register(profile = new LocProfile),
     "mdl" -> Register(profile = new MdlProfile),


### PR DESCRIPTION
- Adds `GettyHarvester.scala` to construct API request
- Add Getty to `ProviderProfiles.scala` and `ProviderRegistry.scala`

Getty configuration for `i3.conf`
```
# Getty (PrimoAPI)
getty.provider="J. Paul Getty Trust"
getty.harvest.type="api"
getty.harvest.rows="500"
getty.harvest.query="facet_local5,exact,DPLA"
```

Sample Harvester output
```
INFO  2018-10-18 09:02:05,742 [HarvestExecutor.scala:37]:  Harvest initiated
INFO  2018-10-18 09:02:05,744 [HarvestExecutor.scala:38]:  Provider short name: getty
INFO  2018-10-18 09:02:06,935 [HarvestExecutor.scala:48]:  Harvest type: api
INFO  2018-10-18 09:02:14,922 [PrimoHarvester.scala:81]:  Fetched 500 of 99,832 from http://primo.getty.edu//PrimoWebServices/xservice/search/brief?indx=1&bulkSize=500&institution=01GRI&loc=local%2Cscope%3A%28GETTY_OCP%2CGETTY_ROSETTA%29&query=facet_local5%2Cexact%2CDPLA
INFO  2018-10-18 09:02:24,958 [PrimoHarvester.scala:81]:  Fetched 1,000 of 99,832 from http://primo.getty.edu//PrimoWebServices/xservice/search/brief?indx=501&bulkSize=500&institution=01GRI&loc=local%2Cscope%3A%28GETTY_OCP%2CGETTY_ROSETTA%29&query=facet_local5%2Cexact%2CDPLA
INFO  2018-10-18 09:02:33,249 [PrimoHarvester.scala:81]:  Fetched 1,500 of 99,832 from http://primo.getty.edu//PrimoWebServices/xservice/search/brief?indx=1001&bulkSize=500&institution=01GRI&loc=local%2Cscope%3A%28GETTY_OCP%2CGETTY_ROSETTA%29&query=facet_local5%2Cexact%2CDPLA
INFO  2018-10-18 09:02:40,567 [PrimoHarvester.scala:81]:  Fetched 2,000 of 99,832 from http://primo.getty.edu//PrimoWebServices/xservice/search/brief?indx=1501&bulkSize=500&institution=01GRI&loc=local%2Cscope%3A%28GETTY_OCP%2CGETTY_ROSETTA%29&query=facet_local5%2Cexact%2CDPLA
INFO  2018-10-18 09:02:47,596 [PrimoHarvester.scala:81]:  Fetched 2,500 of 99,832 from http://primo.getty.edu//PrimoWebServices/xservice/search/brief?indx=2001&bulkSize=500&institution=01GRI&loc=local%2Cscope%3A%28GETTY_OCP%2CGETTY_ROSETTA%29&query=facet_local5%2Cexact%2CDPLA
INFO  2018-10-18 09:02:55,740 [PrimoHarvester.scala:81]:  Fetched 3,000 of 99,832 from http://primo.getty.edu//PrimoWebServices/xservice/search/brief?indx=2501&bulkSize=500&institution=01GRI&loc=local%2Cscope%3A%28GETTY_OCP%2CGETTY_ROSETTA%29&query=facet_local5%2Cexact%2CDPLA
INFO  2018-10-18 09:03:03,188 [PrimoHarvester.scala:81]:  Fetched 3,500 of 99,832 from http://primo.getty.edu//PrimoWebServices/xservice/search/brief?indx=3001&bulkSize=500&institution=01GRI&loc=local%2Cscope%3A%28GETTY_OCP%2CGETTY_ROSETTA%29&query=facet_local5%2Cexact%2CDPLA
INFO  2018-10-18 09:03:09,990 [PrimoHarvester.scala:81]:  Fetched 4,000 of 99,832 from http://primo.getty.edu//PrimoWebServices/xservice/search/brief?indx=3501&bulkSize=500&institution=01GRI&loc=local%2Cscope%3A%28GETTY_OCP%2CGETTY_ROSETTA%29&query=facet_local5%2Cexact%2CDPLA
INFO  2018-10-18 09:03:16,618 [PrimoHarvester.scala:81]:  Fetched 4,500 of 99,832 from http://primo.getty.edu//PrimoWebServices/xservice/search/brief?indx=4001&bulkSize=500&institution=01GRI&loc=local%2Cscope%3A%28GETTY_OCP%2CGETTY_ROSETTA%29&query=facet_local5%2Cexact%2CDPLA
```