### PR TITLE
Fix mapping double count

### DIFF
--- a/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
@@ -54,8 +54,6 @@ trait MappingExecutor extends Serializable with IngestMessageTemplates {
       .config("spark.ui.showConsoleProgress", value = false)
       .getOrCreate()
 
-    val sc = spark.sparkContext
-
     // Need to keep this here despite what IntelliJ and Codacy say
     import spark.implicits._
 
@@ -219,7 +217,7 @@ trait MappingExecutor extends Serializable with IngestMessageTemplates {
         path
     }
 
-    val recordErrorCount: Long = MessageProcessor.getDistinctIdCount(errors)
+    val recordErrorCount: Long = attemptedCount - validRecordCount
     val recordWarnCount: Long = MessageProcessor.getDistinctIdCount(warnings)
 
     val errorMsgDetails: String =

--- a/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
@@ -79,6 +79,7 @@ trait MappingExecutor extends Serializable with IngestMessageTemplates {
 
     val mappingResults: RDD[OreAggregation] = documents.rdd
       .map(document => dplaMap.map(document, shortName, totalCount, successCount))
+      .persist(StorageLevel.MEMORY_AND_DISK_SER)
 
     // Get a list of originalIds that appear in more than one record
     val duplicateOriginalIds: Broadcast[Array[String]] =

--- a/src/main/scala/dpla/ingestion3/messages/MessageProcessor.scala
+++ b/src/main/scala/dpla/ingestion3/messages/MessageProcessor.scala
@@ -44,29 +44,9 @@ object MessageProcessor{
                 |""".stripMargin)
   }
 
-  def getErrors(ds: Dataset[Row]): Dataset[Row] = {
-    val errors = ds.select("message", "level", "field", "id", "value")
+  def getErrors(ds: Dataset[Row]): Dataset[Row] =
+    ds.select("message", "level", "field", "id", "value")
       .where(s"level=='${IngestLogLevel.error}'")
-
-    // TODO: Question for code review:
-    //  Is there a real need to take distinct error messages, rather than all error messages?
-    //  I do not know of one.
-    //  If there is no use case in which undesired duplicates are created,
-    //  it would be simpler to just return errors as defined above.
-    val regularErrors = errors
-      .where("field!='originalId'")
-      .where("field!='dplaUri'")
-    
-    // Documents with duplicate originalId will have identical error messages,
-    // so do NOT return distinct rows.
-    val originalIdErrors = errors.where("field=='originalId'")
-
-    // Documents with missing originalId will have identical error messages for missing dplaUri,
-    // so do NOT return distinct rows.
-    val dplaUriErrors = errors.where("field=='dplaUri'")
-
-    regularErrors.union(originalIdErrors).union(dplaUriErrors)
-  }
 
   def getWarnings(ds: Dataset[Row]): Dataset[Row] =
     ds.select("message", "level", "field", "id", "value")


### PR DESCRIPTION
**Problem**  
During mapping, the reported results for total attempted and total success were incorrect.  `mappingResults` was being evaluated twice, and so the accumulators that tracked these stats were double what they should be - and the mapping was unnecessarily inefficient / taking longer to run.  Also, total success was reported as equal to the total attempted even when not all records were successful.

**Solution**
1) Persist `mappingResults` so that it is only evaluated once.  Persisting this does add some memory pressure - I noticed for example that the Oklahoma mapping runs out of memory locally on the default memory setting - but we agreed that more memory pressure should be ok.

2) Get rid of the `totalCount` accumulator.  It was unnecessary because `encodedMappingResults.count` was already being evaluated and was equivalent to `totalCount`.

3) Get rid of the `successCount` accumulator.  It was incorrect, and accumulators can be unreliable, e.g. if nodes fail in the middle of computations.  Since @mdellabitta discovered that S3 has read-after-write consistency in our use case, we can use that instead to read in `successResults` and count them.  It is more reliable and adds very little time to the overall process.  Alternately, we could persist `successResults` so that we could write and count them without evaluating more than once, but that would add another dose of memory pressure - and it would probably overflow to disk so might not be much faster in a cluster environment than reading from S3.

**Testing**
I tested this locally with Oklahoma data.

BEFORE
```
                                Mapping Summary

Provider................................................................OKLAHOMA
Start date...................................................02/27/2019 12:44:49
Runtime.............................................................00:01:47.426

Attempted................................................................229,340
Successful...............................................................229,340
Failed.......................................................................213


                              Errors and Warnings

Messages
- Errors.....................................................................213
- Warnings...............................................................322,489

Records
- Errors.....................................................................213
- Warnings...............................................................111,943

                                Message Summary
Warnings
- Missing recommended field, language.....................................89,720
- Missing recommended field, publisher....................................51,307
- Missing recommended field, creator......................................47,890
- Missing recommended field, date.........................................43,869
- Missing recommended field, place........................................38,188
- Duplicate, rights and edmRights.........................................14,728
- Missing recommended field, type.........................................13,267
- Missing recommended field, format.......................................12,425
- Missing recommended field, description...................................9,951
- Missing recommended field, subject.......................................1,144
- Total..................................................................322,489
Errors
- Duplicate, originalId......................................................213
- Total......................................................................213
```

AFTER
```
                                Mapping Summary

Provider................................................................OKLAHOMA
Start date...................................................02/27/2019 14:56:21
Runtime.............................................................00:01:00.101

Attempted................................................................114,670
Successful...............................................................114,169
Failed.......................................................................213


                              Errors and Warnings

Messages
- Errors.....................................................................213
- Warnings...............................................................322,489

Records
- Errors.....................................................................213
- Warnings...............................................................111,943

                                Message Summary
Warnings
- Missing recommended field, language.....................................89,720
- Missing recommended field, publisher....................................51,307
- Missing recommended field, creator......................................47,890
- Missing recommended field, date.........................................43,869
- Missing recommended field, place........................................38,188
- Duplicate, rights and edmRights.........................................14,728
- Missing recommended field, type.........................................13,267
- Missing recommended field, format.......................................12,425
- Missing recommended field, description...................................9,951
- Missing recommended field, subject.......................................1,144
- Total..................................................................322,489
Errors
- Duplicate, originalId......................................................213
- Total......................................................................213
```