### PR TITLE
fix spark master setting in spark config

### DIFF
--- a/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
+++ b/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
@@ -49,7 +49,6 @@ class Ingestion3Conf(confFilePath: String, providerName: Option[String] = None) 
         query = getProp(providerConf, "harvest.query")
       ),
       i3Spark(
-        sparkMaster = getProp(providerConf, "spark.master"),
         // FIXME these should be removed
         sparkDriverMemory = getProp(providerConf, "spark.driverMemory"),
         sparkExecutorMemory= getProp(providerConf, "spark.executorMemory")
@@ -97,6 +96,12 @@ class CmdArgs(arguments: Seq[String]) extends ScallopConf(arguments) {
     validate = _.nonEmpty
   )
 
+  val sparkMaster: ScallopOption[String] = opt[String](
+    "sparkMaster",
+    required = false,
+    noshort = true
+  )
+
   /**
     * Gets the configuration file property from command line arguments
     *
@@ -133,6 +138,8 @@ class CmdArgs(arguments: Seq[String]) extends ScallopConf(arguments) {
     .map(_.toString)
     .getOrElse(throw new RuntimeException("No provider name specified."))
 
+  def getSparkMaster(): Option[String] = sparkMaster.toOption
+
   verify()
 }
 
@@ -140,20 +147,20 @@ class CmdArgs(arguments: Seq[String]) extends ScallopConf(arguments) {
   * Classes for defining the application.conf file
   */
 case class Harvest (
-                      // General
-                      endpoint: Option[String] = None,
-                      setlist: Option[String] = None,
-                      blacklist: Option[String] = None,
-                      harvestType: Option[String] = None,
-                      // OAI
-                      verb: Option[String] = None,
-                      metadataPrefix: Option[String] = None,
-                      harvestAllSets: Option[String] = None,
-                      // API
-                      rows: Option[String] = None,
-                      query: Option[String] = None,
-                      apiKey: Option[String] = None
-                    )
+                     // General
+                     endpoint: Option[String] = None,
+                     setlist: Option[String] = None,
+                     blacklist: Option[String] = None,
+                     harvestType: Option[String] = None,
+                     // OAI
+                     verb: Option[String] = None,
+                     metadataPrefix: Option[String] = None,
+                     harvestAllSets: Option[String] = None,
+                     // API
+                     rows: Option[String] = None,
+                     query: Option[String] = None,
+                     apiKey: Option[String] = None
+                   )
 
 case class i3Conf(
                    provider: Option[String] = None,
@@ -163,12 +170,11 @@ case class i3Conf(
                  )
 
 case class i3Twofishes(
-                  hostname: Option[String] = None,
-                  port: Option[String] = None
-                )
+                        hostname: Option[String] = None,
+                        port: Option[String] = None
+                      )
 
 case class i3Spark (
-                     sparkMaster: Option[String] = None,
                      sparkDriverMemory: Option[String] = None,
                      sparkExecutorMemory: Option[String] = None
                    )

--- a/src/main/scala/dpla/ingestion3/entries/ingest/JsonlEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/JsonlEntry.scala
@@ -14,6 +14,8 @@ import org.apache.spark.SparkConf
   * 1) a path to the mapped/enriched data
   * 2) a path to output the jsonl data
   * 3) provider short name (e.g. 'mdl', 'cdl', 'harvard')
+  * 4) spark master (optional parameter that overrides a --master param submitted
+  *    via spark-submit
   *
   * Usage
   * -----
@@ -22,6 +24,7 @@ import org.apache.spark.SparkConf
   *       --input=/input/path/to/enriched/
   *       --output=/output/path/to/jsonl/
   *       --name=shortName"
+  *       --sparkMaster=local[*]
   */
 object JsonlEntry extends JsonlExecutor {
 
@@ -33,11 +36,16 @@ object JsonlEntry extends JsonlExecutor {
     val dataIn = cmdArgs.getInput()
     val dataOut = cmdArgs.getOutput()
     val shortName = cmdArgs.getProviderName()
+    val sparkMaster: Option[String] = cmdArgs.getSparkMaster()
 
-    val sparkConf =
+    val baseConf =
       new SparkConf()
-      .setAppName("jsonl")
-      .setMaster("local[*]")
+        .setAppName(s"JSONL: $shortName")
+
+    val sparkConf = sparkMaster match {
+      case Some(m) => baseConf.setMaster(m)
+      case None => baseConf
+    }
 
     executeJsonl(sparkConf, dataIn, dataOut, shortName, Utils.createLogger("jsonl"))
   }


### PR DESCRIPTION
This makes it possible to set the spark master node from the command line when running a job with either `sbt` or `spark-submit`.  Before, the application code was overwriting any value for `--master` submitted with `spark-submit`.  It was cumbersome to set the master node in the `i3.conf` file b/c it changes with every new cluster.  With this PR, the master node can be set with `sbt` like this:

```
sbt "run-main dpla.ingestion3.entries.ingest.EnrichEntry 
  --output /output/path 
  --conf /path/to/i3.conf 
  --name shortname
  --input /input/path 
  --sparkMaster local[*]"
```

There is no longer a default value for master node b/c there isn't one that is appropriate in both local and cluster modes.