### PR TITLE
Fix temp folder race condition.

### DIFF
--- a/src/main/scala/dpla/ingestion3/executors/HarvestExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/HarvestExecutor.scala
@@ -93,7 +93,7 @@ trait HarvestExecutor {
 
       case Failure(f) => logger.error(s"Harvest failure: ${f.getMessage}")
     }
-
+    harvester.cleanUp()
     spark.stop()
   }
 

--- a/src/main/scala/dpla/ingestion3/harvesters/Harvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/Harvester.scala
@@ -19,7 +19,6 @@ abstract class Harvester(spark: SparkSession,
 
   def harvest: DataFrame = {
     val harvestData: DataFrame = localHarvest()
-    cleanUp()
     harvestData
   }
 


### PR DESCRIPTION
Changed cleanup call to happen at the end of a harvest so the 
temp data doesn't get deleted prior to the save process.