### PR TITLE
Fixup to Minnesota mapping and test

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/MdlMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MdlMapping.scala
@@ -12,7 +12,6 @@ import org.json4s.JsonDSL._
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
 
-// FIXME Why is the implicit conversion not working for JValue when it is for NodeSeq?
 class MdlMapping extends JsonMapping with JsonExtractor with IdMinter[JValue] with IngestMessageTemplates {
 
   val formatBlockList: Set[String] = ExtentIdentificationList.termList
@@ -28,25 +27,24 @@ class MdlMapping extends JsonMapping with JsonExtractor with IdMinter[JValue] wi
 
   // OreAggregation
   override def dataProvider(data: Document[JValue]): ZeroToMany[EdmAgent] =
-    extractStrings(unwrap(data) \\ "record" \ "dataProvider").map(nameOnlyAgent)
+    extractStrings(unwrap(data) \ "record" \ "dataProvider").map(nameOnlyAgent)
 
-  override def dplaUri(data: Document[JValue]): ExactlyOne[URI] =
-    new URI(mintDplaId(data))
+  override def dplaUri(data: Document[JValue]): ExactlyOne[URI] = URI(mintDplaId(data))
 
   override def edmRights(data: Document[json4s.JValue]): ZeroToMany[URI] =
-    extractStrings(unwrap(data)  \\ "record" \ "rights").map(URI)
+    extractStrings(unwrap(data) \ "record" \ "rights").map(URI)
 
   override def intermediateProvider(data: Document[JValue]): ZeroToOne[EdmAgent] =
     extractString(unwrap(data) \ "record" \ "intermediateProvider").map(nameOnlyAgent)
 
   override def isShownAt(data: Document[JValue]): ZeroToMany[EdmWebResource] =
-    extractStrings(unwrap(data) \\ "record" \ "isShownAt").map(stringOnlyWebResource)
+    extractStrings(unwrap(data) \ "record" \ "isShownAt").map(stringOnlyWebResource)
 
   override def originalRecord(data: Document[JValue]): ExactlyOne[String] =
     Utils.formatJson(data)
 
   override def preview(data: Document[JValue]): ZeroToMany[EdmWebResource] =
-    extractStrings(unwrap(data) \\ "record" \ "object").map(stringOnlyWebResource)
+    extractStrings(unwrap(data) \ "record" \ "object").map(stringOnlyWebResource)
 
   override def provider(data: Document[JValue]): ExactlyOne[EdmAgent] = agent
 
@@ -58,60 +56,61 @@ class MdlMapping extends JsonMapping with JsonExtractor with IdMinter[JValue] wi
     extractCollection(unwrap(data) \ "record" \ "sourceResource" \ "collection")
 
   override def contributor(data: Document[JValue]): ZeroToMany[EdmAgent] =
-    extractStrings(unwrap(data) \\ "record" \ "sourceResource" \ "contributor").map(nameOnlyAgent)
+    extractStrings(unwrap(data) \ "record" \ "sourceResource" \ "contributor").map(nameOnlyAgent)
 
   override def creator(data: Document[JValue]): ZeroToMany[EdmAgent] =
-    extractStrings(unwrap(data)  \\ "record" \ "sourceResource" \ "creator").map(nameOnlyAgent)
+    extractStrings(unwrap(data)  \ "record" \ "sourceResource" \ "creator").map(nameOnlyAgent)
 
   override def date(data: Document[JValue]): ZeroToMany[EdmTimeSpan] =
-    extractDate(unwrap(data)  \\ "record" \ "sourceResource" \ "date")
+    extractDate(unwrap(data) \ "record" \ "sourceResource" \ "date")
 
   override def description(data: Document[JValue]): ZeroToMany[String] =
-    extractStrings(unwrap(data) \\ "record" \ "sourceResource" \ "description")
+    extractStrings(unwrap(data) \ "record" \ "sourceResource" \ "description")
 
   override def extent(data: Document[JValue]): ZeroToMany[String] =
-    extractStrings(unwrap(data)  \\ "record" \\ "extent")
+    extractStrings(unwrap(data) \ "record" \ "sourceResource" \ "extent")
 
   override def format(data: Document[JValue]): ZeroToMany[String] =
-    extractStrings(unwrap(data)  \\ "record" \ "sourceResource" \ "format").map(_.applyBlockFilter(formatBlockList))
+    extractStrings(unwrap(data) \ "record" \ "sourceResource" \ "format")
+      .map(_.applyBlockFilter(formatBlockList))
+      .filter(_.nonEmpty)
 
   override def genre(data: Document[JValue]): ZeroToMany[SkosConcept] =
-    extractStrings(unwrap(data)  \\ "record" \ "sourceResource" \ "type").map(nameOnlyConcept)
+    extractStrings(unwrap(data) \ "record" \ "sourceResource" \ "type").map(nameOnlyConcept)
 
   override def language(data: Document[JValue]): ZeroToMany[SkosConcept] = {
-    val codes = extractStrings(unwrap(data) \\ "record" \ "sourceResource" \ "language" \ "iso636_3").map(nameOnlyConcept)
-    val names = extractStrings(unwrap(data) \\ "record" \ "sourceResource" \ "language" \ "name").map(nameOnlyConcept)
+    val codes = extractStrings(unwrap(data) \ "record" \ "sourceResource" \ "language" \ "iso639_3")
+    val names = extractStrings(unwrap(data) \ "record" \ "sourceResource" \ "language" \ "name")
 
-    if (codes.nonEmpty)
-      codes
-    else
-      names
+    (codes.nonEmpty, names.nonEmpty) match {
+      case (true, _) => codes.map(nameOnlyConcept) // if iso639_3 is given use that value
+      case (false, true) => names.map(nameOnlyConcept) // if iso639_3 is not given and name is, use name
+      case (_, _) => List() // empty list
+    }
   }
 
   override def place(data: Document[JValue]): ZeroToMany[DplaPlace] =
-    place(unwrap(data) \\ "record" \\ "sourceResource" \ "spatial")
+    place(unwrap(data) \ "record" \ "sourceResource" \ "spatial")
 
   override def publisher(data: Document[JValue]): ZeroToMany[EdmAgent] =
-    extractStrings(unwrap(data)  \\ "record" \\ "sourceResource" \ "publisher").map(nameOnlyAgent)
+    extractStrings(unwrap(data)  \ "record" \ "sourceResource" \ "publisher").map(nameOnlyAgent)
 
   override def rights(data: Document[JValue]): AtLeastOne[String] =
-    extractStrings(unwrap(data)  \\ "record" \\ "sourceResource" \ "rights")
+    extractStrings(unwrap(data)  \ "record" \ "sourceResource" \ "rights")
 
   override def subject(data: Document[JValue]): ZeroToMany[SkosConcept] =
-    extractStrings(unwrap(data)  \\ "record" \\ "sourceResource" \ "subject" \ "name").map(nameOnlyConcept)
+    extractStrings(unwrap(data)  \ "record" \ "sourceResource" \ "subject" \ "name").map(nameOnlyConcept)
 
   override def title(data: Document[JValue]): AtLeastOne[String] =
-    extractStrings(unwrap(data)  \\ "record" \ "sourceResource" \ "title")
+    extractStrings(unwrap(data)  \ "record" \ "sourceResource" \ "title")
 
   override def `type`(data: Document[JValue]): ZeroToMany[String] =
-    extractStrings(unwrap(data)  \\ "record" \ "sourceResource" \ "type")
+    extractStrings(unwrap(data)  \ "record" \ "sourceResource" \ "type")
 
   // Helper functions
   def extractCollection(collection: JValue): ZeroToMany[DcmiTypeCollection] = {
     iterify(collection).children.map(c => {
       DcmiTypeCollection(
-        // TODO confirm this mapping
-        // Example http://hub-client.lib.umn.edu/api/v1/records?q=32dc110dae8fa8471178e5fbfe5546446dcef7ec
         title = extractString(c \\ "title"),
         description = extractString(c \\ "description")
       )})
@@ -129,10 +128,7 @@ class MdlMapping extends JsonMapping with JsonExtractor with IdMinter[JValue] wi
   def place(place: JValue): ZeroToMany[DplaPlace] = {
     iterify(place).children.map(p =>
       DplaPlace(
-        // head is used b/c name and coordinate values can be string or arrays in original data
-        // TODO Is there a cleaner way to handle this case in data ExtractionUtils extractString method?
-        // See http://cqa-pa.internal.dp.la:8080/qa/compare?id=cfa88467c38a5fa871252c7e0a76962d
-        // vs http://cqa-pa.internal.dp.la:8080/v2/items/8905a0065622a217b0d929cef3f62246?api_key=
+        // use headOption because 'name' and 'coordinate' values can be either Strings or Lists in original data
         name = extractStrings(p \\ "name").headOption,
         coordinates = extractStrings(p \\ "coordinates").headOption
       ))

--- a/src/test/resources/mdl.json
+++ b/src/test/resources/mdl.json
@@ -1,75 +1,114 @@
 {
-  "record_id" : "94d1b3b8487d91222cd1b185ebf528b8f0142b90",
-  "published" : true,
-  "tags" : [ "dpla_oai2", "sd", "dpla", "dplaingest" ],
-  "import_job_name" : "Digital Library of South Dakota",
-  "import_job_id" : 71,
-  "ingested_at" : "2018-07-21T11:14:56Z",
-  "record" : {
-    "object" : "http://explore.digitalsd.org/utils/getthumbnail/collection/Hobo/id/7431",
-    "rights" : "http://rightsstatements.org/vocab/InC-EDU/1.0/",
-    "@context" : "http://dp.la/api/items/context",
-    "provider" : "Minnesota Digital Library",
-    "isShownAt" : "http://explore.digitalsd.org/cdm/ref/collection/Hobo/id/7431",
-    "identifier" : "oai:explore.digitalsd.org:Hobo/7431",
-    "batch_param" : "",
-    "record_hash" : "94d1b3b8487d91222cd1b185ebf528b8f0142b90",
-    "dataProvider" : "South Dakota State University",
-    "originalRecord" : {
-      "header" : {
-        "setSpec" : "Hobo",
-        "datestamp" : "2017-11-14",
-        "identifier" : "oai:explore.digitalsd.org:Hobo/7431"
+  "record_id": "1PP792Z9DMQG9BEV7ME81BCR44",
+  "published": true,
+  "tags": [
+    "dpla_nonoai",
+    "dpla",
+    "dplaingest"
+  ],
+  "import_job_name": "MPR",
+  "import_job_id": 2,
+  "ingested_at": "2018-11-05T12:13:03Z",
+  "record": {
+    "rights": "www.fake.rights.url.org/public-domain",
+    "intermediateProvider": "one intermediate provider",
+    "object": "http://image.prview.org/thumb.jpg",
+    "title": "Hmong vendors learn the law on legal drug sales",
+    "format": "news bulletin",
+    "@context": "http://dp.la/api/items/context",
+    "provider": "Minnesota Digital Library",
+    "isShownAt": "https://archive.mpr.org/stories/2014/08/14/hmong-vendors-learn-the-law-on-legal-drug",
+    "identifier": "1PP792Z9DMQG9BEV7ME81BCR44",
+    "batch_param": "",
+    "record_hash": "1PP792Z9DMQG9BEV7ME81BCR44",
+    "dataProvider": "Minnesota Public Radio",
+    "originalRecord": {
+      "object": null,
+      "@context": "http://dp.la/api/items/context",
+      "provider": "Minnesota Digital Library",
+      "isShownAt": "https://archive.mpr.org/stories/2014/08/14/hmong-vendors-learn-the-law-on-legal-drug",
+      "dataProvider": "Minnesota Public Radio",
+      "originalRecord": {
+        "guid": "1PP792Z9DMQG9BEV7ME81BCR44"
       },
-      "metadata" : {
-        "dc" : {
-          "date" : "2012",
-          "type" : "Still Image",
-          "title" : "Singer in the spotlight",
-          "format" : "Color photographs",
-          "rights" : "http://rightsstatements.org/vocab/InC-EDU/1.0/",
-          "creator" : "DesLauriers, Scott",
-          "subject" : "Preserving Historic Hobo Day; South Dakota State University -- Hobo Day; 100 Years of Hobo Day; Hobo Day Committee",
-          "coverage" : "Brookings (Brookings County : South Dakota)",
-          "relation" : [ "Preserving Historic Hobo Day - Funded by a 2016 Common Heritage grant from the National Endowment for the Humanities", "Hobo Day - SDSU" ],
-          "xmlns:dc" : "http://purl.org/dc/elements/1.1/",
-          "publisher" : "South Dakota State University",
-          "xmlns:xsi" : "http://www.w3.org/2001/XMLSchema-instance",
-          "identifier" : [ "PHHD-1031", "http://explore.digitalsd.org/cdm/ref/collection/Hobo/id/7431" ],
-          "contributor" : "DesLauriers, Scott",
-          "description" : "Hobo Day Committee member in costume sings into microphone during 100 Years of Hobo Day event",
-          "xmlns:oai_dc" : "http://www.openarchives.org/OAI/2.0/oai_dc/",
-          "xsi:schemaLocation" : "http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
-        }
+      "sourceResource": {
+        "collection": ["collection3", "collection4"],
+        "contributor": ["contrib4", "contrib3"],
+        "date": {
+          "end": "2014",
+          "begin": "2014",
+          "displayDate": "faaje "
+        },
+        "title": "Hmong vendors learn the law on legal drug sales",
+        "rights": "http://minnesota.publicradio.org/about/site/terms/",
+        "creator": [
+          "fake creator"
+        ],
+        "subject": [
+          "MPR News Feature",
+          "Cultural Legacy Digitization (2016-2017)"
+        ],
+        "language": [
+          {
+            "name": "English",
+            "iso639_3": "eng"
+          }
+        ],
+        "type": ["fake image"],
+        "description": "A few blocks from the state Capitol, shoppers at the Hmongtown Marketplace can buy just about anything. The bustling center of small businesses is a favorite of the city's Hmong community because if offers fresh groceries, medicinal herbs, and prepared food. But a June 2013 raid found that some vendors in the marketplace also had drugs for sale. Ramsey County Prosecutors charged 14 people with selling misbranded drugs, possessing and selling drugs that require a license, selling syringes, and unlawfully possessing poison."
       }
     },
-    "sourceResource" : {
-      "date" : {
-        "displayDate" : "2012"
+    "sourceResource": {
+      "collection": [
+        {
+          "title": "collection1",
+          "description": "description1"
+        },
+        {
+          "title": "collection2"
+        }
+      ],
+      "contributor": ["contrib1", "contrib2"],
+      "creator": ["creator1", "creator2"],
+      "date": {
+        "end": "2014",
+        "begin": "2014",
+        "displayDate": "2014-08-14"
       },
-      "type" : [ "image" ],
-      "title" : "Singer in the spotlight",
-      "format" : [ "Color photographs" ],
-      "creator" : "DesLauriers, Scott",
-      "subject" : [ {
-        "name" : "100 Years of Hobo Day"
-      }, {
-        "name" : "Hobo Day Committee"
-      }, {
-        "name" : "South Dakota State University"
-      }, {
-        "name" : "Hobo Day"
-      }, {
-        "name" : "Preserving Historic Hobo Day"
-      } ],
-      "relation" : [ [ "Preserving Historic Hobo Day - Funded by a 2016 Common Heritage grant from the National Endowment for the Humanities" ], [ "Hobo Day - SDSU" ] ],
-      "collection" : {
-        "title" : "SDSU - Hobo Day Collection",
-        "description" : "Enter all material related to Hobo Day"
-      },
-      "contributor" : "DesLauriers, Scott",
-      "description" : "Hobo Day Committee member in costume sings into microphone during 100 Years of Hobo Day event"
-    },
-    "intermediateProvider" : "Digital Library of South Dakota"
+      "extent": ["extent1", "extent2"],
+      "format": ["1x2", "pencil on paper"],
+      "title": "Hmong vendors learn the law on legal drug sales",
+      "subject": [
+        {
+          "name": "MPR News Feature"
+        },
+        {
+          "name": "Reports"
+        },
+        {
+          "name": "Cultural Legacy Digitization (2016-2017)"
+        }
+      ],
+      "language": [
+        {
+          "name": "English",
+          "iso639_3": "eng"
+        }
+      ],
+      "description": "description",
+      "type": "image",
+      "rights": ["free text rights statement"],
+      "publisher": ["pub1"],
+      "spatial": [
+        {
+          "name": ["cincinnati", "ohio"],
+          "coordinates": ["1212.5151x1235.548", "151lat 431long"]
+        },
+        {
+          "name": ["hamilton county", "ohio"],
+          "coordinates": ["1.34 83.32", "151lat 431long"]
+        }
+      ]
+    }
   }
 }

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MdlMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MdlMappingTest.scala
@@ -2,9 +2,8 @@
 package dpla.ingestion3.mappers.providers
 
 import dpla.ingestion3.mappers.utils.Document
-import dpla.ingestion3.model._
+import dpla.ingestion3.model.{DcmiTypeCollection, _}
 import dpla.ingestion3.utils.FlatFileIO
-import org.json4s.JString
 import org.json4s.JsonAST.JValue
 import org.json4s.jackson.JsonMethods._
 import org.scalatest.{BeforeAndAfter, FlatSpec}
@@ -16,9 +15,135 @@ class MdlMappingTest extends FlatSpec with BeforeAndAfter {
   val json: Document[JValue] = Document(parse(jsonString))
   val extractor = new MdlMapping
 
-  it should "extract correct edmRights" in {
-    val expected = Seq(URI("http://rightsstatements.org/vocab/InC-EDU/1.0/"))
 
+  it should "use the provider short name when minting DPLA ids" in {
+    assert(extractor.useProviderName === true)
+  }
+
+  it should "return the correct provider name" in {
+    assert(extractor.getProviderName === "minnesota")
+  }
+
+  it should "extract the correct providerId" in {
+    val expected = "https://archive.mpr.org/stories/2014/08/14/hmong-vendors-learn-the-law-on-legal-drug"
+    assert(extractor.getProviderId(json) === expected)
+  }
+
+  // dataProvider
+
+  // dplaUri
+  it should "extract correct edmRights" in {
+    val expected = Seq(URI("www.fake.rights.url.org/public-domain"))
     assert(extractor.edmRights(json) === expected)
   }
+  // intermediateProvider
+  it should "extract the correct intermediateProvider" in {
+    val expected = Some(nameOnlyAgent("one intermediate provider"))
+    assert(extractor.intermediateProvider(json) === expected)
+  }
+  // TODO what if multiple intermediateProviders given?
+
+  // isShownAt
+  it should "extract the correct isShownAt" in {
+    val expected = List(stringOnlyWebResource("https://archive.mpr.org/stories/2014/08/14/hmong-vendors-learn-the-law-on-legal-drug"))
+    assert(extractor.isShownAt(json) === expected)
+  }
+  // preview
+  it should "extract the correct preview" in {
+    val expected = List(stringOnlyWebResource("http://image.prview.org/thumb.jpg"))
+    assert(extractor.preview(json) === expected)
+  }
+
+  // provider
+
+  // collection
+  it should "extract the correct collections" in {
+    val expected = List(
+      DcmiTypeCollection(title = Some("collection1"), description = Some("description1")),
+      DcmiTypeCollection(title = Some("collection2"), description = None)
+    )
+    assert(extractor.collection(json) === expected)
+  }
+  // contributor
+  it should "extract the correct contributors" in {
+    val expected = List("contrib1", "contrib2").map(nameOnlyAgent)
+    assert(extractor.contributor(json) === expected)
+  }
+  // creator
+  it should "extract the correct creator" in {
+    val expected = List("creator1", "creator2").map(nameOnlyAgent)
+    assert(extractor.creator(json) === expected)
+  }
+  // date
+  it should "extract the correct date with display, begin and end" in {
+    val expected = List(EdmTimeSpan(originalSourceDate = Some("2014-08-14"), begin = Some("2014"), end = Some("2014")))
+    assert(extractor.date(json) === expected)
+  }
+  // description
+  it should "extract the correct description" in {
+    val expected = List("description")
+    assert(extractor.description(json) === expected)
+  }
+  // extent
+  it should "extract the correct extent" in {
+    val expected = List("extent1", "extent2")
+    assert(extractor.extent(json) === expected)
+  }
+  // format with value filter
+  it should "extract the correct format" in {
+    val expected = List("pencil on paper")
+    assert(extractor.format(json) === expected)
+  }
+  // genre
+  it should "extract the correct genre from type field" in {
+    val expected = List("image").map(nameOnlyConcept)
+    assert(extractor.genre(json) === expected)
+  }
+  // language
+  it should "extract the correct language values" in {
+    val expected = List("eng").map(nameOnlyConcept)
+    assert(extractor.language(json) === expected)
+  }
+  // place | spatial
+  it should "extract the correct place and spatial values" in {
+    val expected = List(
+      DplaPlace(
+        name = Some("cincinnati"),
+        coordinates = Some("1212.5151x1235.548")
+      ),
+      DplaPlace(
+        name = Some("hamilton county"),
+        coordinates = Some("1.34 83.32")
+      )
+    )
+    assert(extractor.place(json) === expected)
+  }
+  // publisher
+  it should "extract the correct publisher" in {
+    val expected = List("pub1").map(nameOnlyAgent)
+    assert(extractor.publisher(json) === expected)
+  }
+  // rights
+  it should "extract the correct rights" in {
+    val expected = List("free text rights statement")
+    assert(extractor.rights(json) === expected)
+  }
+
+  // subject
+  it should "extract the correct subjects" in {
+    val expected = List("MPR News Feature", "Reports", "Cultural Legacy Digitization (2016-2017)")
+      .map(nameOnlyConcept)
+    assert(extractor.subject(json) === expected)
+  }
+  // title
+  it should "extract the correct title" in {
+    val expected = List("Hmong vendors learn the law on legal drug sales")
+    assert(extractor.title(json) === expected)
+  }
+  // type
+  it should "extract the correct type" in {
+    val expected = List("image")
+    assert(extractor.`type`(json) === expected)
+  }
+
 }


### PR DESCRIPTION
- Add a slew of missing mapping test and updates to test data
- Fixup a few minor errors in the MDL mapping that were uncovered during test rewrites. Changes focused on explicit path selection since they are giving us close to DPLA map and in some cases we were extracting from `record.originalRecord.sourceResource` instead of `record.sourceResource`. 