### PR TITLE
Duplicate original id error message 2

### DIFF
--- a/src/main/resources/avro/MAPRecord.avsc
+++ b/src/main/resources/avro/MAPRecord.avsc
@@ -1080,11 +1080,10 @@
         "string"
       ]
     },
-  {
-    "name":
-    "messages",
-    "type": {
-      "name": "MessagesIngestMessageArray",
+    {
+      "name": "messages",
+      "type": {
+        "name": "MessagesIngestMessageArray",
         "type": "array",
         "items": {
           "name": "MessagesIngestMessage",

--- a/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
@@ -81,14 +81,6 @@ trait MappingExecutor extends Serializable {
     )(oreAggregationEncoder)
       .persist(StorageLevel.MEMORY_AND_DISK_SER)
 
-    val duplicateOriginalIds = mappingResults
-      .select("originalId")
-      .where("originalId != ''")
-      .groupBy("originalId")
-      .agg(count("*").alias("count"))
-      .where("count > 1")
-      .count
-
     // Removes records from mappingResults that have at least one IngestMessage
     // with a level of IngestLogLevel.error
     // Transformation only
@@ -135,8 +127,7 @@ trait MappingExecutor extends Serializable {
       startTime,
       endTime,
       attemptedCount,
-      validRecordCount,
-      duplicateOriginalIds)(spark)
+      validRecordCount)(spark)
 
     // Format the summary report and write it log file
     val mappingSummary = MappingSummary.getSummary(finalReport)
@@ -170,8 +161,7 @@ trait MappingExecutor extends Serializable {
                        startTime: Long,
                        endTime: Long,
                        attemptedCount: Long,
-                       validRecordCount: Long,
-                       duplicateOriginalIds: Long)(implicit spark: SparkSession): MappingSummaryData = {
+                       validRecordCount: Long)(implicit spark: SparkSession): MappingSummaryData = {
     import spark.implicits._
 
     // these three Encoders allow us to tell Spark/Catalyst how to encode our data in a DataSet.
@@ -230,8 +220,7 @@ trait MappingExecutor extends Serializable {
       recordErrorCount,
       recordWarnCount,
       errorMsgDetails,
-      warnMsgDetails,
-      duplicateOriginalIds
+      warnMsgDetails
     )
 
     MappingSummaryData(shortName, operationSummary, timeSummary, messageSummary)

--- a/src/main/scala/dpla/ingestion3/messages/IngestMessageTemplates.scala
+++ b/src/main/scala/dpla/ingestion3/messages/IngestMessageTemplates.scala
@@ -56,6 +56,15 @@ trait IngestMessageTemplates {
       value = "both rights and edmRights are defined"
     )
 
+  def duplicateOriginalId(id: String): IngestMessage =
+    IngestMessage(
+      message = "Duplicate",
+      level = IngestLogLevel.warn,
+      id = id,
+      field = "originalId",
+      value = "at least one other record shares this originalId"
+    )
+
   def enrichedValue(id: String, field: String, origValue: String, enrichValue: String): IngestMessage =
     IngestMessage(
       message = s"Enriched value",

--- a/src/main/scala/dpla/ingestion3/messages/IngestMessageTemplates.scala
+++ b/src/main/scala/dpla/ingestion3/messages/IngestMessageTemplates.scala
@@ -59,7 +59,7 @@ trait IngestMessageTemplates {
   def duplicateOriginalId(id: String): IngestMessage =
     IngestMessage(
       message = "Duplicate",
-      level = IngestLogLevel.warn,
+      level = IngestLogLevel.error,
       id = id,
       field = "originalId",
       value = "at least one other record shares this originalId"

--- a/src/main/scala/dpla/ingestion3/messages/MappingSummary.scala
+++ b/src/main/scala/dpla/ingestion3/messages/MappingSummary.scala
@@ -23,7 +23,6 @@ object MappingSummary {
     val warnRecordsStr = Utils.formatNumber(data.messageSummary.warningRecordCount)
     val errorRecordsStr = Utils.formatNumber(data.messageSummary.errorRecordCount)
     val failedCountStr = Utils.formatNumber(data.operationSummary.recordsFailed)
-    val duplicateOriginalIdsStr = Utils.formatNumber(data.messageSummary.duplicateOriginalIds)
 
     val logFileMsg =
       if(data.operationSummary.logFiles.nonEmpty) data.operationSummary.logFiles.mkString("\n")
@@ -53,7 +52,6 @@ object MappingSummary {
         |Records
         |${ReportFormattingUtils.centerPad("- Errors", errorRecordsStr)}
         |${ReportFormattingUtils.centerPad("- Warnings", warnRecordsStr)}
-        |${ReportFormattingUtils.centerPad("- Duplicate original ID", duplicateOriginalIdsStr)}
         |
         |${if(data.messageSummary.warningCount > 0 || data.messageSummary.errorCount > 0)
             ReportFormattingUtils.center("Message Summary") else ""}

--- a/src/main/scala/dpla/ingestion3/reports/summary/SummaryReportComponents.scala
+++ b/src/main/scala/dpla/ingestion3/reports/summary/SummaryReportComponents.scala
@@ -19,11 +19,8 @@ case class MessageSummary(
                            errorRecordCount: Long = -1, // 1:1 if exception 1:n if from message
                            warningRecordCount: Long = -1, // 1:n a record can raise many warnings
                            errorMessageDetails: String = "", // error messages
-                           warningMessageDetails: String  = "", // warning messages
-                           duplicateOriginalIds: Long = -1 // number of records with duplicate original IDs
+                           warningMessageDetails: String  = ""
                          )
-
-
 
 case class MappingSummaryData(
                                shortName: String = "",


### PR DESCRIPTION
A fresh PR, a fresh take on the `duplicateOriginalId` messaging.

@mdellabitta this is slightly different from what we discussed this morning.  This holds off on encoding the `OreAggregation`s altogether until after the new messages are added.  Let me know what you think.  

If you like this way of doing things, we could consider working with RDD[OreAggregation] for other functions too - such as filtering out successful results and building the final report - and then only do the encoding immediately before writes.  That could help prevent boo-boos like accidentally reordering column rows.

If you don't like this way of doing things, I'm ready to try something else.

I tested this locally by running `IngestRemap` over Oklahoma data.