### PR TITLE
Duplicate original id error message

### DIFF
--- a/src/main/resources/avro/MAPRecord.avsc
+++ b/src/main/resources/avro/MAPRecord.avsc
@@ -1080,11 +1080,10 @@
         "string"
       ]
     },
-  {
-    "name":
-    "messages",
-    "type": {
-      "name": "MessagesIngestMessageArray",
+    {
+      "name": "messages",
+      "type": {
+        "name": "MessagesIngestMessageArray",
         "type": "array",
         "items": {
           "name": "MessagesIngestMessage",

--- a/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
@@ -108,6 +108,7 @@ trait MappingExecutor extends Serializable with IngestMessageTemplates {
     val updatedResults: DataFrame = mappingResults
       .withColumnRenamed("messages", "oldMessages")
       .withColumn("messages", addDupOrigIdMsgUdf(col("originalId"), col("oldMessages")))
+      .drop("oldMessages")
 
     // Removes records from updatedResults that have at least one IngestMessage
     // with a level of IngestLogLevel.error

--- a/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
@@ -161,8 +161,7 @@ trait MappingExecutor extends Serializable with IngestMessageTemplates {
       startTime,
       endTime,
       attemptedCount,
-      validRecordCount,
-      duplicateOriginalIds.count)(spark)
+      validRecordCount)(spark)
 
     // Format the summary report and write it log file
     val mappingSummary = MappingSummary.getSummary(finalReport)
@@ -196,8 +195,7 @@ trait MappingExecutor extends Serializable with IngestMessageTemplates {
                        startTime: Long,
                        endTime: Long,
                        attemptedCount: Long,
-                       validRecordCount: Long,
-                       duplicateOriginalIds: Long)(implicit spark: SparkSession): MappingSummaryData = {
+                       validRecordCount: Long)(implicit spark: SparkSession): MappingSummaryData = {
     import spark.implicits._
 
     // these three Encoders allow us to tell Spark/Catalyst how to encode our data in a DataSet.
@@ -256,8 +254,7 @@ trait MappingExecutor extends Serializable with IngestMessageTemplates {
       recordErrorCount,
       recordWarnCount,
       errorMsgDetails,
-      warnMsgDetails,
-      duplicateOriginalIds
+      warnMsgDetails
     )
 
     MappingSummaryData(shortName, operationSummary, timeSummary, messageSummary)

--- a/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
@@ -105,28 +105,28 @@ trait MappingExecutor extends Serializable with IngestMessageTemplates {
 
     val addDupOrigIdMsgUdf: UserDefinedFunction = udf(addDupOrigIdMsg)
 
-    val orderedColumnNames: Array[String] = Array(
-      "dplaUri", // 0
-      "sourceResource", // 1
-      "dataProvider", // 2
-      "originalRecord", // 3
-      "hasView", // 4
-      "intermediateProvider", // 5
-      "isShownAt", // 6
-      "object", // 7
-      "preview", // 8
-      "provider", // 9
-      "edmRights", // 10
-      "sidecar", // 11
-      "messages", // 12
-      "originalId" // 13
-    )
+//    val orderedColumnNames: Array[String] = Array(
+//      "dplaUri", // 0
+//      "sourceResource", // 1
+//      "dataProvider", // 2
+//      "originalRecord", // 3
+//      "hasView", // 4
+//      "intermediateProvider", // 5
+//      "isShownAt", // 6
+//      "object", // 7
+//      "preview", // 8
+//      "provider", // 9
+//      "edmRights", // 10
+//      "sidecar", // 11
+//      "messages", // 12
+//      "originalId" // 13
+//    )
 
     val updatedResults: DataFrame = mappingResults
       .withColumnRenamed("messages", "oldMessages")
       .withColumn("messages", addDupOrigIdMsgUdf(col("originalId"), col("oldMessages")))
       .drop("oldMessages")
-      .select(orderedColumnNames.head, orderedColumnNames.tail: _*) // put columns in correct serialization order
+//      .select(orderedColumnNames.head, orderedColumnNames.tail: _*) // put columns in correct serialization order
 
     // Removes records from updatedResults that have at least one IngestMessage
     // with a level of IngestLogLevel.error

--- a/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
@@ -105,10 +105,28 @@ trait MappingExecutor extends Serializable with IngestMessageTemplates {
 
     val addDupOrigIdMsgUdf: UserDefinedFunction = udf(addDupOrigIdMsg)
 
+    val orderedColumnNames: Array[String] = Array(
+      "dplaUri", // 0
+      "sourceResource", // 1
+      "dataProvider", // 2
+      "originalRecord", // 3
+      "hasView", // 4
+      "intermediateProvider", // 5
+      "isShownAt", // 6
+      "object", // 7
+      "preview", // 8
+      "provider", // 9
+      "edmRights", // 10
+      "sidecar", // 11
+      "messages", // 12
+      "originalId" // 13
+    )
+
     val updatedResults: DataFrame = mappingResults
       .withColumnRenamed("messages", "oldMessages")
       .withColumn("messages", addDupOrigIdMsgUdf(col("originalId"), col("oldMessages")))
       .drop("oldMessages")
+      .select(orderedColumnNames.head, orderedColumnNames.tail: _*) // put columns in correct serialization order
 
     // Removes records from updatedResults that have at least one IngestMessage
     // with a level of IngestLogLevel.error

--- a/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
@@ -108,7 +108,6 @@ trait MappingExecutor extends Serializable with IngestMessageTemplates {
     val updatedResults: DataFrame = mappingResults
       .withColumnRenamed("messages", "oldMessages")
       .withColumn("messages", addDupOrigIdMsgUdf(col("originalId"), col("oldMessages")))
-      .persist(StorageLevel.MEMORY_AND_DISK_SER)
 
     // Removes records from updatedResults that have at least one IngestMessage
     // with a level of IngestLogLevel.error

--- a/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
@@ -108,6 +108,7 @@ trait MappingExecutor extends Serializable with IngestMessageTemplates {
     val updatedResults: DataFrame = mappingResults
       .withColumnRenamed("messages", "oldMessages")
       .withColumn("messages", addDupOrigIdMsgUdf(col("originalId"), col("oldMessages")))
+      .persist(StorageLevel.MEMORY_AND_DISK_SER)
 
     // Removes records from updatedResults that have at least one IngestMessage
     // with a level of IngestLogLevel.error

--- a/src/main/scala/dpla/ingestion3/messages/IngestMessageTemplates.scala
+++ b/src/main/scala/dpla/ingestion3/messages/IngestMessageTemplates.scala
@@ -56,6 +56,15 @@ trait IngestMessageTemplates {
       value = "both rights and edmRights are defined"
     )
 
+  def duplicateOriginalId(id: String): IngestMessage =
+    IngestMessage(
+      message = "Duplicate",
+      level = IngestLogLevel.warn,
+      id = id,
+      field = "originalId",
+      value = "at least one other record shares this originalId"
+    )
+
   def enrichedValue(id: String, field: String, origValue: String, enrichValue: String): IngestMessage =
     IngestMessage(
       message = s"Enriched value",

--- a/src/main/scala/dpla/ingestion3/messages/MappingSummary.scala
+++ b/src/main/scala/dpla/ingestion3/messages/MappingSummary.scala
@@ -23,7 +23,6 @@ object MappingSummary {
     val warnRecordsStr = Utils.formatNumber(data.messageSummary.warningRecordCount)
     val errorRecordsStr = Utils.formatNumber(data.messageSummary.errorRecordCount)
     val failedCountStr = Utils.formatNumber(data.operationSummary.recordsFailed)
-    val duplicateOriginalIdsStr = Utils.formatNumber(data.messageSummary.duplicateOriginalIds)
 
     val logFileMsg =
       if(data.operationSummary.logFiles.nonEmpty) data.operationSummary.logFiles.mkString("\n")
@@ -53,7 +52,6 @@ object MappingSummary {
         |Records
         |${ReportFormattingUtils.centerPad("- Errors", errorRecordsStr)}
         |${ReportFormattingUtils.centerPad("- Warnings", warnRecordsStr)}
-        |${ReportFormattingUtils.centerPad("- Duplicate original ID", duplicateOriginalIdsStr)}
         |
         |${if(data.messageSummary.warningCount > 0 || data.messageSummary.errorCount > 0)
             ReportFormattingUtils.center("Message Summary") else ""}

--- a/src/main/scala/dpla/ingestion3/model/ModelConverter.scala
+++ b/src/main/scala/dpla/ingestion3/model/ModelConverter.scala
@@ -20,76 +20,76 @@ import scala.util.{Failure, Success, Try}
 object ModelConverter {
 
   def toModel(row: Row): OreAggregation = OreAggregation(
-    dplaUri = requiredUri(row, 0),
-    sourceResource = toSourceResource(row.getStruct(1)),
-    dataProvider = toEdmAgent(row.getStruct(2)),
-    originalRecord = requiredString(row, 3),
-    hasView = toRows(row, 4).map(toEdmWebResource),
-    intermediateProvider = Option(row.getStruct(5)).map(toEdmAgent),
-    isShownAt = toEdmWebResource(row.getStruct(6)),
-    `object` = toOptionEdmWebResource(row.getStruct(7)),
-    preview = toOptionEdmWebResource(row.getStruct(8)),
-    provider = toEdmAgent(row.getStruct(9)),
-    edmRights = optionalUri(row, 10),
-    sidecar = optionalJValue(row, 11),
-    messages = toMulti(row, 12, toIngestMessage),
-    originalId = potentiallyMissingStringField(row, 13).getOrElse("MISSING")
+    dplaUri = requiredUri(row, "dplaUri"),
+    sourceResource = toSourceResource(row.getAs[Row]("SourceResource")),
+    dataProvider = toEdmAgent(row.getAs[Row]("dataProvider")),
+    originalRecord = requiredString(row, "originalRecord"),
+    hasView = toRows(row, "hasView").map(toEdmWebResource),
+    intermediateProvider = Option(row.getAs[Row]("intermediateProvider")).map(toEdmAgent),
+    isShownAt = toEdmWebResource(row.getAs[Row]("isShownAt")),
+    `object` = toOptionEdmWebResource(row.getAs[Row]("object")),
+    preview = toOptionEdmWebResource(row.getAs[Row]("preview")),
+    provider = toEdmAgent(row.getAs[Row]("provider")),
+    edmRights = optionalUri(row, "edmRights"),
+    sidecar = optionalJValue(row, "sidecar"),
+    messages = toMulti(row, "messages", toIngestMessage),
+    originalId = potentiallyMissingStringField(row, "originalId").getOrElse("MISSING")
   )
 
   private[model] def toSourceResource(row: Row): DplaSourceResource = DplaSourceResource(
-    alternateTitle = stringSeq(row, 0),
-    collection = toMulti(row, 1, toDcmiTypeCollection),
-    contributor = toMulti(row, 2, toEdmAgent),
-    creator = toMulti(row, 3, toEdmAgent),
-    date = toMulti(row, 4, toEdmTimeSpan),
-    description = stringSeq(row, 5),
-    extent = stringSeq(row, 6),
-    format = stringSeq(row, 7),
-    genre = toMulti(row, 8, toSkosConcept),
-    identifier = stringSeq(row, 9),
-    language = toMulti(row, 10, toSkosConcept),
-    place = toMulti(row, 11, toDplaPlace),
-    publisher = toMulti(row, 12, toEdmAgent),
-    relation = toMulti(row, 13, toLiteralOrUri),
-    replacedBy = stringSeq(row, 14),
-    replaces = stringSeq(row, 15),
-    rights = stringSeq(row, 16),
-    rightsHolder = toMulti(row, 17, toEdmAgent),
-    subject = toMulti(row, 18, toSkosConcept),
-    temporal = toMulti(row, 19, toEdmTimeSpan),
-    title = stringSeq(row, 20),
-    `type` = stringSeq(row, 21)
+    alternateTitle = stringSeq(row, "alternateTitle"),
+    collection = toMulti(row, "collection", toDcmiTypeCollection),
+    contributor = toMulti(row, "contributor", toEdmAgent),
+    creator = toMulti(row, "creator", toEdmAgent),
+    date = toMulti(row, "date", toEdmTimeSpan),
+    description = stringSeq(row, "description"),
+    extent = stringSeq(row, "extent"),
+    format = stringSeq(row, "format"),
+    genre = toMulti(row, "genre", toSkosConcept),
+    identifier = stringSeq(row, "identifier"),
+    language = toMulti(row, "language", toSkosConcept),
+    place = toMulti(row, "place", toDplaPlace),
+    publisher = toMulti(row, "publisher", toEdmAgent),
+    relation = toMulti(row, "relation", toLiteralOrUri),
+    replacedBy = stringSeq(row, "replacedBy"),
+    replaces = stringSeq(row, "replaces"),
+    rights = stringSeq(row, "rights"),
+    rightsHolder = toMulti(row, "rightsHolder", toEdmAgent),
+    subject = toMulti(row, "subject", toSkosConcept),
+    temporal = toMulti(row, "temporal", toEdmTimeSpan),
+    title = stringSeq(row, "title"),
+    `type` = stringSeq(row, "type")
   )
 
   private[model] def toDplaPlace(row: Row): DplaPlace = DplaPlace(
-    name = optionalString(row, 0),
-    city = optionalString(row, 1),
-    county = optionalString(row, 2),
-    region = optionalString(row, 3),
-    state = optionalString(row, 4),
-    country = optionalString(row, 5),
-    coordinates = optionalString(row, 6)
+    name = optionalString(row, "name"),
+    city = optionalString(row, "city"),
+    county = optionalString(row, "county"),
+    region = optionalString(row, "region"),
+    state = optionalString(row, "state"),
+    country = optionalString(row, "country"),
+    coordinates = optionalString(row, "coordinates")
   )
 
   private[model] def toSkosConcept(row: Row): SkosConcept = SkosConcept(
-    concept = optionalString(row, 0),
-    providedLabel = optionalString(row, 1),
-    note = optionalString(row, 2),
-    scheme = optionalUri(row, 3),
-    exactMatch = uriSeq(row, 4),
-    closeMatch = uriSeq(row, 5)
+    concept = optionalString(row, "concept"),
+    providedLabel = optionalString(row, "providedLabel"),
+    note = optionalString(row, "note"),
+    scheme = optionalUri(row, "scheme"),
+    exactMatch = uriSeq(row, "exactMatch"),
+    closeMatch = uriSeq(row, "closeMatch")
   )
 
   private[model] def toEdmTimeSpan(row: Row): EdmTimeSpan = EdmTimeSpan(
-    originalSourceDate = optionalString(row, 0),
-    prefLabel = optionalString(row, 1),
-    begin = optionalString(row, 2),
-    end = optionalString(row, 3)
+    originalSourceDate = optionalString(row, "originalSourceDate"),
+    prefLabel = optionalString(row, "prefLabel"),
+    begin = optionalString(row, "begin"),
+    end = optionalString(row, "end")
   )
 
   private[model] def toDcmiTypeCollection(row: Row): DcmiTypeCollection = DcmiTypeCollection(
-    title = optionalString(row, 0),
-    description = optionalString(row, 1)
+    title = optionalString(row, "title"),
+    description = optionalString(row, "description")
   )
 
   private[model] def toOptionEdmWebResource(row: Row): Option[EdmWebResource] =
@@ -99,11 +99,11 @@ object ModelConverter {
     }
 
   private[model] def toEdmWebResource(row: Row): EdmWebResource = EdmWebResource(
-    uri = requiredUri(row, 0),
-    fileFormat = stringSeq(row, 1),
-    dcRights = stringSeq(row, 2),
-    edmRights = optionalString(row, 3),
-    isReferencedBy = optionalUri(row, 4)
+    uri = requiredUri(row, "uri"),
+    fileFormat = stringSeq(row, "fileFormat"),
+    dcRights = stringSeq(row, "dcRights"),
+    edmRights = optionalString(row, "edmRights"),
+    isReferencedBy = optionalUri(row, "isReferencedBy")
   )
 
   private[model] def toLiteralOrUri(row: Row): LiteralOrUri =
@@ -111,64 +111,64 @@ object ModelConverter {
     else Left(row.getString(0))
 
   private[model] def toEdmAgent(row: Row): EdmAgent = EdmAgent(
-    uri = optionalUri(row, 0),
-    name = optionalString(row, 1),
-    providedLabel = optionalString(row, 2),
-    note = optionalString(row, 3),
-    scheme = optionalUri(row, 4),
-    exactMatch = uriSeq(row, 5),
-    closeMatch = uriSeq(row, 6)
+    uri = optionalUri(row, "uri"),
+    name = optionalString(row, "name"),
+    providedLabel = optionalString(row, "providedLabel"),
+    note = optionalString(row, "note"),
+    scheme = optionalUri(row, "scheme"),
+    exactMatch = uriSeq(row, "exactMatch"),
+    closeMatch = uriSeq(row, "closeMatch")
   )
 
   private[model] def toIngestMessage(row: Row): IngestMessage = IngestMessage(
-    message = requiredString(row, 0),
-    level = requiredString(row, 1),
-    id = requiredString(row, 2),
-    field = requiredString(row, 3),
-    value = requiredString(row, 4),
-    enrichedValue = requiredString(row, 5) // TODO Fixup and add back
+    message = requiredString(row, "message"),
+    level = requiredString(row, "level"),
+    id = requiredString(row, "id"),
+    field = requiredString(row, "field"),
+    value = requiredString(row, "value"),
+    enrichedValue = requiredString(row, "enrichedValue") // TODO Fixup and add back
   )
 
-  private[model] def toMulti[T](row: Row, fieldPosition: Integer, f: (Row) => T): Seq[T] = {
-    toRows(row, fieldPosition).map(f)
+  private[model] def toMulti[T](row: Row, fieldName: String, f: (Row) => T): Seq[T] = {
+    toRows(row, fieldName).map(f)
   }
 
-  private[model] def toRows(row: Row, fieldPosition: Integer): Seq[Row] = {
-    row.getSeq[Row](fieldPosition)
+  private[model] def toRows(row: Row, fieldName: String): Seq[Row] = {
+    row.getAs[Seq[Row]](fieldName)
   }
 
-  private[model] def requiredUri(row: Row, fieldPosition: Integer): URI =
-    optionalUri(row, fieldPosition)
-      .getOrElse(throw new RuntimeException(s"Couldn't parse URI in row $row, field position $fieldPosition"))
+  private[model] def requiredUri(row: Row, fieldName: String): URI =
+    optionalUri(row, fieldName)
+      .getOrElse(throw new RuntimeException(s"Couldn't parse URI in row $row, field name $fieldName"))
 
-  private[model] def optionalUri(row: Row, fieldPosition: Integer): Option[URI] = {
-    if (row.length > fieldPosition)
-      Option(row.getString(fieldPosition)).map(URI)
-    else
-      None
+  private[model] def optionalUri(row: Row, fieldName: String): Option[URI] = {
+    Try{ Option(row.getAs[String](fieldName)).map(URI) } match {
+      case Success(uriOpt) => uriOpt
+      case Failure(_) => None
+    }
   }
 
-  private[model] def requiredString(row: Row, fieldPosition: Integer): String =
-    optionalString(row, fieldPosition)
-      .getOrElse(throw new RuntimeException(s"Couldn't retrieve string in row $row, field position $fieldPosition"))
+  private[model] def requiredString(row: Row, fieldName: String): String =
+    optionalString(row, fieldName)
+      .getOrElse(throw new RuntimeException(s"Couldn't retrieve string in row $row, field name $fieldName"))
 
-  private[model] def optionalString(row: Row, fieldPosition: Integer): Option[String] =
-    Option(row.getString(fieldPosition))
+  private[model] def optionalString(row: Row, fieldName: String): Option[String] =
+    Option(row.getAs[String](fieldName))
 
-  private[model] def stringSeq(row: Row, fieldPosition: Integer): Seq[String] =
-    row.getSeq[String](fieldPosition)
+  private[model] def stringSeq(row: Row, fieldName: String): Seq[String] =
+    row.getAs[Seq[String]](fieldName)
 
-  private[model] def uriSeq(row: Row, fieldPosition: Integer): Seq[URI] =
-    stringSeq(row, fieldPosition).map(new URI(_))
+  private[model] def uriSeq(row: Row, fieldName: String): Seq[URI] =
+    stringSeq(row, fieldName).map(new URI(_))
 
-  private[model] def optionalJValue(row: Row, fieldPosition: Integer): JValue =
-    Try { parse(row.getString(fieldPosition)) } match {
+  private[model] def optionalJValue(row: Row, fieldName: String): JValue =
+    Try { parse(row.getAs[String](fieldName)) } match {
       case Success(jv) => jv
       case Failure(_) => JNothing
     }
 
   // Handle field index that may not be present in the data.
-  private[model] def potentiallyMissingStringField(row: Row, fieldPosition: Integer): Option[String] = {
-    Try { optionalString(row, fieldPosition) }.getOrElse(None)
+  private[model] def potentiallyMissingStringField(row: Row, fieldName: String): Option[String] = {
+    Try { optionalString(row, fieldName) }.getOrElse(None)
   }
 }

--- a/src/main/scala/dpla/ingestion3/reports/summary/SummaryReportComponents.scala
+++ b/src/main/scala/dpla/ingestion3/reports/summary/SummaryReportComponents.scala
@@ -19,11 +19,8 @@ case class MessageSummary(
                            errorRecordCount: Long = -1, // 1:1 if exception 1:n if from message
                            warningRecordCount: Long = -1, // 1:n a record can raise many warnings
                            errorMessageDetails: String = "", // error messages
-                           warningMessageDetails: String  = "", // warning messages
-                           duplicateOriginalIds: Long = -1 // number of records with duplicate original IDs
+                           warningMessageDetails: String  = "" // warning messages
                          )
-
-
 
 case class MappingSummaryData(
                                shortName: String = "",


### PR DESCRIPTION
This adds an error/warning message for duplicate `originalId`s.

This also removes the old logic to pretty-print the duplicate `originalId` count, as it is now included in the "Message Summary" part of the pretty printout.

I also confirmed that the duplicate `originalId`s are showing up in the `_LOGS/warnings` csv report. 

This has been tested locally with Oklahoma.

The logic to join the old error messages with the new error messages is a bit convoluted.  The `messages` column in the `DataFrame` of mapped records is an array of `structs`.  I could not find an elegant way to add a new `struct` (i.e. the duplicate original ID message) to an existing array, as the existing spark SQL methods all seem to deal with simpler datatypes.  If anyone has ideas of how to improve on what I landed on, feel free to share.

This addresses `DT-765`