### PR TITLE
Tune jsonl

### DIFF
--- a/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
+++ b/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
@@ -102,6 +102,12 @@ class CmdArgs(arguments: Seq[String]) extends ScallopConf(arguments) {
     noshort = true
   )
 
+  val mergeOutput: ScallopOption[String] = opt[String](
+    "mergeOutput",
+    required = false,
+    noshort = true
+  )
+
   /**
     * Gets the configuration file property from command line arguments
     *
@@ -139,6 +145,8 @@ class CmdArgs(arguments: Seq[String]) extends ScallopConf(arguments) {
     .getOrElse(throw new RuntimeException("No provider name specified."))
 
   def getSparkMaster(): Option[String] = sparkMaster.toOption
+
+  def getMergeOutput(): Boolean = mergeOutput.toOption.getOrElse("false").toBoolean
 
   verify()
 }

--- a/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
@@ -16,7 +16,9 @@ import org.apache.spark.SparkConf
   *   3)  --conf    A path to the application configuration file
   *   4)  --name    Provider short name
   *   5)  --sparkMaster optional parameter that overrides a --master param submitted
-  * *                   via spark-submit (e.g. local[*])
+  *                     via spark-submit (e.g. local[*])
+  *   6) --mergeOutput boolean indicating whether or not output should be
+  *                    consolidated into a single file (defaults to false)
   */
 object IngestRemap extends MappingExecutor
   with JsonlExecutor
@@ -32,6 +34,7 @@ object IngestRemap extends MappingExecutor
     val shortName = cmdArgs.getProviderName()
     val input = cmdArgs.getInput()
     val sparkMaster: Option[String] = cmdArgs.getSparkMaster()
+    val mergeOutput: Boolean = cmdArgs.getMergeOutput
 
     // Get logger
     val logger = Utils.createLogger("ingest", shortName)
@@ -73,7 +76,7 @@ object IngestRemap extends MappingExecutor
       executeEnrichment(sparkConf, mapDataOut, baseDataOut, shortName, logger, conf)
 
     // Json-l
-    executeJsonl(sparkConf, enrichDataOut, baseDataOut, shortName, logger)
+    executeJsonl(sparkConf, enrichDataOut, baseDataOut, shortName, mergeOutput, logger)
 
     // Reports
     executeAllReports(sparkConf, enrichDataOut, baseDataOut, shortName, logger)

--- a/src/main/scala/dpla/ingestion3/entries/ingest/JsonlEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/JsonlEntry.scala
@@ -16,6 +16,8 @@ import org.apache.spark.SparkConf
   * 3) provider short name (e.g. 'mdl', 'cdl', 'harvard')
   * 4) spark master (optional parameter that overrides a --master param submitted
   *    via spark-submit
+  * 5) boolean indicating whether or not output should be consolidated into
+  *    a single file (defaults to false)
   *
   * Usage
   * -----
@@ -25,6 +27,7 @@ import org.apache.spark.SparkConf
   *       --output=/output/path/to/jsonl/
   *       --name=shortName"
   *       --sparkMaster=local[*]
+  *       --mergeOutput=true
   */
 object JsonlEntry extends JsonlExecutor {
 
@@ -37,6 +40,7 @@ object JsonlEntry extends JsonlExecutor {
     val dataOut = cmdArgs.getOutput()
     val shortName = cmdArgs.getProviderName()
     val sparkMaster: Option[String] = cmdArgs.getSparkMaster()
+    val mergeOutput: Boolean = cmdArgs.getMergeOutput()
 
     val baseConf =
       new SparkConf()
@@ -47,6 +51,8 @@ object JsonlEntry extends JsonlExecutor {
       case None => baseConf
     }
 
-    executeJsonl(sparkConf, dataIn, dataOut, shortName, Utils.createLogger("jsonl"))
+    val logger = Utils.createLogger("jsonl")
+
+    executeJsonl(sparkConf, dataIn, dataOut, shortName, mergeOutput, logger)
   }
 }

--- a/src/main/scala/dpla/ingestion3/executors/JsonlExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/JsonlExecutor.scala
@@ -60,6 +60,7 @@ trait JsonlExecutor extends Serializable {
     // data will be written out inside a JSON object (e.g. {'value': <doc>}) which is
     // invalid for our use
     mergeOutput match {
+      // repartition is notably faster than coalesce on moderately large datasets
       case true => indexRecords.repartition(1).write.text(outputPath)
       case false => indexRecords.write.text(outputPath)
     }

--- a/src/main/scala/dpla/ingestion3/executors/JsonlExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/JsonlExecutor.scala
@@ -2,11 +2,13 @@ package dpla.ingestion3.executors
 
 import java.time.LocalDateTime
 
+import com.databricks.spark.avro._
 import dpla.ingestion3.model.{ModelConverter, jsonlRecord}
 import dpla.ingestion3.dataStorage.OutputHelper
 import org.apache.log4j.Logger
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{Dataset, SparkSession}
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
+import org.apache.spark.storage.StorageLevel
 
 import scala.util.{Failure, Success}
 
@@ -22,6 +24,7 @@ trait JsonlExecutor extends Serializable {
                    dataIn: String,
                    dataOut: String,
                    shortName: String,
+                   mergeOutput: Boolean,
                    logger: Logger): String = {
 
     // This start time is used for documentation and output file naming.
@@ -42,30 +45,33 @@ trait JsonlExecutor extends Serializable {
     import spark.implicits._
     val sc = spark.sparkContext
 
-    val enrichedRows =
-      spark.read
-        .format("com.databricks.spark.avro")
-        .load(dataIn)
+    val enrichedRows: DataFrame = spark.read.avro(dataIn)
 
     val indexRecords: Dataset[String] = enrichedRows.map(
       row => {
         val record = ModelConverter.toModel(row)
         jsonlRecord(record)
       }
-    )
+    ).persist(StorageLevel.MEMORY_AND_DISK_SER)
+
+    val indexCount = indexRecords.count
 
     // This should always write out as #text() because if we use #json() then the
     // data will be written out inside a JSON object (e.g. {'value': <doc>}) which is
     // invalid for our use
-    indexRecords.coalesce(1).write.text(outputPath)
+    mergeOutput match {
+      case true => indexRecords.repartition(1).write.text(outputPath)
+      case false => indexRecords.write.text(outputPath)
+    }
 
     // Create and write manifest.
 
     val manifestOpts: Map[String, String] = Map(
       "Activity" -> "JSON-L",
       "Provider" -> shortName,
-      "Record count" -> indexRecords.count.toString,
-      "Input" -> dataIn
+      "Record count" -> indexCount.toString,
+      "Input" -> dataIn,
+      "Partition output" -> (!mergeOutput).toString
     )
 
     outputHelper.writeManifest(manifestOpts) match {


### PR DESCRIPTION
This optimizes performance in the jsonl task.  It introduces a new parameter, `mergeOutput` to indicate whether or not to consolidate the output into a single file.