### PR TITLE
add format block list to va mapping

### DIFF
--- a/src/test/resources/virginias.xml
+++ b/src/test/resources/virginias.xml
@@ -27,7 +27,6 @@
     <dcterms:spatial>Ontario</dcterms:spatial>
     <dcterms:spatial>Stratford</dcterms:spatial>
     <dcterms:language>eng</dcterms:language>
-    <dcterms:medium>biography</dcterms:medium>
     <dcterms:type>Text</dcterms:type>
     <dcterms:isReferencedBy>http://search.lib.virginia.edu/catalog/uva-lib:1002813/iiif/manifest.json</dcterms:isReferencedBy>
     <dcterms:rights>http://rightsstatements.org/vocab/NoC-US/1.0/</dcterms:rights>

--- a/src/test/scala/dpla/ingestion3/mappers/providers/VirginiasMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/VirginiasMappingTest.scala
@@ -60,6 +60,29 @@ class VirginiasMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.extent(xml) === expected)
   }
 
+  it should "extract the correct format" in {
+    val expected = Seq("print")
+    assert(extractor.format(xml) === expected)
+  }
+
+  it should "extract the correct format and remove values in that are stop words ('image')" in {
+    val xml =
+      <mdRecord>
+        <dcterms:medium>image</dcterms:medium>
+        <dcterms:medium>photograph</dcterms:medium>
+      </mdRecord>
+    val expected = Seq("photograph")
+    assert(extractor.format(Document(xml)) === expected)
+  }
+
+  it should "extract no format when values are in format blacklist" in {
+    val xml =
+      <mdRecord>
+        <dcterms:medium>image/jpeg</dcterms:medium>
+      </mdRecord>
+    assert(extractor.format(Document(xml)) === Seq())
+  }
+
   it should "extract the correct identifier" in {
     val expected = Seq("uva-lib:1002813")
     assert(extractor.identifier(xml) === expected)


### PR DESCRIPTION
This adds a format filter in the Digital Virginias mapping.