### PR TITLE
add entry to generate all reports

### DIFF
--- a/src/main/scala/dpla/ingestion3/entries/ingest/ReportsEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/ReportsEntry.scala
@@ -1,6 +1,6 @@
 package dpla.ingestion3.entries.ingest
 
-import dpla.ingestion3.confs.CmdArgs
+import dpla.ingestion3.confs.{CmdArgs, Ingestion3Conf, i3Conf}
 import dpla.ingestion3.entries.reports.ReporterMain.executeAllReports
 import dpla.ingestion3.utils.Utils
 import org.apache.spark.SparkConf
@@ -12,7 +12,8 @@ import org.apache.spark.SparkConf
   * Expects three parameters:
   * 1) a path to the mapped/enriched data
   * 2) a path to output the reports
-  * 3) provider short name (e.g. 'mdl', 'cdl', 'harvard')
+  * 3) a path to the application configuration file
+  * 4) provider short name
   *
   * Usage
   * -----
@@ -20,6 +21,7 @@ import org.apache.spark.SparkConf
   * sbt "run-main dpla.ingestion3.ReportsEntry
   *       --input=/input/path/to/enriched/
   *       --output=/output/path/to/reports/
+  *       --conf=/path/to/application.conf
   *       --name=shortName"
   */
 object ReportsEntry {
@@ -32,6 +34,10 @@ object ReportsEntry {
     val dataIn = cmdArgs.getInput()
     val dataOut = cmdArgs.getOutput()
     val shortName = cmdArgs.getProviderName()
+    val confFile = cmdArgs.getConfigFile()
+
+    // Load configuration from file
+    val i3Conf: i3Conf = new Ingestion3Conf(confFile).load()
 
     // Get logger
     val logger = Utils.createLogger("reports", shortName)
@@ -39,7 +45,7 @@ object ReportsEntry {
     val sparkConf =
       new SparkConf()
         .setAppName("reports")
-        .setMaster("local[*]")
+        .setMaster(i3Conf.spark.sparkMaster.getOrElse("local[*]"))
 
     executeAllReports(sparkConf, dataIn, dataOut, shortName, logger)
   }

--- a/src/main/scala/dpla/ingestion3/entries/ingest/ReportsEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/ReportsEntry.scala
@@ -1,0 +1,46 @@
+package dpla.ingestion3.entries.ingest
+
+import dpla.ingestion3.confs.CmdArgs
+import dpla.ingestion3.entries.reports.ReporterMain.executeAllReports
+import dpla.ingestion3.utils.Utils
+import org.apache.spark.SparkConf
+
+/**
+  * Driver for reading DplaMapData records (mapped or enriched) and generating
+  * Reports
+  *
+  * Expects three parameters:
+  * 1) a path to the mapped/enriched data
+  * 2) a path to output the reports
+  * 3) provider short name (e.g. 'mdl', 'cdl', 'harvard')
+  *
+  * Usage
+  * -----
+  * To invoke via sbt:
+  * sbt "run-main dpla.ingestion3.ReportsEntry
+  *       --input=/input/path/to/enriched/
+  *       --output=/output/path/to/reports/
+  *       --name=shortName"
+  */
+object ReportsEntry {
+
+  def main(args: Array[String]): Unit = {
+
+    // Read in command line args.
+    val cmdArgs = new CmdArgs(args)
+
+    val dataIn = cmdArgs.getInput()
+    val dataOut = cmdArgs.getOutput()
+    val shortName = cmdArgs.getProviderName()
+
+    // Get logger
+    val logger = Utils.createLogger("reports", shortName)
+
+    val sparkConf =
+      new SparkConf()
+        .setAppName("reports")
+        .setMaster("local[*]")
+
+    executeAllReports(sparkConf, dataIn, dataOut, shortName, logger)
+  }
+}


### PR DESCRIPTION
This adds an entry to generate all reports (the same set of reports generated in `IngestRemap`).  I used this today to generate MO reports on EC2 with SBT.  The other entry point for reports, `ReporterMain.main`, is optimized to run one report at a time, rather than running all the reports at once.