### PR TITLE
tune mapping

### DIFF
--- a/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
@@ -13,7 +13,6 @@ import org.apache.log4j.Logger
 import org.apache.spark.SparkConf
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
-import org.apache.spark.sql.functions.col
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.LongAccumulator
 
@@ -170,7 +169,6 @@ trait MappingExecutor extends Serializable {
     // Transformation
     val messages: DataFrame = MessageProcessor.getAllMessages(results)(spark)
       .persist(StorageLevel.MEMORY_AND_DISK_SER)
-      .repartition(col("id"))
 
     val warnings: DataFrame = MessageProcessor.getWarnings(messages)
     val errors: DataFrame = MessageProcessor.getErrors(messages)

--- a/src/main/scala/dpla/ingestion3/messages/MessageProcessor.scala
+++ b/src/main/scala/dpla/ingestion3/messages/MessageProcessor.scala
@@ -5,7 +5,6 @@ import org.apache.commons.lang.StringUtils
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 
-import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
 
 case class MessageFieldRpt(msg: String, field: String, count: Long)
@@ -43,10 +42,12 @@ object MessageProcessor{
   }
 
   def getErrors(ds: Dataset[Row]): Dataset[Row] =
-    ds.select("message", "level", "field", "id", "value").where(s"level=='${IngestLogLevel.error}'").distinct()
+    ds.select("message", "level", "field", "id", "value")
+      .where(s"level=='${IngestLogLevel.error}'").distinct()
 
   def getWarnings(ds: Dataset[Row]): Dataset[Row] =
-    ds.select("message", "level", "field", "id", "value").where(s"level=='${IngestLogLevel.warn}'").distinct()
+    ds.select("message", "level", "field", "id", "value")
+      .where(s"level=='${IngestLogLevel.warn}'").distinct()
 
   def getDistinctIdCount(df: Dataset[Row]): Long =
     df.select("id").groupBy("id").count().count()


### PR DESCRIPTION
This optimizes mapping performance.

**Persistence**
Persistence has been kept minimal so as not to overload storage capacity, and tested for optimal performance.

**Accumulators and Counts**
I found that accumulators were more efficient than counts when working with very large DataFrames, and they helped minimize the number of data evaluations.  In some cases, the work of accumulators was being duplicated by counts.  In other cases, the same DataFrames were being counted repeatedly.  The `failureCount` accumulator was not being used.

**Repartitioning**
In the mapping, the input harvest data was repartitioned into 1024 segments.  This actually slowed the process once other adjustments had been made.  I repartitioned the `messages` DataFrame b/c it was lumpy.

The changes in `MessageProcessor` are inconsequential, just cleanup I did while reading the code.