### PR TITLE
Initial CT mapping work

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
@@ -175,7 +175,12 @@ class XmlMapper extends Mapper[NodeSeq, XmlMapping] {
   override def map(document: Document[NodeSeq], mapping: Mapping[NodeSeq]): OreAggregation = {
 
     implicit val msgCollector: MessageCollector[IngestMessage] = new MessageCollector[IngestMessage]
-    val providerId = (mapping.sidecar(document) \\ "prehashId").extractOrElse[String]("Unknown")
+    val providerId = Try {
+      (mapping.sidecar(document) \\ "prehashId")
+    } match {
+      case Success(s) => s.extractOrElse[String]("Unknown")
+      case Failure(f) => s"Fatal error - Missing required ID $document"
+    }
 
     // Field validation
     val validatedDataProvider = validateDataProvider(mapping.dataProvider(document), providerId)

--- a/src/main/scala/dpla/ingestion3/mappers/providers/CtMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/CtMapping.scala
@@ -23,10 +23,10 @@ class CtMapping extends Mapping[NodeSeq] with XmlExtractor with IdMinter[NodeSeq
 
   override def getProviderName(): String = "ct"
 
-  // TODO: What field in CT records should we use for persistent ID?
   override def getProviderId(implicit data: Document[NodeSeq]): String =
-    extractString(data \ "identifier")
-      .getOrElse(throw new RuntimeException(s"No ID for record $data"))
+  isShownAtStrings(data)
+    .headOption
+    .getOrElse(throw new RuntimeException(s"No ID for record $data"))
 
   //  mods/titleInfo @type=alternative> children combined as follows (with a single space between):
   //  <nonSort> <title> <subTitle>  <partName> <partNumber>
@@ -142,9 +142,7 @@ class CtMapping extends Mapping[NodeSeq] with XmlExtractor with IdMinter[NodeSeq
 
   // OreAggregation
   override def dplaUri(data: Document[NodeSeq]): URI = mintDplaItemUri(data)
-
-  // FIXME There is no mapping for the required field dataProvider in the MAPv5 doc
-  // FIXME guessing this might be a valid mapping
+  
   // <note type="ownership">
   override def dataProvider(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
     (data \ "note").map(n => getByAttribute(n, "type", "ownership"))
@@ -173,7 +171,6 @@ class CtMapping extends Mapping[NodeSeq] with XmlExtractor with IdMinter[NodeSeq
     ("prehashId" -> buildProviderBaseId()(data)) ~ ("dplaId" -> mintDplaId(data))
 
   // Helper method
-  // TODO: Is this the correct URI?
   def agent = EdmAgent(
     name = Some("Connecticut Digital Library"),
     uri = Some(URI("http://dp.la/api/contributor/ct"))

--- a/src/main/scala/dpla/ingestion3/mappers/providers/CtMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/CtMapping.scala
@@ -1,0 +1,197 @@
+package dpla.ingestion3.mappers.providers
+
+import dpla.ingestion3.enrichments.normalizations.filters.{DigitalSurrogateBlockList, FormatTypeValuesBlockList}
+import dpla.ingestion3.mappers.utils.{Document, IdMinter, Mapping, XmlExtractor}
+import dpla.ingestion3.messages.IngestMessageTemplates
+import dpla.ingestion3.model.DplaMapData.{AtLeastOne, ExactlyOne, ZeroToMany}
+import dpla.ingestion3.model._
+import dpla.ingestion3.utils.Utils
+import org.json4s.JValue
+import org.json4s.JsonDSL._
+
+import scala.xml._
+
+class CtMapping extends Mapping[NodeSeq] with XmlExtractor with IdMinter[NodeSeq]
+  with IngestMessageTemplates {
+
+  val formatBlockList: Set[String] =
+    DigitalSurrogateBlockList.termList ++
+      FormatTypeValuesBlockList.termList
+
+  // ID minting functions
+  override def useProviderName(): Boolean = false
+
+  override def getProviderName(): String = "ct"
+
+  // TODO: What field in CT records should we use for persistent ID?
+  override def getProviderId(implicit data: Document[NodeSeq]): String =
+    extractString(data \ "identifier")
+      .getOrElse(throw new RuntimeException(s"No ID for record $data"))
+
+  //  mods/titleInfo @type=alternative> children combined as follows (with a single space between):
+  //  <nonSort> <title> <subTitle>  <partName> <partNumber>
+  override def alternateTitle(data: Document[NodeSeq]): ZeroToMany[String] = {
+    val altTitles = (data \ "titleInfo").flatMap(node => getByAttribute(node, "type", "alternative"))
+    constructTitles(altTitles)
+  }
+
+  // mods/name/namePart when metadata/mods/name/role/roleTerm equals anything OTHER THAN "creator" (case insentive)
+  override def contributor(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
+    (data \ "name")
+      .filterNot(node => (node \ "role" \ "roleTerm").text.equalsIgnoreCase("creator"))
+      .flatMap(n => extractStrings(n \ "namePart"))
+      .map(nameOnlyAgent)
+
+  // metadata/mods/name/namePart when metadata/mods/name/role/roleTerm equals anything OTHER THAN "creator" (case insentive)
+  override def creator(data: Document[NodeSeq]): Seq[EdmAgent] =
+    (data \ "name")
+      .filter(node => (node \ "role" \ "roleTerm").text.equalsIgnoreCase("creator"))
+      .flatMap(n => extractStrings(n \ "namePart"))
+      .map(nameOnlyAgent)
+
+  // metadata/mods/originInfo/dateIssued OR
+  // metadata/mods/originInfo @point=start + metadata/mods/originInfo @point=end
+  // (some records do not have the @point, but other indicate a start and end in separate fields)
+  override def date(data: Document[NodeSeq]): Seq[EdmTimeSpan] = {
+    val dateIssued = extractStrings(data \ "originInfo" \ "dateIssued")
+      .map(stringOnlyTimeSpan)
+
+    val startEndDates = (data \ "originInfo")
+      .filter(n => (n \@ "start").nonEmpty && (n \@ "end").nonEmpty)
+      .map(n => s"${n \@ "start"}-${n \@ "end"}")
+      .map(stringOnlyTimeSpan)
+
+    if(dateIssued.nonEmpty)
+      dateIssued
+    else
+      startEndDates
+  }
+
+  // metadata/mods/abstract
+  override def description(data: Document[NodeSeq]): Seq[String] =
+    extractStrings(data \ "abstract")
+
+  // metadata/mods/physicalDescription/extent + value of the @unit attribute
+  override def extent(data: Document[NodeSeq]): ZeroToMany[String] =
+    (data \ "physicalDescription" \ "extent").map(node => {
+      s"${node.text} ${node \@ "unit"}".trim
+    })
+
+  // metadata/mods/genre
+  // metadata/mods/physicalDescription/form
+  // metadata/mods/subject/genre
+  override def format(data: Document[NodeSeq]): Seq[String] =
+    extractStrings(data \ "genre") ++
+      extractStrings(data \ "physicalDescription" \ "form") ++
+      extractStrings(data \ "subject" \ "genre")
+
+  // metadata/mods/identifier
+  override def identifier(data: Document[NodeSeq]): Seq[String] =
+    extractStrings(data \ "identifier")
+
+  // metadata/mods/language/languageTerm
+  override def language(data: Document[NodeSeq]): Seq[SkosConcept] =
+    extractStrings(data \ "language" \ "languageTerm")
+      .map(nameOnlyConcept)
+
+  // metadata/mods/subject/cartographics/coordinates AND metadata/mods/subject/geographic
+  override def place(data: Document[NodeSeq]): Seq[DplaPlace] =
+    (extractStrings(data \ "subject" \ "cartographics" \ "coordinates") ++ // FIXME Shouldn't coordinates get mapped differently?
+      extractStrings(data \ "subject" \ "geographic"))
+      .map(nameOnlyPlace)
+
+  // metadata/mods/originInfo/publisher
+  override def publisher(data: Document[NodeSeq]): Seq[EdmAgent] =
+    extractStrings(data \ "originInfo" \ "publisher")
+      .map(nameOnlyAgent)
+
+  // metadata/mods/accessCondition
+  override def rights(data: Document[NodeSeq]): AtLeastOne[String] =
+    extractStrings(data \ "accessCondition")
+
+  // ALL CHILDREN of metadata/mods/subject/topic|name|titleInfo
+  // TODO Confirm this mappping, unsure what 'all children' means here
+  override def subject(data: Document[NodeSeq]): Seq[SkosConcept] =
+    (extractStrings(data \ "subject" \ "topic") ++
+      extractStrings(data \ "subject" \ "name") ++
+      extractStrings(data \ "subject" \ "titleInfo"))
+        .map(nameOnlyConcept)
+
+  // metadata/mods/subject/temporal
+  override def temporal(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] =
+    extractStrings(data \ "subject" \ "temporal")
+      .map(stringOnlyTimeSpan)
+
+  // <titleInfo> children combined as follows (with a single space between):
+  // <nonSort> <title> <subTitle>  <partName> <partNumber>
+  // EXCEPT WHEN titleInfo @type = alternative"
+  override def title(data: Document[NodeSeq]): Seq[String] = {
+    val altTitles = (data \ "titleInfo").filterNot(node => filterAttribute(node, "type", "alternative"))
+    constructTitles(altTitles)
+  }
+
+  // metadata/mods/genre
+  // metadata/mods/physicalDescription/form
+  // metadata/mods/subject/genre
+  // metadata/mods/typeofresource
+  override def `type`(data: Document[NodeSeq]): Seq[String] =
+    extractStrings(data \ "genre") ++
+      extractStrings(data \ "physicalDescription" \ "form") ++
+      extractStrings(data \ "subject" \ "genre") ++
+      extractStrings(data \ "typeOfResource")
+
+  // OreAggregation
+  override def dplaUri(data: Document[NodeSeq]): URI = mintDplaItemUri(data)
+
+  // FIXME There is no mapping for the required field dataProvider in the MAPv5 doc
+  // FIXME guessing this might be a valid mapping
+  // <note type="ownership">
+  override def dataProvider(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
+    (data \ "note").map(n => getByAttribute(n, "type", "ownership"))
+      .flatMap(extractStrings)
+      .map(nameOnlyAgent)
+
+  // <identifier type=”hdl>
+  override def isShownAt(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
+    isShownAtStrings(data)
+      .map(stringOnlyWebResource)
+
+  override def originalRecord(data: Document[NodeSeq]): ExactlyOne[String] = Utils.formatXml(data)
+
+  // Take the <identifier type=”hdl”> element, (e.g. http://hdl.handle.net/11134/20004:20073175)
+  // Change http://hdl.handle.net/11134 into https://ctdigitalarchive.org/islandora/object
+  // and then add the PID (20004:20073175) followed by /datastream/TN.
+  override def preview(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
+    isShownAtStrings(data)
+      .map(isa => isa.replaceAllLiterally("http://hdl.handle.net/11134/", "https://ctdigitalarchive.org/islandora/object/"))
+      .map(preview => preview + "/datastream/TN")
+      .map(stringOnlyWebResource)
+
+  override def provider(data: Document[NodeSeq]): ExactlyOne[EdmAgent] = agent
+
+  override def sidecar(data: Document[NodeSeq]): JValue =
+    ("prehashId" -> buildProviderBaseId()(data)) ~ ("dplaId" -> mintDplaId(data))
+
+  // Helper method
+  // TODO: Is this the correct URI?
+  def agent = EdmAgent(
+    name = Some("Connecticut Digital Library"),
+    uri = Some(URI("http://dp.la/api/contributor/ct"))
+  )
+
+  // Help functions
+  def constructTitles(nodeSeq: NodeSeq): ZeroToMany[String] = {
+    nodeSeq.map (node => {
+      val nonSort = extractString( node \ "nonSort")
+      val title = extractString( node \ "title")
+      val subTitle = extractString( node \ "subTitle")
+      val partName = extractString( node \ "partName")
+      val partNumber = extractString( node \ "partNumber")
+      List(nonSort, title, subTitle, partName, partNumber).flatten.mkString(" ")
+    })
+  }
+
+  def isShownAtStrings(data: Document[NodeSeq]): Seq[String] =
+    (data \ "identifier").map(node => getByAttribute(node, "type", "hdl"))
+      .flatMap(extractStrings)
+}

--- a/src/main/scala/dpla/ingestion3/mappers/utils/Extractor.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/Extractor.scala
@@ -86,6 +86,10 @@ trait XmlExtractor extends Extractor[NodeSeq] {
   def getByAttribute(e: Elem, att: String, value: String): NodeSeq = {
     e \\ "_" filter { n => filterAttribute(n, att, value) }
   }
+
+  def getByAttribute(e: NodeSeq, att: String, value: String): NodeSeq = {
+    getByAttribute(e.asInstanceOf[Elem], att, value)
+  }
 }
 
 /**

--- a/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
+++ b/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
@@ -17,6 +17,16 @@ class CdlProfile extends JsonProfile {
 }
 
 /**
+  * Connecticut Digital Library
+  */
+class CtProfile extends XmlProfile {
+  type Mapping = CtMapping
+
+  override def getHarvester = classOf[VaFileHarvester] // CT reuses the VA zipped XML file harvester
+  override def getMapping = new CtMapping
+}
+
+/**
   * District Digital
   */
 class DcProfile extends XmlProfile {

--- a/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
+++ b/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
@@ -44,6 +44,7 @@ object ProviderRegistry {
     // FIXME Register is redundant here and should be removed
 
     "cdl" -> Register(profile = new CdlProfile),
+    "ct" -> Register(profile = new CtProfile),
     "dc" -> Register(profile = new DcProfile),
     "esdn" -> Register(profile = new EsdnProfile),
     "getty" -> Register(profile = new GettyProfile),

--- a/src/test/resources/ct.xml
+++ b/src/test/resources/ct.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mods xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" version="3.5" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+    <titleInfo>
+        <title>Anschluss</title>
+    </titleInfo>
+    <name authority="fast" type="personal" valueURI="http://id.worldcat.org/fast/255922">
+        <namePart>Dodd, Thomas J. (Thomas Joseph), 1907-1971</namePart>
+        <role>
+            <roleTerm authority="marcrelator" type="text">Collector</roleTerm>
+        </role>
+    </name>
+    <typeOfResource>text</typeOfResource>
+    <genre authority="aat" valueURI="300027590">legal documents</genre>
+    <genre authority="aat" valueURI="300027425">administrative records</genre>
+    <originInfo>
+        <dateIssued encoding="w3cdtf" keyDate="yes">1938</dateIssued>
+        <issuance>monographic</issuance>
+    </originInfo>
+    <physicalDescription>
+        <internetMediaType>image/jp2</internetMediaType>
+        <digitalOrigin>reformatted digital</digitalOrigin>
+        <note type="physical description">translated German documents</note>
+    </physicalDescription>
+    <abstract>The Common Plan or Conspiracy (Boxes 282-284) refers to Count I of the IMT indictment, namely conspiracy to commit unlawful aggression. This subseries consists of trial briefs and German documents used by the Allied prosecution team. The papers are arranged thematically as the conspiracy charge had economic, political, and military dimensions. This subseries includes detailed German war plans for invading such nations as Poland, France, Russia, Norway, and Yugoslavia. The minutes of high-level economic meetings on the mobilization for war also highlight these files. Includes: English and German language version of Document no. 2307-PS. Annotated.</abstract>
+    <note type="Preferred Citation">
+        Anschluss
+        , 282:7223, Thomas J. Dodd Papers. Archives &amp; Special Collections at the Thomas J. Dodd Research Center, University of Connecticut Libraries.</note>
+    <subject>
+        <topic authority="fast" valueURI="http://id.worldcat.org/fast/1709901">Nuremberg War Crime Trials (Germany : 1946-1949)</topic>
+        <topic authority="fast" valueURI="http://id.worldcat.org/fast/1156316">Trials (Conspiracy)</topic>
+        <topic authority="fast" valueURI="http://id.worldcat.org/fast/1033761">National socialism</topic>
+        <topic authority="fast" valueURI="http://id.worldcat.org/fast/809991">Anschluss movement (1918-1938)</topic>
+        <geographic>
+            <continent>North America</continent>
+        </geographic>
+        <geographic authority="tgn" valueURI="7000084">Germany (nation)</geographic>
+        <topic valueURI="http://id.worldcat.org/fast/815827">Aggression (International law)</topic>
+        <geographic authority="tgn" valueURI="1000062">Austria (nation)</geographic>
+        <topic authority="fast" valueURI="http://id.worldcat.org/fast/1170357">War--Planning</topic>
+        <topic authority="fast" valueURI="http://id.worldcat.org/fast/1020840">Militarism--Economic aspects</topic>
+        <name type="corporate" authority="fast" valueURI="http://id.worldcat.org/fast/1642697">
+            <namePart>Germany. Reichsregierung</namePart>
+        </name>
+    </subject>
+    <identifier type="local">MSS19940065:282:7223</identifier>
+    <accessCondition type="restrictions on access">The collection is open and available for research.</accessCondition>
+    <accessCondition type="use and reproduction" displayLabel="Intellectual Rights Statement">This work is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License, CC BY-NC.</accessCondition>
+    <recordInfo>
+        <recordCreationDate encoding="w3cdtf">2011-12-16T15:09-0500</recordCreationDate>
+        <recordOrigin>This finding aid was produced using the Archivists' Toolkit</recordOrigin>
+        <languageOfCataloging>
+            <languageTerm type="code" authority="iso639-3">eng</languageTerm>
+        </languageOfCataloging>
+        <descriptionStandard>Describing Archives: A Content Standard</descriptionStandard>
+        <recordContentSource>University of Connecticut Libraries</recordContentSource>
+        <languageOfCataloging>
+            <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
+        </languageOfCataloging>
+    </recordInfo>
+    <identifier type="hdl">http://hdl.handle.net/11134/20002:1323</identifier>
+    <note type="ownership">Archives &amp; Special Collections at the Thomas J. Dodd Research Center, University of Connecticut Libraries</note>
+    <name type="corporate" authority="naf" valueURI="http://id.loc.gov/authorities/names/n50069897">
+        <namePart>International Military Tribunal</namePart>
+        <role>
+            <roleTerm type="text" authority="marcrelator">Contributor</roleTerm>
+        </role>
+    </name>
+    <name type="corporate" authority="naf" valueURI="http://id.loc.gov/authorities/names/n50069897">
+        <namePart>Creator</namePart>
+        <role>
+            <roleTerm type="text" authority="marcrelator">Creator</roleTerm>
+        </role>
+    </name>
+    <titleInfo type="alternative">
+        <title>Translation of Document 2307-PS</title>
+    </titleInfo>
+
+    <titleInfo type="alternative">
+        <nonSort>nonsort</nonSort>
+        <title>title</title>
+        <subTitle>subtitle</subTitle>
+        <partName>partname</partName>
+        <partNumber>partnumber</partNumber>
+    </titleInfo>
+
+    <titleInfo type="alternative">
+        <title>Law concerning the reunion of Austria with the German Reich of 13 March 1938</title>
+    </titleInfo>
+    <name type="corporate" authority="naf" valueURI="http://id.loc.gov/authorities/names/no98077600">
+        <namePart>Germany. Laws, etc. (Reichsgesetzblatt)</namePart>
+        <role>
+            <roleTerm type="text" authority="marcrelator">Contributor</roleTerm>
+        </role>
+    </name>
+    <genre authority="aat" valueURI="300027894">laws (documents)</genre>
+    <genre authority="aat" valueURI="300027389">translations (documents)</genre>
+    <note type="source note">Thomas J. Dodd Papers</note>
+    <note type="source identifier">MSS 1994.0065</note>
+</mods>

--- a/src/test/scala/dpla/ingestion3/mappers/providers/CtMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/CtMappingTest.scala
@@ -1,0 +1,93 @@
+package dpla.ingestion3.mappers.providers
+
+import dpla.ingestion3.mappers.utils.Document
+import dpla.ingestion3.messages.{IngestMessage, MessageCollector}
+import dpla.ingestion3.utils.FlatFileIO
+import org.scalatest.{BeforeAndAfter, FlatSpec}
+import dpla.ingestion3.model._
+import scala.xml.{NodeSeq, XML}
+
+class CtMappingTest extends FlatSpec with BeforeAndAfter {
+
+  implicit val msgCollector: MessageCollector[IngestMessage] = new MessageCollector[IngestMessage]
+  val shortName = "ct"
+  val xmlString: String = new FlatFileIO().readFileAsString("/ct.xml")
+  val xml: Document[NodeSeq] = Document(XML.loadString(xmlString))
+  val extractor = new CtMapping
+
+  it should "not use the provider shortname in minting IDs "in
+    assert(!extractor.useProviderName())
+
+  it should "extract the correct alternate titles " in {
+    val expected_1 = "Law concerning the reunion of Austria with the German Reich of 13 March 1938"
+    val expected_2 = "Translation of Document 2307-PS"
+    val expected_3 = "nonsort title subtitle partname partnumber"
+
+    assert(extractor.alternateTitle(xml).contains(expected_1))
+    assert(extractor.alternateTitle(xml).contains(expected_2))
+    assert(extractor.alternateTitle(xml).contains(expected_3))
+  }
+
+  it should "extract the correct contributors" in {
+    val expected = Seq(
+      "Dodd, Thomas J. (Thomas Joseph), 1907-1971",
+      "International Military Tribunal",
+      "Germany. Laws, etc. (Reichsgesetzblatt)"
+    ).map(nameOnlyAgent)
+
+    assert(extractor.contributor(xml) === expected)
+  }
+
+  it should "extract the correct creators" in {
+    val expected = Seq("Creator").map(nameOnlyAgent)
+    assert(extractor.creator(xml) === expected)
+  }
+
+  it should "extract the correct dates" in {
+    val expected = Seq("1938").map(stringOnlyTimeSpan)
+    assert(extractor.date(xml) === expected)
+  }
+
+  it should "extract and construct the correct dates from start and end attributes" in {
+    val xml = <mods><originInfo start="1938" end="1939"></originInfo></mods>
+    val expected = Seq("1938-1939").map(stringOnlyTimeSpan)
+    assert(extractor.date(Document(xml)) === expected)
+  }
+
+  it should "extract the correct description" in {
+    val expected = Seq("The Common Plan or Conspiracy (Boxes 282-284) refers to Count I of the IMT indictment, namely conspiracy to commit unlawful aggression. This subseries consists of trial briefs and German documents used by the Allied prosecution team. The papers are arranged thematically as the conspiracy charge had economic, political, and military dimensions. This subseries includes detailed German war plans for invading such nations as Poland, France, Russia, Norway, and Yugoslavia. The minutes of high-level economic meetings on the mobilization for war also highlight these files. Includes: English and German language version of Document no. 2307-PS. Annotated.")
+    assert(extractor.description(xml) === expected)
+  }
+
+  it should "extract the correct extent values" in {
+    val xml = <mods><physicalDescription><extent unit="unitVal">extent</extent></physicalDescription></mods>
+    val expected = Seq("extent unitVal")
+    assert(extractor.extent(Document(xml)) === expected)
+  }
+
+  it should "extract the correct extent values if only unit given" in {
+    val xml = <mods><physicalDescription><extent unit="unitVal"></extent></physicalDescription></mods>
+    val expected = Seq("unitVal")
+    assert(extractor.extent(Document(xml)) === expected)
+  }
+
+  it should "extract the correct extent values if none given" in {
+    val expected = Seq()
+    assert(extractor.extent(xml) === expected)
+  }
+
+  it should "extract the correct titles" in {
+    val expected = Seq("Anschluss")
+    assert(extractor.title(xml) === expected)
+  }
+
+  it should "extract the correct isShownAt" in {
+    val expected = List(stringOnlyWebResource("http://hdl.handle.net/11134/20002:1323"))
+    assert(extractor.isShownAt(xml) === expected)
+  }
+
+  it should "extract the correct preview" in {
+    val expected = List(stringOnlyWebResource("https://ctdigitalarchive.org/islandora/object/20002:1323/datastream/TN"))
+    assert(extractor.preview(xml) === expected)
+  }
+}


### PR DESCRIPTION
- CT mapping for CQA review 
- Fixes bug where entire mapping jobs would fail because a record was missing the base provider id field [what is hashed to mint DPLA ids]. The exception thrown in specific provider mapping is caught within the `Try` block when mapping the entire record but isn't caught when getting the providerId to record validation messages. 