### PR TITLE
Fix/2018 11 nara harvest

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/Harvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/Harvester.scala
@@ -7,6 +7,7 @@ import dpla.ingestion3.utils.{FlatFileIO, Utils}
 import org.apache.avro.Schema
 import org.apache.avro.file.DataFileWriter
 import org.apache.avro.generic.GenericRecord
+import org.apache.commons.io.FileUtils
 import org.apache.log4j.Logger
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -58,7 +59,7 @@ abstract class LocalHarvester(
   //   then loaded into a spark DataFrame,
   //   then written to their final destination.
   // TODO: make tmp path configurable rather than hard-coded
-  val tmpOutStr = s"/tmp/$shortName"
+  val tmpOutStr = new File(FileUtils.getTempDirectory, shortName).getAbsolutePath
 
   // Delete temporary output directory and files if they already exist.
   Utils.deleteRecursively(new File(tmpOutStr))

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NaraFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NaraFileHarvester.scala
@@ -84,7 +84,8 @@ class NaraFileHarvester(
 
       case Some(data) =>
         Try {
-          val xml = XML.loadString(new String(data))
+          val dataString = new String(data).replaceAll("<\\?xml.*\\?>", "")
+          val xml = XML.loadString(dataString)
           val items = handleXML(xml)
           val entryName = tarResult.entryName
           // log the file name


### PR DESCRIPTION
Quick fixes to make NARA harvest work:

- System temp dir specified in platform agnostic way for FileHarvester
- Added filter for inline xml processing instructions in data that was blowing up the xml parser.