### PR TITLE
IN-666 CDL edmRights

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/Harvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/Harvester.scala
@@ -69,6 +69,7 @@ abstract class LocalHarvester(
   def getAvroWriter: DataFileWriter[GenericRecord] = avroWriter
 
   override def cleanUp(): Unit = {
+    avroWriter.flush()
     avroWriter.close()
     // Delete temporary output directory and files.
     Utils.deleteRecursively(new File(tmpOutStr))

--- a/src/main/scala/dpla/ingestion3/mappers/providers/CdlMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/CdlMapping.scala
@@ -30,6 +30,10 @@ class CdlMapping() extends Mapping[JValue] with IdMinter[JValue] with JsonExtrac
 
   override def dataProvider(data: Document[JValue]): ZeroToMany[EdmAgent] = Seq(nameOnlyAgent(getDataProvider(data)))
 
+  override def edmRights(data: Document[JValue]): ZeroToMany[URI] =
+    extractStrings("rights_uri")(data)
+    .map(URI)
+
   override def originalRecord(data: Document[JValue]): ExactlyOne[String] = Utils.formatJson(data)
 
   override def preview(data: Document[JValue]): ZeroToMany[EdmWebResource] = thumbnail(data)


### PR DESCRIPTION
Adds mapping for edmRIghts and fixes a bug where all records were not getting written out by calling flush() before closing avroWriter.