### PR TITLE
remove mergeOuput option from jsonl

### DIFF
--- a/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
+++ b/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
@@ -102,12 +102,6 @@ class CmdArgs(arguments: Seq[String]) extends ScallopConf(arguments) {
     noshort = true
   )
 
-  val mergeOutput: ScallopOption[String] = opt[String](
-    "mergeOutput",
-    required = false,
-    noshort = true
-  )
-
   /**
     * Gets the configuration file property from command line arguments
     *
@@ -145,8 +139,6 @@ class CmdArgs(arguments: Seq[String]) extends ScallopConf(arguments) {
     .getOrElse(throw new RuntimeException("No provider name specified."))
 
   def getSparkMaster(): Option[String] = sparkMaster.toOption
-
-  def getMergeOutput(): Boolean = mergeOutput.toOption.getOrElse("false").toBoolean
 
   verify()
 }

--- a/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
@@ -17,8 +17,6 @@ import org.apache.spark.SparkConf
   *   4)  --name    Provider short name
   *   5)  --sparkMaster optional parameter that overrides a --master param submitted
   *                     via spark-submit (e.g. local[*])
-  *   6) --mergeOutput boolean indicating whether or not output should be
-  *                    consolidated into a single file (defaults to false)
   */
 object IngestRemap extends MappingExecutor
   with JsonlExecutor
@@ -34,7 +32,6 @@ object IngestRemap extends MappingExecutor
     val shortName = cmdArgs.getProviderName()
     val input = cmdArgs.getInput()
     val sparkMaster: Option[String] = cmdArgs.getSparkMaster()
-    val mergeOutput: Boolean = cmdArgs.getMergeOutput
 
     // Get logger
     val logger = Utils.createLogger("ingest", shortName)
@@ -76,7 +73,7 @@ object IngestRemap extends MappingExecutor
       executeEnrichment(sparkConf, mapDataOut, baseDataOut, shortName, logger, conf)
 
     // Json-l
-    executeJsonl(sparkConf, enrichDataOut, baseDataOut, shortName, mergeOutput, logger)
+    executeJsonl(sparkConf, enrichDataOut, baseDataOut, shortName, logger)
 
     // Reports
     executeAllReports(sparkConf, enrichDataOut, baseDataOut, shortName, logger)

--- a/src/main/scala/dpla/ingestion3/entries/ingest/JsonlEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/JsonlEntry.scala
@@ -16,8 +16,6 @@ import org.apache.spark.SparkConf
   * 3) provider short name (e.g. 'mdl', 'cdl', 'harvard')
   * 4) spark master (optional parameter that overrides a --master param submitted
   *    via spark-submit
-  * 5) boolean indicating whether or not output should be consolidated into
-  *    a single file (defaults to false)
   *
   * Usage
   * -----
@@ -27,7 +25,6 @@ import org.apache.spark.SparkConf
   *       --output=/output/path/to/jsonl/
   *       --name=shortName"
   *       --sparkMaster=local[*]
-  *       --mergeOutput=true
   */
 object JsonlEntry extends JsonlExecutor {
 
@@ -40,7 +37,6 @@ object JsonlEntry extends JsonlExecutor {
     val dataOut = cmdArgs.getOutput()
     val shortName = cmdArgs.getProviderName()
     val sparkMaster: Option[String] = cmdArgs.getSparkMaster()
-    val mergeOutput: Boolean = cmdArgs.getMergeOutput()
 
     val baseConf =
       new SparkConf()
@@ -53,6 +49,6 @@ object JsonlEntry extends JsonlExecutor {
 
     val logger = Utils.createLogger("jsonl")
 
-    executeJsonl(sparkConf, dataIn, dataOut, shortName, mergeOutput, logger)
+    executeJsonl(sparkConf, dataIn, dataOut, shortName, logger)
   }
 }

--- a/src/main/scala/dpla/ingestion3/executors/JsonlExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/JsonlExecutor.scala
@@ -16,15 +16,16 @@ trait JsonlExecutor extends Serializable {
 
   /**
     * Generate JSON-L files from AVRO file
-    * @param sparkConf Spark configuration
-    * @param dataIn Data to transform into JSON-L
-    * @param dataOut Location to save JSON-L
+    * @param sparkConf  Spark configuration
+    * @param dataIn     Data to transform into JSON-L
+    * @param dataOut    Location to save JSON-L
+    * @param shortName  Provider shortname
+    * @param logger     Logger object
     */
   def executeJsonl(sparkConf: SparkConf,
                    dataIn: String,
                    dataOut: String,
                    shortName: String,
-                   mergeOutput: Boolean,
                    logger: Logger): String = {
 
     // This start time is used for documentation and output file naming.
@@ -59,11 +60,7 @@ trait JsonlExecutor extends Serializable {
     // This should always write out as #text() because if we use #json() then the
     // data will be written out inside a JSON object (e.g. {'value': <doc>}) which is
     // invalid for our use
-    mergeOutput match {
-      // repartition is notably faster than coalesce on moderately large datasets
-      case true => indexRecords.repartition(1).write.text(outputPath)
-      case false => indexRecords.write.text(outputPath)
-    }
+    indexRecords.write.text(outputPath)
 
     // Create and write manifest.
 
@@ -71,8 +68,7 @@ trait JsonlExecutor extends Serializable {
       "Activity" -> "JSON-L",
       "Provider" -> shortName,
       "Record count" -> indexCount.toString,
-      "Input" -> dataIn,
-      "Partition output" -> (!mergeOutput).toString
+      "Input" -> dataIn
     )
 
     outputHelper.writeManifest(manifestOpts) match {


### PR DESCRIPTION
Remove option to write jsonl as a single file (as opposed to partitioned files).  There is no use case for it.