### PR TITLE
Mo harvester

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/file/FileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/FileHarvester.scala
@@ -1,5 +1,7 @@
 package dpla.ingestion3.harvesters.file
 
+import java.io.BufferedReader
+
 import dpla.ingestion3.confs.i3Conf
 import dpla.ingestion3.harvesters.{Harvester, LocalHarvester}
 import org.apache.avro.generic.GenericData
@@ -23,14 +25,15 @@ abstract class FileHarvester(spark: SparkSession,
                              logger: Logger)
   extends LocalHarvester(spark, shortName, conf, logger) {
 
-
   /**
     * Case class to hold the results of a file
     *
     * @param entryName Path of the entry in the file
     * @param data      Holds the data for the entry, or None if it's a directory.
     */
-  case class FileResult(entryName: String, data: Option[Array[Byte]])
+  case class FileResult(entryName: String,
+                        data: Option[Array[Byte]],
+                        bufferedData: Option[BufferedReader] = None)
 
   /**
     * Case class hold the parsed value from a given FileResult

--- a/src/main/scala/dpla/ingestion3/harvesters/file/FileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/FileHarvester.scala
@@ -28,8 +28,10 @@ abstract class FileHarvester(spark: SparkSession,
   /**
     * Case class to hold the results of a file
     *
-    * @param entryName Path of the entry in the file
-    * @param data      Holds the data for the entry, or None if it's a directory.
+    * @param entryName    Path of the entry in the file
+    * @param data         Holds the data for the entry, or None if it's a directory.
+    * @param bufferedData Holds a buffered reader for the entry if it's too
+    *                     large to be held in memory.
     */
   case class FileResult(entryName: String,
                         data: Option[Array[Byte]],

--- a/src/main/scala/dpla/ingestion3/harvesters/file/MoFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/MoFileHarvester.scala
@@ -76,6 +76,7 @@ class MoFileHarvester(spark: SparkSession,
         Success(0) // a directory, no results
       case Some(data) => Try {
 
+        // Assume that each line of the file contains a single record.
         var line: String = data.readLine
         var itemCount: Int = 0
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/MoFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/MoFileHarvester.scala
@@ -1,0 +1,144 @@
+package dpla.ingestion3.harvesters.file
+
+import java.io.{File, FileInputStream}
+import java.util.zip.ZipInputStream
+
+import dpla.ingestion3.confs.i3Conf
+import dpla.ingestion3.mappers.utils.JsonExtractor
+import org.apache.commons.io.IOUtils
+import org.apache.log4j.Logger
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.json4s.jackson.JsonMethods._
+import org.json4s.{JValue, _}
+import com.databricks.spark.avro._
+
+import scala.util.{Failure, Success, Try}
+
+
+/**
+  * Extracts values from parsed JSON
+  */
+class MoFileExtractor extends JsonExtractor
+
+/**
+  * Entry for performing a Missouri file harvest
+  */
+class MoFileHarvester(spark: SparkSession,
+                       shortName: String,
+                       conf: i3Conf,
+                       logger: Logger)
+  extends FileHarvester(spark, shortName, conf, logger) {
+
+  def mimeType: String = "application_json"
+
+  protected val extractor = new MoFileExtractor()
+
+  /**
+    * Loads .zip files
+    *
+    * @param file File to parse
+    * @return TarInputstream of the tar contents
+    */
+  def getInputStream(file: File): Option[ZipInputStream] = {
+    file.getName match {
+      case zipName if zipName.endsWith("zip") =>
+        Some(new ZipInputStream(new FileInputStream(file)))
+      case _ => None
+    }
+  }
+
+  /**
+    * Parses JValue to extract item local item id and renders compact
+    * full record
+    *
+    * @param json Full JSON item record
+    * @return Option[ParsedResult]
+    */
+  def getJsonResult(json: JValue): Option[ParsedResult] =
+    Option(ParsedResult(
+      extractor.extractString(json \ "@id")
+        .getOrElse(throw new RuntimeException("Missing ID")),
+      compact(render(json))
+    ))
+
+  /**
+    * Parses and extracts ZipInputStream and writes
+    * parsed records out.
+    *
+    * @param zipResult  Case class representing extracted items from the zip
+    * @return Count of metadata items found.
+    */
+  def handleFile(zipResult: FileResult,
+                 unixEpoch: Long): Try[Int] =
+
+    zipResult.data match {
+      case None =>
+        Success(0) // a directory, no results
+      case Some(data) => Try {
+        Try {
+          parse(new String(data)) // parse string to json
+        } match {
+          case Success(json) =>
+            // Expect that input json is an array of objects
+            json.asInstanceOf[JArray].arr.map(j =>
+              getJsonResult(j) match {
+                case Some(item) => {
+                  writeOut(unixEpoch, item)
+                  1
+                }
+                case _ => 0
+              }
+            ).sum
+          case _ => 0
+        }
+      }
+    }
+
+  /**
+    * Implements a stream of files from the zip
+    * Can't use @tailrec here because the compiler can't recognize it as tail recursive,
+    * but this won't blow the stack.
+    *
+    * @param zipInputStream
+    * @return Lazy stream of tar records
+    */
+  def iter(zipInputStream: ZipInputStream): Stream[FileResult] =
+    Option(zipInputStream.getNextEntry) match {
+      case None =>
+        Stream.empty
+      case Some(entry) =>
+        val result =
+          if (entry.isDirectory)
+            None
+          else
+            Some(IOUtils.toByteArray(zipInputStream, entry.getSize))
+        FileResult(entry.getName, result) #:: iter(zipInputStream)
+    }
+
+  /**
+    * Executes the Missouri harvest
+    */
+  override def localHarvest(): DataFrame = {
+    val harvestTime = System.currentTimeMillis()
+    val unixEpoch = harvestTime / 1000L
+    val inFiles = new File(conf.harvest.endpoint.getOrElse("in"))
+
+    inFiles.listFiles(new ZipFileFilter).foreach( inFile => {
+      val inputStream = getInputStream(inFile)
+        .getOrElse(throw new IllegalArgumentException("Couldn't load ZIP files."))
+      val recordCount = (for (result <- iter(inputStream)) yield {
+        handleFile(result, unixEpoch) match {
+          case Failure(exception) =>
+            logger.error(s"Caught exception on $inFile.", exception)
+            0
+          case Success(count) =>
+            count
+        }
+      }).sum
+      IOUtils.closeQuietly(inputStream)
+    })
+
+    // Read harvested data into Spark DataFrame and return.
+    spark.read.avro(tmpOutStr)
+  }
+}

--- a/src/main/scala/dpla/ingestion3/harvesters/file/MoFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/MoFileHarvester.scala
@@ -37,7 +37,7 @@ class MoFileHarvester(spark: SparkSession,
     * Loads .zip files
     *
     * @param file File to parse
-    * @return TarInputstream of the tar contents
+    * @return ZipInputstream of the zip contents
     */
   def getInputStream(file: File): Option[ZipInputStream] = {
     file.getName match {
@@ -83,6 +83,7 @@ class MoFileHarvester(spark: SparkSession,
         while (line != null) {
           val count = Try {
 
+            // Clean up leading/trailing characters
             val json: JValue = parse(line.stripPrefix("[").stripPrefix(","))
 
             getJsonResult(json) match {

--- a/src/main/scala/dpla/ingestion3/harvesters/file/MoFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/MoFileHarvester.scala
@@ -8,6 +8,7 @@ import dpla.ingestion3.mappers.utils.JsonExtractor
 import org.apache.commons.io.IOUtils
 import org.apache.log4j.Logger
 import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.functions._
 import org.json4s.jackson.JsonMethods._
 import org.json4s.{JValue, _}
 import com.databricks.spark.avro._
@@ -150,7 +151,10 @@ class MoFileHarvester(spark: SparkSession,
       IOUtils.closeQuietly(inputStream)
     })
 
-    // Read harvested data into Spark DataFrame and return.
-    spark.read.avro(tmpOutStr)
+    // Read harvested data into Spark DataFrame.
+    val df = spark.read.avro(tmpOutStr)
+
+    // Filter out records with "status":"deleted"
+    df.where(!col("document").like("%\"status\":\"deleted\"%"))
   }
 }

--- a/src/main/scala/dpla/ingestion3/harvesters/file/P2PFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/P2PFileHarvester.scala
@@ -37,7 +37,7 @@ class P2PFileHarvester(spark: SparkSession,
     * Loads .zip files
     *
     * @param file File to parse
-    * @return TarInputstream of the tar contents
+    * @return ZipInputstream of the zip contents
     */
   def getInputStream(file: File): Option[ZipInputStream] = {
     file.getName match {
@@ -99,7 +99,7 @@ class P2PFileHarvester(spark: SparkSession,
     * but this won't blow the stack.
     *
     * @param zipInputStream
-    * @return Lazy stream of tar records
+    * @return Lazy stream of zip records
     */
   def iter(zipInputStream: ZipInputStream): Stream[FileResult] =
     Option(zipInputStream.getNextEntry) match {

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MoMapping.scala
@@ -1,0 +1,55 @@
+package dpla.ingestion3.mappers.providers
+
+import dpla.ingestion3.enrichments.normalizations.StringNormalizationUtils._
+import dpla.ingestion3.enrichments.normalizations.filters.ExtentIdentificationList
+import dpla.ingestion3.mappers.utils._
+import dpla.ingestion3.messages.IngestMessageTemplates
+import dpla.ingestion3.model.DplaMapData.{AtLeastOne, ExactlyOne, ZeroToMany, ZeroToOne}
+import dpla.ingestion3.model._
+import dpla.ingestion3.utils.Utils
+import org.json4s
+import org.json4s.JsonDSL._
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+
+class MoMapping extends JsonMapping with JsonExtractor with IdMinter[JValue] with IngestMessageTemplates {
+
+  val formatBlockList: Set[String] = ExtentIdentificationList.termList
+
+  // ID minting functions
+  override def useProviderName: Boolean = true
+
+  override def getProviderName: String = "mo"
+
+  override def getProviderId(implicit data: Document[JValue]): String =
+    extractString(unwrap(data) \ "@id")
+      .getOrElse(throw new RuntimeException(s"No ID for record: ${compact(data)}"))
+
+  // OreAggregation
+  override def dataProvider(data: Document[JValue]): ZeroToMany[EdmAgent] =
+    extractStrings(unwrap(data) \ "dataProvider").map(nameOnlyAgent)
+
+  override def dplaUri(data: Document[JValue]): ExactlyOne[URI] = URI(mintDplaId(data))
+
+  override def hasView(data: Document[JValue]): ZeroToMany[EdmWebResource] =
+    extractStrings(unwrap(data) \ "hasView" \ "@id").map(stringOnlyWebResource)
+
+  override def isShownAt(data: Document[JValue]): ZeroToMany[EdmWebResource] =
+    extractStrings(unwrap(data) \ "isShownAt").map(stringOnlyWebResource)
+
+  override def `object`(data: Document[JValue]): ZeroToMany[EdmWebResource] =
+    extractStrings(unwrap(data) \ "object").map(stringOnlyWebResource)
+
+  override def originalRecord(data: Document[JValue]): ExactlyOne[String] =
+    Utils.formatJson(data)
+
+  override def provider(data: Document[JValue]): ExactlyOne[EdmAgent] = agent
+
+  override def sidecar(data: Document[JValue]): JValue =
+    ("prehashId", buildProviderBaseId()(data)) ~ ("dplaId", mintDplaId(data))
+
+  def agent = EdmAgent(
+    name = Some("Missouri Hub"),
+    uri = Some(URI("http://dp.la/api/contributor/missouri-hub"))
+  )
+}

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MoMapping.scala
@@ -1,13 +1,11 @@
 package dpla.ingestion3.mappers.providers
 
-import dpla.ingestion3.enrichments.normalizations.StringNormalizationUtils._
 import dpla.ingestion3.enrichments.normalizations.filters.ExtentIdentificationList
 import dpla.ingestion3.mappers.utils._
 import dpla.ingestion3.messages.IngestMessageTemplates
-import dpla.ingestion3.model.DplaMapData.{AtLeastOne, ExactlyOne, ZeroToMany, ZeroToOne}
+import dpla.ingestion3.model.DplaMapData.{AtLeastOne, ExactlyOne, ZeroToMany}
 import dpla.ingestion3.model._
 import dpla.ingestion3.utils.Utils
-import org.json4s
 import org.json4s.JsonDSL._
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
@@ -17,8 +15,10 @@ class MoMapping extends JsonMapping with JsonExtractor with IdMinter[JValue] wit
   val formatBlockList: Set[String] = ExtentIdentificationList.termList
 
   // ID minting functions
+  // TODO: Should this be true or false?
   override def useProviderName: Boolean = true
 
+  // TODO: Should this be the same as provider short name?
   override def getProviderName: String = "mo"
 
   override def getProviderId(implicit data: Document[JValue]): String =
@@ -26,6 +26,7 @@ class MoMapping extends JsonMapping with JsonExtractor with IdMinter[JValue] wit
       .getOrElse(throw new RuntimeException(s"No ID for record: ${compact(data)}"))
 
   // OreAggregation
+
   override def dataProvider(data: Document[JValue]): ZeroToMany[EdmAgent] =
     extractStrings(unwrap(data) \ "dataProvider").map(nameOnlyAgent)
 
@@ -48,8 +49,52 @@ class MoMapping extends JsonMapping with JsonExtractor with IdMinter[JValue] wit
   override def sidecar(data: Document[JValue]): JValue =
     ("prehashId", buildProviderBaseId()(data)) ~ ("dplaId", mintDplaId(data))
 
+  // SourceResource
+
+  override def creator(data: Document[JValue]): ZeroToMany[EdmAgent] =
+    extractStrings(unwrap(data)  \ "sourceResource" \ "creator").map(nameOnlyAgent)
+
+  override def description(data: Document[JValue]): ZeroToMany[String] =
+    extractStrings(unwrap(data) \ "sourceResource" \ "description")
+
+  override def format(data: Document[JValue]): ZeroToMany[String] =
+    extractStrings(unwrap(data) \ "sourceResource" \ "format")
+
+  // TODO: Confirm with team that this is an appropriate mapping
+  override def genre(data: Document[JValue]): ZeroToMany[SkosConcept] =
+    extractStrings(unwrap(data) \ "sourceResource" \ "specType").map(nameOnlyConcept)
+
+  override def identifier(data: Document[JValue]): ZeroToMany[String] =
+    extractStrings(unwrap(data) \ "sourceResource" \ "identifier")
+
+  // TODO: Confirm with team that this is an appropriate mapping
+  // Initial analysis suggests that all languages have iso639_3 values
+  override def language(data: Document[JValue]): ZeroToMany[SkosConcept] =
+    extractStrings(unwrap(data) \ "sourceResource" \ "language" \ "iso639_3").map(nameOnlyConcept)
+
+  override def rights(data: Document[JValue]): AtLeastOne[String] =
+    extractStrings(unwrap(data) \ "sourceResource" \ "rights")
+
+  override def subject(data: Document[JValue]): ZeroToMany[SkosConcept] =
+    extractStrings(unwrap(data)  \ "sourceResource" \ "subject" \ "name").map(nameOnlyConcept)
+
+  override def temporal(data: Document[JValue]): ZeroToMany[EdmTimeSpan] =
+     extractDate(unwrap(data) \ "sourceResource" \ "temporal")
+
+  override def title(data: Document[JValue]): AtLeastOne[String] =
+    extractStrings(unwrap(data) \ "sourceResource" \ "title")
+
   def agent = EdmAgent(
     name = Some("Missouri Hub"),
     uri = Some(URI("http://dp.la/api/contributor/missouri-hub"))
   )
+
+  def extractDate(date: JValue): ZeroToMany[EdmTimeSpan] = {
+    iterify(date).children.map(d =>
+      EdmTimeSpan(
+        begin = extractString(d \ "start"),
+        end = extractString(d \ "end"),
+        originalSourceDate = extractString(d \ "displayDate")
+      ))
+  }
 }

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MoMapping.scala
@@ -29,7 +29,7 @@ class MoMapping extends JsonMapping with JsonExtractor with IdMinter[JValue] wit
   override def dataProvider(data: Document[JValue]): ZeroToMany[EdmAgent] =
     extractStrings(unwrap(data) \ "dataProvider").map(nameOnlyAgent)
 
-  override def dplaUri(data: Document[JValue]): ExactlyOne[URI] = URI(mintDplaId(data))
+  override def dplaUri(data: Document[JValue]): ExactlyOne[URI] = mintDplaItemUri(data)
 
   override def hasView(data: Document[JValue]): ZeroToMany[EdmWebResource] =
     extractStrings(unwrap(data) \ "hasView" \ "@id").map(stringOnlyWebResource)

--- a/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
+++ b/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
@@ -80,10 +80,10 @@ class MdlProfile extends JsonProfile {
   * Missouri
   */
 class MoProfile extends JsonProfile {
-  type Mapping = MdlMapping // TODO: Set correct mapper
+  type Mapping = MoMapping
 
   override def getHarvester: Class[_ <: Harvester] = classOf[MoFileHarvester]
-  override def getMapping = new MdlMapping // TODO: Set correct Mapper
+  override def getMapping = new MoMapping
 }
 
 /**

--- a/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
+++ b/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
@@ -2,7 +2,7 @@ package dpla.ingestion3.profiles
 
 import dpla.ingestion3.harvesters.Harvester
 import dpla.ingestion3.harvesters.api._
-import dpla.ingestion3.harvesters.file.{NaraFileHarvester, P2PFileHarvester, VaFileHarvester}
+import dpla.ingestion3.harvesters.file._
 import dpla.ingestion3.harvesters.oai.OaiHarvester
 import dpla.ingestion3.mappers.providers._
 
@@ -74,6 +74,16 @@ class MdlProfile extends JsonProfile {
 
   override def getHarvester: Class[_ <: Harvester] = classOf[MdlHarvester]
   override def getMapping = new MdlMapping
+}
+
+/**
+  * Missouri
+  */
+class MoProfile extends JsonProfile {
+  type Mapping = MdlMapping // TODO: Set correct mapper
+
+  override def getHarvester: Class[_ <: Harvester] = classOf[MoFileHarvester]
+  override def getMapping = new MdlMapping // TODO: Set correct Mapper
 }
 
 /**

--- a/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
+++ b/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
@@ -50,6 +50,7 @@ object ProviderRegistry {
     "ia" -> Register(profile = new IaProfile),
     "lc" -> Register(profile = new LocProfile),
     "minnesota" -> Register(profile = new MdlProfile),
+    "mo" -> Register(profile = new MoProfile),
     "mt" -> Register(profile = new MtProfile),
     "mwdl" -> Register(profile = new MwdlProfile),
     "nara" -> Register(profile = new NaraProfile),

--- a/src/test/resources/mo.json
+++ b/src/test/resources/mo.json
@@ -17,17 +17,11 @@
       "Photograph of students posing on bench"
     ],
     "description": [
-      "Six students posing on a bench outside of the Education Building (now Hill Hall) with Siceluff Hall in the background, on the campus of Southwest Missouri State Teachers College (now Missouri State University).  Back: dated May 1940.  June Davis (standing).  Joan Ballman, unknown, Mary Lou Burkhart, Mary Lou Moon, Clara Lillian Moon (seated)."
+      "Six students posing on a bench."
     ],
     "subject": [
       {
         "name": "Schools--Missouri--Springfield"
-      },
-      {
-        "name": " Southwest Missouri State Teachers College. Greenwood Laboratory School"
-      },
-      {
-        "name": " Missouri State University"
       },
       {
         "name": " Alternative education"
@@ -36,18 +30,20 @@
         "name": " Springfield (Mo.)"
       },
       {
-        "name": " Students--Missouri--Springfield"
-      },
-      {
         "name": ""
       }
     ],
     "temporal": [
       {
         "displayDate": "1940-05"
+      },
+      {
+        "start": "1991",
+        "end": "1995",
+        "displayDate": "1991/1995"
       }
     ],
-    "rights": "Use of digital images found on this website is permitted for private or personal use only. This material may be protected by U.S. Copyright Law (Title 17, U.S. Code). Copyrighted materials may be used for research, instruction, and private study under the provisions of Fair Use, outlined in section 107 of copyright law. Publication, commercial use, or reproduction of this image or the accompanying data requires prior written permission from the copyright holder. User assumes all responsibility for obtaining the necessary permission to publish (including in digital format) from the copyright holder. For more information on using this image, contact Special Collections and Archives, Missouri State University: http://library.missouristate.edu/archives/generalinfo.htm",
+    "rights": "Use of digital images found on this website is permitted for private or personal use only.",
     "@id": "oai:digitalcollections.missouristate.edu:Hennicke/94",
     "language": [
       {
@@ -64,8 +60,13 @@
     "identifier": [
       "http://digitalcollections.missouristate.edu/cdm/ref/collection/Hennicke/id/94"
     ],
-    "creator": [],
-    "specType": []
+    "creator": [
+      "Leo. Feist",
+      "Herman Darewski Music"
+    ],
+    "specType": [
+      "Photograph/Pictorial Works"
+    ]
   },
   "@id": "missouri--urn:data.mohistory.org:msu_all:oai:digitalcollections.missouristate.edu:Hennicke/94"
 }

--- a/src/test/resources/mo.json
+++ b/src/test/resources/mo.json
@@ -1,0 +1,71 @@
+{
+  "@context": "http://dp.la/api/items/context",
+  "isShownAt": "http://digitalcollections.missouristate.edu/cdm/ref/collection/Hennicke/id/94",
+  "dataProvider": "Missouri State University",
+  "@type": "ore:Aggregation",
+  "hasView": {
+    "@id": "http://digitalcollections.missouristate.edu/cdm/ref/collection/Hennicke/id/94"
+  },
+  "provider": {
+    "@id": "http://dp.la/api/contributor/missouri-hub",
+    "name": "Missouri Hub"
+  },
+  "object": "http://digitalcollections.missouristate.edu/utils/getthumbnail/collection/Hennicke/id/94",
+  "aggregatedCHO": "#sourceResource",
+  "sourceResource": {
+    "title": [
+      "Photograph of students posing on bench"
+    ],
+    "description": [
+      "Six students posing on a bench outside of the Education Building (now Hill Hall) with Siceluff Hall in the background, on the campus of Southwest Missouri State Teachers College (now Missouri State University).  Back: dated May 1940.  June Davis (standing).  Joan Ballman, unknown, Mary Lou Burkhart, Mary Lou Moon, Clara Lillian Moon (seated)."
+    ],
+    "subject": [
+      {
+        "name": "Schools--Missouri--Springfield"
+      },
+      {
+        "name": " Southwest Missouri State Teachers College. Greenwood Laboratory School"
+      },
+      {
+        "name": " Missouri State University"
+      },
+      {
+        "name": " Alternative education"
+      },
+      {
+        "name": " Springfield (Mo.)"
+      },
+      {
+        "name": " Students--Missouri--Springfield"
+      },
+      {
+        "name": ""
+      }
+    ],
+    "temporal": [
+      {
+        "displayDate": "1940-05"
+      }
+    ],
+    "rights": "Use of digital images found on this website is permitted for private or personal use only. This material may be protected by U.S. Copyright Law (Title 17, U.S. Code). Copyrighted materials may be used for research, instruction, and private study under the provisions of Fair Use, outlined in section 107 of copyright law. Publication, commercial use, or reproduction of this image or the accompanying data requires prior written permission from the copyright holder. User assumes all responsibility for obtaining the necessary permission to publish (including in digital format) from the copyright holder. For more information on using this image, contact Special Collections and Archives, Missouri State University: http://library.missouristate.edu/archives/generalinfo.htm",
+    "@id": "oai:digitalcollections.missouristate.edu:Hennicke/94",
+    "language": [
+      {
+        "iso639_3": "eng",
+        "name": "English"
+      }
+    ],
+    "stateLocatedIn": [
+      {
+        "name": "Missouri"
+      }
+    ],
+    "format": "Book",
+    "identifier": [
+      "http://digitalcollections.missouristate.edu/cdm/ref/collection/Hennicke/id/94"
+    ],
+    "creator": [],
+    "specType": []
+  },
+  "@id": "missouri--urn:data.mohistory.org:msu_all:oai:digitalcollections.missouristate.edu:Hennicke/94"
+}

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MoMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MoMappingTest.scala
@@ -2,7 +2,7 @@
 package dpla.ingestion3.mappers.providers
 
 import dpla.ingestion3.mappers.utils.Document
-import dpla.ingestion3.model.{DcmiTypeCollection, _}
+import dpla.ingestion3.model._
 import dpla.ingestion3.utils.FlatFileIO
 import org.json4s.JsonAST.JValue
 import org.json4s.jackson.JsonMethods._
@@ -24,7 +24,7 @@ class MoMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.getProviderName === "mo")
   }
 
-  it should "extract the correct identifier" in {
+  it should "extract the correct providerId" in {
     val expected = "missouri--urn:data.mohistory.org:msu_all:oai:digitalcollections.missouristate.edu:Hennicke/94"
     assert(extractor.getProviderId(json) === expected)
   }
@@ -57,5 +57,69 @@ class MoMappingTest extends FlatSpec with BeforeAndAfter {
   it should "extract the correct object" in {
     val expected = List(stringOnlyWebResource("http://digitalcollections.missouristate.edu/utils/getthumbnail/collection/Hennicke/id/94"))
     assert(extractor.`object`(json) === expected)
+  }
+
+  // creator
+  it should "extract the correct creator" in {
+    val expected = List("Leo. Feist","Herman Darewski Music").map(nameOnlyAgent)
+    assert(extractor.creator(json) === expected)
+  }
+
+  // description
+  it should "extract the correct description" in {
+    val expected = List("Six students posing on a bench.")
+    assert(extractor.description(json) === expected)
+  }
+
+  // format
+  it should "extract the correct format" in {
+    val expected = List("Book")
+    assert(extractor.format(json) === expected)
+  }
+
+  // genre
+  it should "extract the correct genre from specType field" in {
+    val expected = List("Photograph/Pictorial Works").map(nameOnlyConcept)
+    assert(extractor.genre(json) === expected)
+  }
+
+  // identifier
+  it should "extract the correct identifier" in {
+    val expected = List("http://digitalcollections.missouristate.edu/cdm/ref/collection/Hennicke/id/94")
+    assert(extractor.identifier(json) === expected)
+  }
+
+  // language
+  it should "extract the correct language" in {
+    val expected = List("eng").map(nameOnlyConcept)
+    assert(extractor.language(json) === expected)
+  }
+
+  // rights
+  it should "extract the correct rights" in {
+    val expected = List("Use of digital images found on this website is permitted for private or personal use only.")
+    assert(extractor.rights(json) === expected)
+  }
+
+  // subject
+  it should "extract the correct subjects" in {
+    val expected = List("Schools--Missouri--Springfield", " Alternative education", " Springfield (Mo.)", "")
+      .map(nameOnlyConcept)
+    assert(extractor.subject(json) === expected)
+  }
+
+  // temporal
+  it should "extract the correct temporal with display, begin and end" in {
+    val expected = List(
+      EdmTimeSpan(originalSourceDate = Some("1940-05")),
+      EdmTimeSpan(originalSourceDate = Some("1991/1995"), begin = Some("1991"), end = Some("1995"))
+    )
+    assert(extractor.temporal(json) === expected)
+  }
+
+  // title
+  it should "extract the correct title" in {
+    val expected = List("Photograph of students posing on bench")
+    assert(extractor.title(json) === expected)
   }
 }

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MoMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MoMappingTest.scala
@@ -36,10 +36,8 @@ class MoMappingTest extends FlatSpec with BeforeAndAfter {
   }
 
   // dplaUri
-  // TODO: Should this equal a full URI, not just an ID hash?
-  // E.g. "http://dp.la/api/items/ad6472a5e0575718616b5fd54c599095"
   it should "create the correct DPLA URI" in {
-    val expected = new URI("8c630431c601bd29753c93d3d8eea6cf")
+    val expected = new URI("http://dp.la/api/items/8c630431c601bd29753c93d3d8eea6cf")
     assert(extractor.dplaUri(json) === expected)
   }
 

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MoMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MoMappingTest.scala
@@ -1,0 +1,63 @@
+
+package dpla.ingestion3.mappers.providers
+
+import dpla.ingestion3.mappers.utils.Document
+import dpla.ingestion3.model.{DcmiTypeCollection, _}
+import dpla.ingestion3.utils.FlatFileIO
+import org.json4s.JsonAST.JValue
+import org.json4s.jackson.JsonMethods._
+import org.scalatest.{BeforeAndAfter, FlatSpec}
+
+class MoMappingTest extends FlatSpec with BeforeAndAfter {
+
+  val shortName = "mo"
+  val jsonString: String = new FlatFileIO().readFileAsString("/mo.json")
+  val json: Document[JValue] = Document(parse(jsonString))
+  val extractor = new MoMapping
+
+
+  it should "use the provider short name when minting DPLA ids" in {
+    assert(extractor.useProviderName === true)
+  }
+
+  it should "return the correct provider name" in {
+    assert(extractor.getProviderName === "mo")
+  }
+
+  it should "extract the correct identifier" in {
+    val expected = "missouri--urn:data.mohistory.org:msu_all:oai:digitalcollections.missouristate.edu:Hennicke/94"
+    assert(extractor.getProviderId(json) === expected)
+  }
+
+  // dataProvider
+  it should "extract the correct dataProvider" in {
+    val expected = List(nameOnlyAgent("Missouri State University"))
+    assert(extractor.dataProvider(json) === expected)
+  }
+
+  // dplaUri
+  // TODO: Should this equal a full URI, not just an ID hash?
+  // E.g. "http://dp.la/api/items/ad6472a5e0575718616b5fd54c599095"
+  it should "create the correct DPLA URI" in {
+    val expected = new URI("8c630431c601bd29753c93d3d8eea6cf")
+    assert(extractor.dplaUri(json) === expected)
+  }
+
+  // hasView
+  it should "extract the correct hasView" in {
+    val expected = List(stringOnlyWebResource("http://digitalcollections.missouristate.edu/cdm/ref/collection/Hennicke/id/94"))
+    assert(extractor.hasView(json) === expected)
+  }
+
+  // isShownAt
+  it should "extract the correct isShownAt" in {
+    val expected = List(stringOnlyWebResource("http://digitalcollections.missouristate.edu/cdm/ref/collection/Hennicke/id/94"))
+    assert(extractor.isShownAt(json) === expected)
+  }
+
+  // object
+  it should "extract the correct object" in {
+    val expected = List(stringOnlyWebResource("http://digitalcollections.missouristate.edu/utils/getthumbnail/collection/Hennicke/id/94"))
+    assert(extractor.`object`(json) === expected)
+  }
+}


### PR DESCRIPTION
This adds a harvester and mapping for Missouri.  Both have been tested locally against a full MO data dump.  I left a few questions in the mapping `TODO` comments. 

The harvester includes logic to iterate through multiple zip files.  This isn't strictly necessary for MO since its zip contains only one file, but it keeps the MO harvester consistent with other harvesters.