### PR TITLE
Fixup language config files and Missouri mapping

### DIFF
--- a/src/main/resources/languages/iso639-3.csv
+++ b/src/main/resources/languages/iso639-3.csv
@@ -1710,7 +1710,6 @@ dnd,Daonda
 dne,Ndendeule
 dng,Dungan
 dni,Lower Grand Valley Dani
-dnj,Dan
 dnk,Dengka
 dnn,Dzùùngoo
 dnr,Danaru

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MoMapping.scala
@@ -38,7 +38,7 @@ class MoMapping extends JsonMapping with JsonExtractor with IdMinter[JValue] wit
   override def isShownAt(data: Document[JValue]): ZeroToMany[EdmWebResource] =
     extractStrings(unwrap(data) \ "isShownAt").map(stringOnlyWebResource)
 
-  override def `object`(data: Document[JValue]): ZeroToMany[EdmWebResource] =
+  override def preview(data: Document[JValue]): ZeroToMany[EdmWebResource] =
     extractStrings(unwrap(data) \ "object").map(stringOnlyWebResource)
 
   override def originalRecord(data: Document[JValue]): ExactlyOne[String] =
@@ -70,7 +70,8 @@ class MoMapping extends JsonMapping with JsonExtractor with IdMinter[JValue] wit
   // TODO: Confirm with team that this is an appropriate mapping
   // Initial analysis suggests that all languages have iso639_3 values
   override def language(data: Document[JValue]): ZeroToMany[SkosConcept] =
-    extractStrings(unwrap(data) \ "sourceResource" \ "language" \ "iso639_3").map(nameOnlyConcept)
+    extractStrings(unwrap(data) \ "sourceResource" \ "language" \ "iso639_3")
+      .map(nameOnlyConcept)
 
   override def rights(data: Document[JValue]): AtLeastOne[String] =
     extractStrings(unwrap(data) \ "sourceResource" \ "rights")
@@ -78,7 +79,7 @@ class MoMapping extends JsonMapping with JsonExtractor with IdMinter[JValue] wit
   override def subject(data: Document[JValue]): ZeroToMany[SkosConcept] =
     extractStrings(unwrap(data)  \ "sourceResource" \ "subject" \ "name").map(nameOnlyConcept)
 
-  override def temporal(data: Document[JValue]): ZeroToMany[EdmTimeSpan] =
+  override def date(data: Document[JValue]): ZeroToMany[EdmTimeSpan] =
      extractDate(unwrap(data) \ "sourceResource" \ "temporal")
 
   override def title(data: Document[JValue]): AtLeastOne[String] =

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MoMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MoMappingTest.scala
@@ -54,9 +54,9 @@ class MoMappingTest extends FlatSpec with BeforeAndAfter {
   }
 
   // object
-  it should "extract the correct object" in {
+  it should "extract the correct preview" in {
     val expected = List(stringOnlyWebResource("http://digitalcollections.missouristate.edu/utils/getthumbnail/collection/Hennicke/id/94"))
-    assert(extractor.`object`(json) === expected)
+    assert(extractor.preview(json) === expected)
   }
 
   // creator
@@ -109,12 +109,12 @@ class MoMappingTest extends FlatSpec with BeforeAndAfter {
   }
 
   // temporal
-  it should "extract the correct temporal with display, begin and end" in {
+  it should "extract the correct date with display, begin and end" in {
     val expected = List(
       EdmTimeSpan(originalSourceDate = Some("1940-05")),
       EdmTimeSpan(originalSourceDate = Some("1991/1995"), begin = Some("1991"), end = Some("1995"))
     )
-    assert(extractor.temporal(json) === expected)
+    assert(extractor.date(json) === expected)
   }
 
   // title


### PR DESCRIPTION
- Removes `dje/Dan` language from iso-639 configuration file [Danish <> Dan]
- Fixup mapping for Missouri so that date values are mapped to to `date` instead of `temporal` and thumbnails map to `preview` and not `object`