### PR TITLE
Fix nara preview url

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/NaraMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/NaraMapping.scala
@@ -3,7 +3,6 @@ package dpla.ingestion3.mappers.providers
 import dpla.ingestion3.enrichments.TypeEnrichment
 import dpla.ingestion3.mappers.rdf.DCMIType
 import dpla.ingestion3.mappers.utils._
-import dpla.ingestion3.messages.{IngestMessage, MessageCollector}
 import dpla.ingestion3.model.DplaMapData._
 import dpla.ingestion3.model._
 import dpla.ingestion3.utils.Utils
@@ -11,6 +10,7 @@ import org.eclipse.rdf4j.model.IRI
 import org.json4s.JsonAST
 import org.json4s.JsonDSL._
 
+import scala.util.{Try, Success, Failure}
 import scala.xml.{Node, NodeSeq}
 
 
@@ -270,12 +270,28 @@ class NaraMapping extends Mapping[NodeSeq] with XmlExtractor with IdMinter[NodeS
       }
   }
 
-  private def extractPreview(data: Document[NodeSeq]) = for {
+  private def extractPreview(data: Document[NodeSeq]): Seq[EdmWebResource] = for {
     digitalObject <- data \ "digitalObjectArray" \ "digitalObject"
-    accessFileName = (digitalObject \ "accessFilename").text
+    accessFileName = (digitalObject \ "accessFilename").text.trim
     termName = (digitalObject \ "objectType" \ "termName").text.toLowerCase
-    if termName.contains("image") && (termName.contains("jpg") || termName.contains("gif"))
-  } yield stringOnlyWebResource(accessFileName.trim)
+
+    badPrefix = "https://opaexport-conv.s3.amazonaws.com/"
+    url = accessFileName.startsWith(badPrefix) match {
+      case false => accessFileName
+      case true => {
+        Try { getProviderId(data) } match {
+          case Success(id) => "https://catalog.archives.gov/OpaAPI/media/" +
+            id + "/content/" + accessFileName.stripPrefix(badPrefix)
+          case Failure(_) => null
+        }
+      }
+    }
+
+    if termName.contains("image") &&
+      (termName.contains("jpg") || termName.contains("gif")) &&
+      url != null
+
+  } yield stringOnlyWebResource(url)
 
   private def extractPublisher(data: NodeSeq): Seq[String] = {
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/NaraMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/NaraMapping.scala
@@ -48,6 +48,9 @@ class NaraMapping extends Mapping[NodeSeq] with XmlExtractor with IdMinter[NodeS
   override def isShownAt(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
     Seq(uriOnlyWebResource(itemUri(data)))
 
+  override def `object`(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
+    extractPreview(data)
+
   override def originalRecord(data: Document[NodeSeq]): ExactlyOne[String] =
     Utils.formatXml(data)
 

--- a/src/test/scala/dpla/ingestion3/mappers/providers/NaraMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/NaraMappingTest.scala
@@ -24,6 +24,10 @@ class NaraMappingTest extends FlatSpec with BeforeAndAfter {
   it should "pass through the short name to ID minting" in
     assert(extractor.getProviderName() === shortName)
 
+  it should "extract provider ID" in {
+    assert(extractor.getProviderId(xml) === "2132862")
+  }
+
   it should "construct the correct item uri" in
     assert(extractor.itemUri(xml) === itemUri)
 
@@ -142,6 +146,10 @@ class NaraMappingTest extends FlatSpec with BeforeAndAfter {
   //todo should we eliminate these default thumbnails?
   it should "find the item previews" in {
     assert(extractor.preview(xml) === Seq(uriOnlyWebResource(URI("https://nara-media-001.s3.amazonaws.com/arcmedia/great-lakes/001/517805_a.jpg"))))
+  }
+
+  it should "correct preview URLs that begin with https://opaexport-conv.s3.amazonaws.com/" in {
+
   }
 
   it should "extract dataProvider from records with fileUnitPhysicalOccurrence" in {

--- a/src/test/scala/dpla/ingestion3/mappers/providers/NaraMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/NaraMappingTest.scala
@@ -148,8 +148,52 @@ class NaraMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.preview(xml) === Seq(uriOnlyWebResource(URI("https://nara-media-001.s3.amazonaws.com/arcmedia/great-lakes/001/517805_a.jpg"))))
   }
 
-  it should "correct preview URLs that begin with https://opaexport-conv.s3.amazonaws.com/" in {
+  it should "not map previews with invalid term names" in {
+    val xml = <item>
+      <naId>51046777</naId>
+      <digitalObjectArray>
+        <digitalObject>
+          <accessFilename>https://nara-media-001.s3.amazonaws.com/arcmedia/great-lakes/001/517805_a.jpg</accessFilename>
+          <objectType>
+            <termName>NOT VALID</termName>
+          </objectType>
+        </digitalObject>
+      </digitalObjectArray>
+    </item>
 
+    assert(extractor.preview(Document(xml)) === Seq())
+  }
+
+  it should "correct preview URLs that begin with https://opaexport-conv.s3.amazonaws.com/" in {
+    val xml = <item>
+      <naId>51046777</naId>
+      <digitalObjectArray>
+        <digitalObject>
+          <accessFilename>https://opaexport-conv.s3.amazonaws.com/TB149/Civil_War_Service_Index/M545-CW_ServRecdIndexUnion_MI/M545_0042/images/2514.jpg</accessFilename>
+          <objectType>
+            <termName>Image (JPG)</termName>
+          </objectType>
+        </digitalObject>
+      </digitalObjectArray>
+    </item>
+
+    val correctUrl = "https://catalog.archives.gov/OpaAPI/media/51046777/content/TB149/Civil_War_Service_Index/M545-CW_ServRecdIndexUnion_MI/M545_0042/images/2514.jpg"
+    assert(extractor.preview(Document(xml)) === Seq(uriOnlyWebResource(URI(correctUrl))))
+  }
+
+  it should "not map previews that depend on providerIds if providerId is missing" in {
+    val xml = <item>
+      <digitalObjectArray>
+        <digitalObject>
+          <accessFilename>https://opaexport-conv.s3.amazonaws.com/TB149/Civil_War_Service_Index/M545-CW_ServRecdIndexUnion_MI/M545_0042/images/2514.jpg</accessFilename>
+          <objectType>
+            <termName>Image (JPG)</termName>
+          </objectType>
+        </digitalObject>
+      </digitalObjectArray>
+    </item>
+
+    assert(extractor.preview(Document(xml)) === Seq())
   }
 
   it should "extract dataProvider from records with fileUnitPhysicalOccurrence" in {


### PR DESCRIPTION
This fixes an incorrect URL prefix for some item previews.  I tested this by running a new mapping.  I confirmed that in the old mapping 6108168 records had the bad prefix, while in a mapping with these changes, there were 6108168 records with the new prefix and 0 with the bad prefix.  I also tested a few of the new URLs and confirmed that they resolve to images.