### PR TITLE
Michigan mapper

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/MichiganMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MichiganMapping.scala
@@ -135,18 +135,25 @@ class MichiganMapping extends XmlMapping with XmlExtractor with IngestMessageTem
   // <mods:accessCondition>
     extractStrings(data \\ "mods" \ "accessCondition")
 
-  override def subject(data: Document[NodeSeq]): Seq[SkosConcept] =
-  // <mods:subject> AND
-  // <mods:subject><mods:topic> AND
-  // <mods:subject><mods:name><mods:namePart> AND
-  // <mods:subject><mods:genre> AND
-  // <mods:subject><mods:titleInfo><mods:title>
+  override def subject(data: Document[NodeSeq]): Seq[SkosConcept] = {
+    // <mods:subject> AND
+    // <mods:subject><mods:topic> AND
+    // <mods:subject><mods:name><mods:namePart> AND
+    // <mods:subject><mods:genre> AND
+    // <mods:subject><mods:titleInfo><mods:title>
+
+    // TODO: Make this a reusable method in XmlExtractor
+    val subjectChildStrings: Seq[String] = (data \\ "mods" \ "subject").flatMap { node =>
+      node.child.collect{ case Text(t) => t }.map(_.trim).filterNot(_.isEmpty)
+    }
+
     (extractStrings(data \\ "mods" \ "subject" \ "topic") ++
       extractStrings(data \\ "mods" \ "subject" \ "name" \ "namePart") ++
       extractStrings(data \\ "mods" \ "subject" \ "genre") ++
       extractStrings(data \\ "mods" \ "subject" \ "titleInfo" \ "title") ++
-      extractStrings(data \\ "mods" \ "subject")
-    ).map(nameOnlyConcept)
+      subjectChildStrings
+      ).map(nameOnlyConcept)
+  }
 
   override def temporal(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] =
   // <mods:subject><mods:temporal>

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MichiganMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MichiganMapping.scala
@@ -1,0 +1,204 @@
+package dpla.ingestion3.mappers.providers
+
+import dpla.ingestion3.enrichments.normalizations.filters.{DigitalSurrogateBlockList, FormatTypeValuesBlockList}
+import dpla.ingestion3.mappers.utils.{Document, XmlExtractor, XmlMapping}
+import dpla.ingestion3.messages.IngestMessageTemplates
+import dpla.ingestion3.model.DplaMapData._
+import dpla.ingestion3.model.{nameOnlyAgent, _}
+import dpla.ingestion3.utils.Utils
+import org.json4s.JValue
+import org.json4s.JsonDSL._
+
+import scala.xml._
+
+
+class MichiganMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates {
+
+  val formatBlockList: Set[String] =
+    DigitalSurrogateBlockList.termList ++
+      FormatTypeValuesBlockList.termList
+
+  // ID minting functions
+  override def useProviderName(): Boolean = true
+
+  override def getProviderName(): String = "mi"
+
+  override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
+    extractString(data \ "header" \ "identifier")
+
+  // SourceResource mapping
+  override def collection(data: Document[NodeSeq]): ZeroToMany[DcmiTypeCollection] =
+  // <mods:relatedItem type=host><mods:titleInfo><mods:title>
+    (data \\ "relatedItem")
+      .flatMap(node => getByAttribute(node.asInstanceOf[Elem], "type", "host"))
+      .flatMap(collection => extractStrings(collection \ "titleInfo" \ "title"))
+      .map(nameOnlyCollection)
+
+  override def contributor(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
+  // when <role><roleTerm> DOES equal "contributor>
+    (data \\ "name")
+      .filter(node => (node \ "role" \ "roleTerm").text.equalsIgnoreCase("contributor"))
+      .flatMap(n => extractStrings(n \ "namePart"))
+      .map(nameOnlyAgent)
+
+  override def creator(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
+  // <mods:name><mods:namePart> when <role><roleTerm> is 'creator' or blank
+    (data \\ "name")
+      .filter(node => {
+        val role = (node \ "role" \ "roleTerm").text
+        role.isEmpty || role.equalsIgnoreCase("creator")
+      } )
+      .flatMap(n => extractStrings(n \ "namePart"))
+      .map(nameOnlyAgent)
+
+  override def date(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] = {
+    // <mods:originInfo><mods:dateCreated>
+    val dateCreated = extractStrings(data \\ "originInfo" \\ "dateCreated")
+      .map(stringOnlyTimeSpan)
+
+    // Get dateIssued values
+    val dateIssued = (data \\ "originInfo" \\ "dateIssued")
+      .filter(node => node.attributes.get("point").isEmpty)
+      .flatMap(node => extractStrings(node))
+      .map(stringOnlyTimeSpan)
+    // Get dateIssued values with attribute of point=start
+    val dateIssuedEarly = (data \\ "originInfo" \\ "dateIssued")
+      .flatMap(node => getByAttribute(node.asInstanceOf[Elem], "point", "start"))
+      .flatMap(node => extractStrings(node))
+    // Get dateIssued values with attribute of point=end
+    val dateIssuedLate = (data \\ "originInfo" \\ "dateIssued")
+      .flatMap(node => getByAttribute(node.asInstanceOf[Elem], "point", "end"))
+      .flatMap(node => extractStrings(node))
+
+    val constructedDateIssued = if(dateIssuedEarly.length == dateIssuedLate.length) {
+        dateIssuedEarly.zip(dateIssuedLate).map {
+          case (begin: String, end: String) =>
+            EdmTimeSpan(
+              originalSourceDate = Some(s"$begin-$end"),
+              begin = Some(begin),
+              end = Some(end)
+            )
+        }
+    } else {
+      Seq()
+    }
+
+    (dateCreated.nonEmpty, dateIssued.nonEmpty, constructedDateIssued.nonEmpty) match {
+      case (true, _, _) => dateCreated // if any dateCreated exist return only those values
+      case (false, true, _) => dateIssued // if any dateIssued exist return only those values
+      case (false, false, true) => constructedDateIssued // if neither dateCreated or dateIssued exist return constructed
+      case _ => Seq()
+    }
+  }
+
+  override def description(data: Document[NodeSeq]): Seq[String] = {
+    // <mods:note> and <mods:abstract> and <mods:physicalDescription> \ <note>
+    extractStrings(data \\ "physicalDescription" \ "note") ++
+      extractStrings(data \\ "abstract") ++
+      extractStrings(data \ "note")
+  }
+
+  override def extent(data: Document[NodeSeq]): ZeroToMany[String] =
+  // <mods:physicalDescription><mods:extent>
+    extractStrings(data \\ "physicalDescription" \ "extent")
+
+  override def format(data: Document[NodeSeq]): Seq[String] =
+  // <mods:genre> AND <mods:physicialDescription><mods:form>
+    extractStrings(data \\ "genre") ++
+      extractStrings(data \\ "physicalDescription" \ "form")
+
+  override def identifier(data: Document[NodeSeq]): Seq[String] =
+  // <mods:identifier>
+    extractStrings(data \ "metadata" \ "mods" \ "identifier")
+
+  override def language(data: Document[NodeSeq]): Seq[SkosConcept] =
+  // <mods:language><mods:languageTerm>
+    extractStrings(data \\ "language" \\ "languageTerm")
+      .map(nameOnlyConcept)
+
+  override def place(data: Document[NodeSeq]): Seq[DplaPlace] =
+  // <mods:subject><mods:geographic>
+    extractStrings(data \\ "subject" \\ "geographic")
+      .map(nameOnlyPlace)
+
+  override def publisher(data: Document[NodeSeq]): Seq[EdmAgent] =
+  // <mods:originInfo><mods:publisher>
+    extractStrings(data \\ "originInfo" \\ "publisher")
+      .map(nameOnlyAgent)
+
+  //  <accessCondition> when the @type="use and reproduction" attribute is not present
+  override def rights(data: Document[NodeSeq]): AtLeastOne[String] =
+    extractStrings(data \ "metadata" \ "mods" \ "accessCondition")
+
+  override def subject(data: Document[NodeSeq]): Seq[SkosConcept] =
+  // <mods:subject> AND
+  // <mods:subject><mods:topic> AND
+  // <mods:subject><mods:name><mods:namePart> AND
+  // <mods:subject><mods:genre> AND
+  // <mods:subject><mods:titleInfo><mods:title>
+    (extractStrings(data \\ "subject" \ "topic") ++
+      extractStrings(data \\ "subject" \ "name" \ "namePart") ++
+      extractStrings(data \\ "subject" \ "genre") ++
+      extractStrings(data \\ "subject" \ "titleInfo" \ "title") ++
+      extractStrings(data \\ "subject")
+    ).map(nameOnlyConcept)
+
+  override def temporal(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] =
+  // <mods:subject><mods:temporal>
+    extractStrings(data \\ "subject" \ "temporal")
+      .map(stringOnlyTimeSpan)
+
+  override def title(data: Document[NodeSeq]): Seq[String] =
+  // <mods:titleInfo><mods:title>
+    extractStrings(data \\ "mods" \ "titleInfo" \ "title")
+
+  override def `type`(data: Document[NodeSeq]): Seq[String] =
+  // <mods:typeofresource>
+    extractStrings(data \ "metadata" \ "mods" \ "typeOfResource")
+
+  // OreAggregation
+  override def dplaUri(data: Document[NodeSeq]): ZeroToOne[URI] = mintDplaItemUri(data)
+
+  override def dataProvider(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
+  // first <mods:recordInfo><mods:recordContentSource>
+    extractStrings(data \\ "recordInfo" \ "recordContentSource")
+      .map(nameOnlyAgent)
+      .take(1)
+
+  override def intermediateProvider(data: Document[NodeSeq]): ZeroToOne[EdmAgent] = {
+    // second <mods:recordInfo><mods:recordContentSource> if exists
+    val providers = extractStrings(data \\ "recordInfo" \ "recordContentSource")
+      .map(nameOnlyAgent)
+    if (providers.length > 1)
+      Some(providers(2))
+    else None
+  }
+
+  override def isShownAt(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
+  // <mods:location><mods:url usage="primary display" access="object in  context">
+    (data \ "metadata" \ "mods" \ "location" \ "url")
+      .flatMap(node => getByAttribute(node.asInstanceOf[Elem], "usage", "primary"))
+      .flatMap(extractStrings)
+      .map(stringOnlyWebResource)
+
+  override def originalRecord(data: Document[NodeSeq]): ExactlyOne[String] = Utils.formatXml(data)
+
+  override def preview(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
+  // <mods:location><mods:url access="preview">
+    (data \ "metadata" \ "mods" \ "location" \ "url")
+      .flatMap(node => getByAttribute(node.asInstanceOf[Elem], "access", "preview"))
+      .flatMap(extractStrings)
+      .map(stringOnlyWebResource)
+
+  override def provider(data: Document[NodeSeq]): ExactlyOne[EdmAgent] = agent
+
+  override def sidecar(data: Document[NodeSeq]): JValue =
+    ("prehashId" -> buildProviderBaseId()(data)) ~ ("dplaId" -> mintDplaId(data))
+
+  // Helper method
+  def agent = EdmAgent(
+    name = Some("Michigan Service Hub"),
+    uri = Some(URI("http://dp.la/api/contributor/michigan"))
+  )
+}
+

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MichiganMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MichiganMapping.scala
@@ -25,6 +25,7 @@ class MichiganMapping extends XmlMapping with XmlExtractor with IngestMessageTem
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "header" \ "identifier")
+      .map(_.trim)
 
   // SourceResource mapping
   override def collection(data: Document[NodeSeq]): ZeroToMany[DcmiTypeCollection] =
@@ -169,8 +170,8 @@ class MichiganMapping extends XmlMapping with XmlExtractor with IngestMessageTem
     // second <mods:recordInfo><mods:recordContentSource> if exists
     val providers = extractStrings(data \\ "recordInfo" \ "recordContentSource")
       .map(nameOnlyAgent)
-    if (providers.length > 1)
-      Some(providers(2))
+    if (providers.length > 2)
+      Some(providers(1))
     else None
   }
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MichiganMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MichiganMapping.scala
@@ -142,16 +142,11 @@ class MichiganMapping extends XmlMapping with XmlExtractor with IngestMessageTem
     // <mods:subject><mods:genre> AND
     // <mods:subject><mods:titleInfo><mods:title>
 
-    // TODO: Make this a reusable method in XmlExtractor
-    val subjectChildStrings: Seq[String] = (data \\ "mods" \ "subject").flatMap { node =>
-      node.child.collect{ case Text(t) => t }.map(_.trim).filterNot(_.isEmpty)
-    }
-
     (extractStrings(data \\ "mods" \ "subject" \ "topic") ++
       extractStrings(data \\ "mods" \ "subject" \ "name" \ "namePart") ++
       extractStrings(data \\ "mods" \ "subject" \ "genre") ++
       extractStrings(data \\ "mods" \ "subject" \ "titleInfo" \ "title") ++
-      subjectChildStrings
+      extractChildStrings(data \\ "mods" \ "subject")
       ).map(nameOnlyConcept)
   }
 

--- a/src/main/scala/dpla/ingestion3/mappers/utils/Extractor.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/Extractor.scala
@@ -2,7 +2,7 @@ package dpla.ingestion3.mappers.utils
 
 import org.json4s.JsonAST._
 
-import scala.xml.{Elem, Node, NodeSeq}
+import scala.xml.{Elem, Node, NodeSeq, Text}
 
 
 /**
@@ -89,6 +89,20 @@ trait XmlExtractor extends Extractor[NodeSeq] {
 
   def getByAttribute(e: NodeSeq, att: String, value: String): NodeSeq = {
     getByAttribute(e.asInstanceOf[Elem], att, value)
+  }
+
+  /**
+    * For each given node, get any immediate children that are text values.
+    * Ignore nested text values.
+    *
+    * E.g. <foo>bar</foo> => "bar"
+    * E.g. <foo><bar>bat</bar></foo> => nothing
+    *
+    * @param xValue NodeSeq
+    * @return Seq[String]
+    */
+  def extractChildStrings(xValue: NodeSeq): Seq[String] = xValue.flatMap { node =>
+    node.child.collect{ case Text(t) => t }.map(_.trim).filterNot(_.isEmpty)
   }
 }
 

--- a/src/main/scala/dpla/ingestion3/messages/IngestMessageTemplates.scala
+++ b/src/main/scala/dpla/ingestion3/messages/IngestMessageTemplates.scala
@@ -96,7 +96,7 @@ trait IngestMessageTemplates {
 
   def exception(id: String, exception: Throwable): IngestMessage =
     IngestMessage(
-      message = s"Exception (see error report)",
+      message = s"Exception (see value column)",
       level = IngestLogLevel.error,
       id = id,
       field = "",

--- a/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
+++ b/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
@@ -97,6 +97,16 @@ class MdlProfile extends JsonProfile {
 }
 
 /**
+  * Michigan Service Hub
+  */
+class MiProfile extends XmlProfile {
+  type Mapping = MichiganMapping
+
+  override def getHarvester: Class[_ <: Harvester] = classOf[OaiHarvester]
+  override def getMapping = new MichiganMapping
+}
+
+/**
   * Missouri
   */
 class MoProfile extends JsonProfile {

--- a/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
+++ b/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
@@ -51,6 +51,7 @@ object ProviderRegistry {
     "getty" -> Register(profile = new GettyProfile),
     "ia" -> Register(profile = new IaProfile),
     "lc" -> Register(profile = new LocProfile),
+    "mi" -> Register(profile = new MiProfile),
     "minnesota" -> Register(profile = new MdlProfile),
     "mo" -> Register(profile = new MoProfile),
     "mt" -> Register(profile = new MtProfile),

--- a/src/test/resources/michigan.xml
+++ b/src/test/resources/michigan.xml
@@ -1,0 +1,66 @@
+<record xmlns="http://www.openarchives.org/OAI/2.0/">
+    <header>
+        <identifier>
+            oai:michigan:ochr:oai:digital.library.wayne.edu:ochr:oai:demo.ptfs.com:library10_lib/87490
+        </identifier>
+        <datestamp>2019-01-14</datestamp>
+        <setSpec>ochr</setSpec>
+    </header>
+    <metadata>
+        <mods:mods xmlns:mods="http://www.loc.gov/mods/v3" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+            <mods:titleInfo>
+                <mods:title>Avon Township Offices</mods:title>
+            </mods:titleInfo>
+            <mods:subject>
+                <mods:topic>Government</mods:topic>
+            </mods:subject>
+            <mods:subject>
+                <mods:geographic>407 Pine Street</mods:geographic>
+            </mods:subject>
+            <mods:subject>
+                <mods:geographic>Rochester</mods:geographic>
+            </mods:subject>
+            <mods:abstract>
+                Avon Township Offices, located on the northwest corner of Fourth and Pine Streets. Built in 1880 as a single story structure, the building has been remodeled and expanded several times. Date is approximated. (RRP-166) Ray Russell Postcard Collection
+            </mods:abstract>
+            <mods:originInfo>
+                <mods:dateIssued>01-Jan-1930</mods:dateIssued>
+            </mods:originInfo>
+            <mods:physicalDescription>
+                <mods:form>Postcard</mods:form>
+            </mods:physicalDescription>
+            <mods:location>
+                <mods:url usage="primary">
+                    http://oaklandcountyhistory.org/knowvation/app/consolidatedSearch/#autologin/guest/lb_document_id=87490
+                </mods:url>
+            </mods:location>
+            <mods:location>
+                <mods:url access="preview">
+                    http://oaklandcountyhistory.org/awweb/pdfopener?fp=auto&amp;umb=87490
+                </mods:url>
+            </mods:location>
+            <mods:accessCondition type="use and reproduction">
+                Users can cite and link to these materials without obtaining permission. Users can also use the materials for non-commercial educational and research purposes in accordance with fair use. For other uses or to obtain high resolution images, please contact the copyright holder.
+            </mods:accessCondition>
+            <mods:note>
+                Oakland County Historical Resources hosts digitized materials from Rochester Hills Public Library and many other local cultural heritage organizations in Oakland County, Michigan.
+            </mods:note>
+            <mods:recordInfo>
+                <recordContentSource>Oakland County Historical Resources</recordContentSource>
+                <recordContentSource>Rochester Hills Public Library</recordContentSource>
+            </mods:recordInfo>
+        </mods:mods>
+    </metadata>
+    <about>
+        <oaiProvenance:provenance xmlns:oaiProvenance="http://www.openarchives.org/OAI/2.0/provenance" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/provenance http://www.openarchives.org/OAI/2.0/provenance.xsd">
+            <oaiProvenance:originDescription harvestDate="2019-01-14" altered="true">
+                <oaiProvenance:baseURL>http://combine.michiganservicehub.org/combine/oai</oaiProvenance:baseURL>
+                <oaiProvenance:identifier>
+                    oai:digital.library.wayne.edu:ochr:oai:demo.ptfs.com:library10_lib/87490
+                </oaiProvenance:identifier>
+                <oaiProvenance:datestamp>2019-01-14</oaiProvenance:datestamp>
+                <oaiProvenance:metadataNamespace>http://www.loc.gov/mods/v3</oaiProvenance:metadataNamespace>
+            </oaiProvenance:originDescription>
+        </oaiProvenance:provenance>
+    </about>
+</record>

--- a/src/test/resources/michigan.xml
+++ b/src/test/resources/michigan.xml
@@ -20,9 +20,10 @@
             <mods:subject>
                 <mods:geographic>Rochester</mods:geographic>
             </mods:subject>
-            <mods:abstract>
-                Avon Township Offices, located on the northwest corner of Fourth and Pine Streets. Built in 1880 as a single story structure, the building has been remodeled and expanded several times. Date is approximated. (RRP-166) Ray Russell Postcard Collection
-            </mods:abstract>
+            <mods:subject>
+                <mods:temporal>1967-2011</mods:temporal>
+            </mods:subject>
+            <mods:abstract>Avon Township Offices, located on the northwest corner of Fourth and Pine Streets.</mods:abstract>
             <mods:originInfo>
                 <mods:dateIssued>01-Jan-1930</mods:dateIssued>
             </mods:originInfo>
@@ -39,16 +40,45 @@
                     http://oaklandcountyhistory.org/awweb/pdfopener?fp=auto&amp;umb=87490
                 </mods:url>
             </mods:location>
-            <mods:accessCondition type="use and reproduction">
-                Users can cite and link to these materials without obtaining permission. Users can also use the materials for non-commercial educational and research purposes in accordance with fair use. For other uses or to obtain high resolution images, please contact the copyright holder.
-            </mods:accessCondition>
-            <mods:note>
-                Oakland County Historical Resources hosts digitized materials from Rochester Hills Public Library and many other local cultural heritage organizations in Oakland County, Michigan.
-            </mods:note>
+            <mods:accessCondition type="use and reproduction">Users can cite and link to these materials without obtaining permission.</mods:accessCondition>
             <mods:recordInfo>
                 <recordContentSource>Oakland County Historical Resources</recordContentSource>
                 <recordContentSource>Rochester Hills Public Library</recordContentSource>
             </mods:recordInfo>
+            <mods:relatedItem type="host">
+                <mods:titleInfo>
+                    <mods:title>Veterans History Project interviews, RHC-27</mods:title>
+                </mods:titleInfo>
+            </mods:relatedItem>
+            <mods:name valueURI="http://id.loc.gov/authorities/names/n86026453" type="corporate" authorityURI="http://id.loc.gov/authorities/names" authority="naf">
+                <mods:namePart>Boston Cooking School (Boston, Mass.)</mods:namePart>
+                <mods:role>
+                    <mods:roleTerm valueURI="http://id.loc.gov/vocabulary/relators/ctb" type="text" authorityURI="http://id.loc.gov/vocabulary/relators" authority="marcrelator">contributor</mods:roleTerm>
+                </mods:role>
+            </mods:name>
+            <mods:name>
+                <mods:namePart>City of Lansing</mods:namePart>
+                <mods:role>
+                    <mods:roleTerm>Creator</mods:roleTerm>
+                </mods:role>
+            </mods:name>
+            <mods:name>
+                <mods:namePart>City Planning Division Ingells, Norris</mods:namePart>
+                <mods:role>
+                    <mods:roleTerm>Creator</mods:roleTerm>
+                </mods:role>
+            </mods:name>
+            <mods:physicalDescription>
+                <mods:extent>1 Postcard (3.5" x 5.5")</mods:extent>
+            </mods:physicalDescription>
+            <mods:identifier type="local">MICH1306517</mods:identifier>
+            <mods:language>
+                <mods:languageTerm type="code">eng</mods:languageTerm>
+            </mods:language>
+            <mods:originInfo>
+                <mods:publisher>Grand Valley State University. University Libraries.</mods:publisher>
+            </mods:originInfo>
+            <mods:typeOfResource>still image</mods:typeOfResource>
         </mods:mods>
     </metadata>
     <about>

--- a/src/test/resources/michigan_bad.xml
+++ b/src/test/resources/michigan_bad.xml
@@ -1,0 +1,86 @@
+<record xmlns="http://www.openarchives.org/OAI/2.0/">
+    <header>
+        <identifier>
+            oai:michigan:wsuoai:oai:digital.library.wayne.edu:wsudor_dpla:oai:digital.library.wayne.edu:wayne:StudentLife36797
+        </identifier>
+        <datestamp>2019-01-11</datestamp>
+        <setSpec>wsuoai</setSpec>
+    </header>
+    <metadata>
+        <mods:mods xmlns:mods="http://www.loc.gov/mods/v3">
+            <mods:titleInfo>
+                <mods:title>
+                    The 1937 tennis team. Won 15, lost 3. F. Winton, J. Schlesinger, R. Balow (Capt) P. Kondrasky, W. Maul, S. Rotberg.
+                </mods:title>
+            </mods:titleInfo>
+            <mods:subject>
+                <mods:topic xmlns:mets="http://www.loc.gov/METS/" xmlns:xl="http://www.w3.org/1999/xlink" xmlns:xlink="http://www.w3.org/1999/xlink">Sports</mods:topic>
+            </mods:subject>
+            <mods:subject>
+                <mods:topic xmlns:mets="http://www.loc.gov/METS/" xmlns:xl="http://www.w3.org/1999/xlink" xmlns:xlink="http://www.w3.org/1999/xlink">Tennis</mods:topic>
+            </mods:subject>
+            <mods:subject>
+                <mods:topic xmlns:mets="http://www.loc.gov/METS/" xmlns:xl="http://www.w3.org/1999/xlink" xmlns:xlink="http://www.w3.org/1999/xlink">College students</mods:topic>
+            </mods:subject>
+            <mods:subject>
+                <mods:geographic>
+                    <mods:placeTerm xmlns:mets="http://www.loc.gov/METS/" xmlns:xl="http://www.w3.org/1999/xlink" xmlns:xlink="http://www.w3.org/1999/xlink" type="text">Detroit, MI</mods:placeTerm>
+                </mods:geographic>
+            </mods:subject>
+            <mods:originInfo>
+                <mods:dateIssued>1937</mods:dateIssued>
+            </mods:originInfo>
+            <mods:typeOfResource>still image</mods:typeOfResource>
+            <mods:physicalDescription>
+                <mods:form authority="">photographic prints</mods:form>
+            </mods:physicalDescription>
+            <mods:location>
+                <mods:url usage="primary">
+                    http://digital.library.wayne.edu/item/&wayne:StudentLife36797
+                </mods:url>
+            </mods:location>
+            <mods:location>
+                <mods:url access="preview">
+                    http://digital.library.wayne.edu/item/wayne:StudentLife36797/thumbnail
+                </mods:url>
+            </mods:location>
+            <mods:relatedItem type="host">
+                <mods:titleInfo>
+                    <mods:title>Wayne State University Student Life</mods:title>
+                </mods:titleInfo>
+            </mods:relatedItem>
+            <mods:note>
+                To schedule an appointment to view the original image, order high resolution copies, or seek permission to use an image, contact the Walter P. Reuther Library AudioVisual Department at reutherreference@wayne.edu.
+            </mods:note>
+            <mods:note>
+                Walter P. Reuther Library, Archives of Labor and Urban Affairs, Wayne State University
+            </mods:note>
+            <mods:recordInfo>
+                <mods:recordContentSource xmlns:mets="http://www.loc.gov/METS/" xmlns:xl="http://www.w3.org/1999/xlink" xmlns:xlink="http://www.w3.org/1999/xlink">Wayne State University. Libraries</mods:recordContentSource>
+                <mods:recordContentSource xmlns:mets="http://www.loc.gov/METS/" xmlns:xl="http://www.w3.org/1999/xlink" xmlns:xlink="http://www.w3.org/1999/xlink">Walter P. Reuther Library</mods:recordContentSource>
+            </mods:recordInfo>
+            <mods:note>
+                This metadata was created by Wayne State University Library system based on original description by the Walter P. Reuther Library
+            </mods:note>
+            <mods:accessCondition type="use and reproduction">Copyright Wayne State University</mods:accessCondition>
+            <mods:name type="corporate">
+                <mods:namePart>Wayne State University</mods:namePart>
+                <mods:role>
+                    <mods:roleTerm authority="marcrelator">Creator</mods:roleTerm>
+                </mods:role>
+            </mods:name>
+        </mods:mods>
+    </metadata>
+    <about>
+        <oaiProvenance:provenance xmlns:oaiProvenance="http://www.openarchives.org/OAI/2.0/provenance" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/provenance http://www.openarchives.org/OAI/2.0/provenance.xsd">
+            <oaiProvenance:originDescription harvestDate="2019-01-11" altered="true">
+                <oaiProvenance:baseURL>http://combine.michiganservicehub.org/combine/oai</oaiProvenance:baseURL>
+                <oaiProvenance:identifier>
+                    oai:digital.library.wayne.edu:wsudor_dpla:oai:digital.library.wayne.edu:wayne:StudentLife36797
+                </oaiProvenance:identifier>
+                <oaiProvenance:datestamp>2019-01-11</oaiProvenance:datestamp>
+                <oaiProvenance:metadataNamespace>http://www.loc.gov/mods/v3</oaiProvenance:metadataNamespace>
+            </oaiProvenance:originDescription>
+        </oaiProvenance:provenance>
+    </about>
+</record>

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MichiganMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MichiganMappingTest.scala
@@ -190,7 +190,7 @@ class MichiganMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.format(Document(xml)) == expected)
   }
 
-  it should "not extract genre from the subject/genre field" in {
+  it should "not extract format from the subject/genre field" in {
     val xml =
       <record>
         <metadata>
@@ -301,6 +301,40 @@ class MichiganMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.subject(Document(xml)) == expected)
   }
 
+  it should "not extract subject from the subject/geographic field" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <mods:subject>
+              <mods:geographic>
+                Ann Arbor
+              </mods:geographic>
+            </mods:subject>
+          </mods>
+        </metadata>
+      </record>
+
+    assert(extractor.subject(Document(xml)) == Seq())
+  }
+
+  it should "not extract subject from the subject/temporal field" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <mods:subject>
+              <mods:temporal>
+                1984-1985
+              </mods:temporal>
+            </mods:subject>
+          </mods>
+        </metadata>
+      </record>
+
+    assert(extractor.subject(Document(xml)) == Seq())
+  }
+
   it should "extract the correct temporal" in {
     val expected = Seq("1967-2011").map(stringOnlyTimeSpan)
     assert(extractor.temporal(xml) == expected)
@@ -321,6 +355,23 @@ class MichiganMappingTest extends FlatSpec with BeforeAndAfter {
                 <mods:title>Birds</mods:title>
               </mods:titleInfo>
             </mods:subject>
+          </mods>
+        </metadata>
+      </record>
+
+    assert(extractor.title(Document(xml)) == Seq())
+  }
+
+  it should "not extract title from relatedItem/titleInfo/title field" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <mods:relatedItem>
+              <mods:titleInfo>
+                <mods:title>Collection title</mods:title>
+              </mods:titleInfo>
+            </mods:relatedItem>
           </mods>
         </metadata>
       </record>

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MichiganMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MichiganMappingTest.scala
@@ -166,6 +166,22 @@ class MichiganMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.description(Document(xml)) == expected)
   }
 
+  it should "extract the correct description from physicalDescription/note field" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <mods:physicalDescription>
+              <mods:note>jpeg</mods:note>
+            </mods:physicalDescription>
+          </mods>
+        </metadata>
+      </record>
+
+    val expected = Seq("jpeg")
+    assert(extractor.description(Document(xml)) == expected)
+  }
+
   it should "extract the correct extent" in {
     val expected = Seq("1 Postcard (3.5\" x 5.5\")")
     assert(extractor.extent(xml) == expected)

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MichiganMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MichiganMappingTest.scala
@@ -12,12 +12,18 @@ class MichiganMappingTest extends FlatSpec with BeforeAndAfter {
 
   implicit val msgCollector: MessageCollector[IngestMessage] = new MessageCollector[IngestMessage]
   val shortName = "mi"
-  val xmlString: String = new FlatFileIO().readFileAsString("/oklahoma.xml")
+  val xmlString: String = new FlatFileIO().readFileAsString("/michigan.xml")
+  val badXmlString: String = new FlatFileIO().readFileAsString("/michigan_bad.xml")
   val xml: Document[NodeSeq] = Document(XML.loadString(xmlString))
   val extractor = new MichiganMapping
 
   it should "use the provider shortname in minting IDs " in
     assert(extractor.useProviderName())
+
+  it should "extract the correct original identifier" in {
+    val expected = Some("oai:michigan:ochr:oai:digital.library.wayne.edu:ochr:oai:demo.ptfs.com:library10_lib/87490")
+    assert(extractor.originalId(xml) == expected)
+  }
 
   it should "extract the correct dates for 2007" in {
     val xml =

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MichiganMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MichiganMappingTest.scala
@@ -25,6 +25,53 @@ class MichiganMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.originalId(xml) == expected)
   }
 
+  it should "extract the correct collection title" in {
+    val expected = Seq("Veterans History Project interviews, RHC-27").map(nameOnlyCollection)
+    assert(extractor.collection(xml) == expected)
+  }
+
+  it should "extract correct contributor" in {
+    val expected = Seq("Boston Cooking School (Boston, Mass.)").map(nameOnlyAgent)
+    assert(extractor.contributor(xml) == expected)
+  }
+
+  it should "extract the correct creators when roleTerm is 'creator'" in {
+    val expected = Seq("City of Lansing", "City Planning Division Ingells, Norris").map(nameOnlyAgent)
+    assert(extractor.creator(xml) == expected)
+  }
+
+  it should "extract the correct creator when roleTerm is blank" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <mods:name>
+              <mods:namePart>City of Lansing</mods:namePart>
+            </mods:name>
+          </mods>
+        </metadata>
+      </record>
+    val expected = Seq("City of Lansing").map(nameOnlyAgent)
+    assert(extractor.creator(Document(xml)) == expected)
+  }
+
+  it should "not extract creator from the subject/name/namePart field" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <mods:subject>
+              <mods:name>
+                <mods:namePart>Cats</mods:namePart>
+              </mods:name>
+            </mods:subject>
+          </mods>
+        </metadata>
+      </record>
+
+    assert(extractor.creator(Document(xml)) == Seq())
+  }
+
   it should "extract the correct dates for 2007" in {
     val xml =
       <record>
@@ -98,5 +145,218 @@ class MichiganMappingTest extends FlatSpec with BeforeAndAfter {
 
     val expected = Seq(stringOnlyTimeSpan("2003"), stringOnlyTimeSpan("2005"))
     assert(expected === extractor.date(Document(xml)))
+  }
+
+  it should "extract the correct description from abstract field" in {
+    val expected = Seq( "Avon Township Offices, located on the northwest corner of Fourth and Pine Streets.")
+    assert(extractor.description(xml) === expected)
+  }
+
+  it should "extract the correct description from note field" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <mods:note>Oakland County Historical Resources hosts digitized materials.</mods:note>
+          </mods>
+        </metadata>
+      </record>
+
+    val expected = Seq("Oakland County Historical Resources hosts digitized materials.")
+    assert(extractor.description(Document(xml)) == expected)
+  }
+
+  it should "extract the correct extent" in {
+    val expected = Seq("1 Postcard (3.5\" x 5.5\")")
+    assert(extractor.extent(xml) == expected)
+  }
+
+  it should "extract the correct format from physicalDescription field" in {
+    val expected = Seq("Postcard")
+    assert(extractor.format(xml) === expected)
+  }
+
+  it should "extract the correct format from genre field" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <mods:genre authority="dct">still image</mods:genre>
+          </mods>
+        </metadata>
+      </record>
+
+    val expected = Seq("still image")
+    assert(extractor.format(Document(xml)) == expected)
+  }
+
+  it should "not extract genre from the subject/genre field" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <mods:subject>
+              <mods:genre>Cows</mods:genre>
+            </mods:subject>
+          </mods>
+        </metadata>
+      </record>
+
+    assert(extractor.format(Document(xml)) == Seq())
+  }
+
+  it should "extract the correct identifier" in {
+    val expected = Seq("MICH1306517")
+    assert(extractor.identifier(xml) == expected)
+  }
+
+  it should "extract the correct language" in {
+    val expected = Seq("eng").map(nameOnlyConcept)
+    assert(extractor.language(xml) == expected)
+  }
+
+  it should "extract the correct place" in {
+    val expected = Seq("407 Pine Street", "Rochester").map(nameOnlyPlace)
+    assert(extractor.place(xml) == expected)
+  }
+
+  it should "extract the correct publisher" in {
+    val expected = Seq("Grand Valley State University. University Libraries.").map(nameOnlyAgent)
+    assert(extractor.publisher(xml) == expected)
+  }
+
+  it should "extract the correct rights" in {
+    val expected = Seq("Users can cite and link to these materials without obtaining permission.")
+    assert(extractor.rights(xml) == expected)
+  }
+
+  it should "extract the correct subject from subject field" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <mods:subject>Dogs</mods:subject>
+          </mods>
+        </metadata>
+      </record>
+
+    val expected = Seq("Dogs").map(nameOnlyConcept)
+    assert(extractor.subject(Document(xml)) == expected)
+  }
+
+  it should "extract the correct subject from subject/topic field" in {
+    val expected = Seq("Government").map(nameOnlyConcept)
+    assert(extractor.subject(xml) == expected)
+  }
+
+  it should "extract the correct subject from subject/name/namePart field" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <mods:subject>
+              <mods:name>
+                <mods:namePart>Cats</mods:namePart>
+              </mods:name>
+            </mods:subject>
+          </mods>
+        </metadata>
+      </record>
+
+    val expected = Seq("Cats").map(nameOnlyConcept)
+    assert(extractor.subject(Document(xml)) == expected)
+  }
+
+  it should "extract the correct subject from subject/genre field" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <mods:subject>
+              <mods:genre>Cows</mods:genre>
+            </mods:subject>
+          </mods>
+        </metadata>
+      </record>
+
+    val expected = Seq("Cows").map(nameOnlyConcept)
+    assert(extractor.subject(Document(xml)) == expected)
+  }
+
+  it should "extract the correct subject from subject/titleInfo/title field" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <mods:subject>
+              <mods:titleInfo>
+                <mods:title>Birds</mods:title>
+              </mods:titleInfo>
+            </mods:subject>
+          </mods>
+        </metadata>
+      </record>
+
+    val expected = Seq("Birds").map(nameOnlyConcept)
+    assert(extractor.subject(Document(xml)) == expected)
+  }
+
+  it should "extract the correct temporal" in {
+    val expected = Seq("1967-2011").map(stringOnlyTimeSpan)
+    assert(extractor.temporal(xml) == expected)
+  }
+
+  it should "extract the correct title" in {
+    val expected = Seq("Avon Township Offices")
+    assert(extractor.title(xml) == expected)
+  }
+
+  it should "not extract the title from the subject/titleInfo/title field" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <mods:subject>
+              <mods:titleInfo>
+                <mods:title>Birds</mods:title>
+              </mods:titleInfo>
+            </mods:subject>
+          </mods>
+        </metadata>
+      </record>
+
+    assert(extractor.title(Document(xml)) == Seq())
+  }
+
+  it should "extract the correct type" in {
+    val expected = Seq("still image")
+    assert(extractor.`type`(xml) == expected)
+  }
+
+  it should "create the correct DPLA Uri" in {
+    val expected = Some(new URI("http://dp.la/api/items/dfcebfc0d4ce4e47845dd76dc5a86b23"))
+    assert(extractor.dplaUri(xml) == expected)
+  }
+
+  it should "extract the correct dataProvider" in {
+    val expected = Seq("Oakland County Historical Resources").map(nameOnlyAgent)
+    assert(extractor.dataProvider(xml) == expected)
+  }
+
+  it should "extract the correct intermediateProvider" in {
+    val expected = Some("Rochester Hills Public Library").map(nameOnlyAgent)
+    assert(extractor.intermediateProvider(xml) == expected)
+  }
+
+  it should "extract the correct isShownAt" in {
+    val expected = Seq("http://oaklandcountyhistory.org/knowvation/app/consolidatedSearch/#autologin/guest/lb_document_id=87490")
+      .map(stringOnlyWebResource)
+    assert(extractor.isShownAt(xml) == expected)
+  }
+
+  it should "extract the correct preview" in {
+    val expected = Seq("http://oaklandcountyhistory.org/awweb/pdfopener?fp=auto&umb=87490")
+      .map(stringOnlyWebResource)
+    assert(extractor.preview(xml) == expected)
   }
 }

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MichiganMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MichiganMappingTest.scala
@@ -1,0 +1,96 @@
+package dpla.ingestion3.mappers.providers
+
+import dpla.ingestion3.mappers.utils.Document
+import dpla.ingestion3.messages.{IngestMessage, MessageCollector}
+import dpla.ingestion3.model._
+import dpla.ingestion3.utils.FlatFileIO
+import org.scalatest.{BeforeAndAfter, FlatSpec}
+
+import scala.xml.{NodeSeq, XML}
+
+class MichiganMappingTest extends FlatSpec with BeforeAndAfter {
+
+  implicit val msgCollector: MessageCollector[IngestMessage] = new MessageCollector[IngestMessage]
+  val shortName = "mi"
+  val xmlString: String = new FlatFileIO().readFileAsString("/oklahoma.xml")
+  val xml: Document[NodeSeq] = Document(XML.loadString(xmlString))
+  val extractor = new MichiganMapping
+
+  it should "use the provider shortname in minting IDs " in
+    assert(extractor.useProviderName())
+
+  it should "extract the correct dates for 2007" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <originInfo>
+                <dateCreated>2007</dateCreated>
+            </originInfo>
+        </mods>
+      </metadata>
+    </record>
+
+    val expected = Seq(stringOnlyTimeSpan("2007"))
+    assert(expected === extractor.date(Document(xml)))
+  }
+
+  it should "extract the correct dates for start=2007 end=2008" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <originInfo>
+                <dateIssued point="start">2007</dateIssued>
+                <dateIssued point="end">2008</dateIssued>
+            </originInfo>
+        </mods>
+      </metadata>
+    </record>
+
+    val expected = Seq(
+      EdmTimeSpan(originalSourceDate = Some("2007-2008"),
+        begin = Some("2007"),
+        end = Some("2008")
+      )
+    )
+    assert(expected === extractor.date(Document(xml)))
+  }
+
+  it should "extract the correct dates when dateCreated, dateIssued and dateIssued start/end exist" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <originInfo>
+                <dateCreated>2003</dateCreated>
+                <dateIssued>2004</dateIssued>
+                <dateIssued point="start">2007</dateIssued>
+                <dateIssued point="end">2008</dateIssued>
+            </originInfo>
+        </mods>
+      </metadata>
+    </record>
+
+    val expected = Seq(stringOnlyTimeSpan("2003"))
+    assert(expected === extractor.date(Document(xml)))
+  }
+
+  it should "extract the correct dates when dateCreated and dateIssued exist" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <originInfo>
+                <dateCreated>2003</dateCreated>
+                <dateCreated>2005</dateCreated>
+                <dateIssued>2004</dateIssued>
+            </originInfo>
+        </mods>
+      </metadata>
+    </record>
+
+    val expected = Seq(stringOnlyTimeSpan("2003"), stringOnlyTimeSpan("2005"))
+    assert(expected === extractor.date(Document(xml)))
+  }
+}


### PR DESCRIPTION
This adds a Michigan mapping.  This has been tested locally by running just the mapping.

There are two `TODO` statements, one of which requires follow-up from a hub, and the other may just need confirmation from the reviewer.
