### PR TITLE
VT Mapping changes 

### DIFF
--- a/src/main/resources/formats/vt.csv
+++ b/src/main/resources/formats/vt.csv
@@ -1,0 +1,28 @@
+# DPLA specific IMT/MIME values to remove from the format field
+# These values came from the VT mapping
+Archive BitTorrent
+Metadata
+JPEG Thumb
+Abbyy GZ
+Djvu XML
+Scandata
+Single Page Processed JP2 ZIP
+DjVuTXT
+Ogg Vorbis
+VBR MP3
+Image/tiff : text/Color: 24 bits; 800 ppi, Microtek ScanMaker 9800XL.
+Image Container PDF
+Additional Text PDF
+Animated GIF
+PNG
+N/a
+O
+EPUB
+Born digital
+Quality=8-bit grayscale, 150 ppi
+No
+Yes
+DjVu
+Essentia Low GZ
+Flac
+WAVE

--- a/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
@@ -43,9 +43,9 @@ class EnrichmentDriver(conf: i3Conf) extends Serializable {
 
     enriched.copy(
       sourceResource = enriched.sourceResource.copy(
-        date = enriched.sourceResource.date.map(date => dateEnrichment.generateBeginEnd(date.originalSourceDate)),
-        language = enriched.sourceResource.language.map(languageEnrichment.enrichLanguage),
-        `type` = enriched.sourceResource.`type`.flatMap(typeEnrichment.enrich)
+        date = enriched.sourceResource.date.map(date => dateEnrichment.generateBeginEnd(date.originalSourceDate)).distinct,
+        language = enriched.sourceResource.language.map(languageEnrichment.enrichLanguage).distinct,
+        `type` = enriched.sourceResource.`type`.flatMap(typeEnrichment.enrich).distinct
         //, place = enriched.sourceResource.place.map(p => spatialEnrichment.enrich(p))
       )
     )

--- a/src/main/scala/dpla/ingestion3/enrichments/normalizations/filters/DigitalSurrogateBlockList.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/normalizations/filters/DigitalSurrogateBlockList.scala
@@ -18,6 +18,7 @@ object DigitalSurrogateBlockList extends FilterList {
     "/formats/in.csv",
     "/formats/ohio.csv",
     "/formats/p2p.csv",
+    "/formats/vt.csv",
     "/formats/iana-imt-types.csv"
   )
 }

--- a/src/test/scala/dpla/ingestion3/mappers/providers/VtMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/VtMappingTest.scala
@@ -46,7 +46,7 @@ class VtMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.description(xml) == Seq("Box 1, Cylinder 7"))
 
   it should "extract the correct format" in {
-    val expected = Seq("Archive BitTorrent", "JPEG Thumb", "Metadata", "Spectrogram")
+    val expected = Seq("Spectrogram")
     assert(extractor.format(xml) === expected)
   }
 

--- a/src/test/scala/dpla/ingestion3/mappers/providers/VtMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/VtMappingTest.scala
@@ -28,7 +28,7 @@ class VtMappingTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "extract the correct contributors" in {
-    val expected = Seq("Wilson, Douglas B.;").map(nameOnlyAgent)
+    val expected = Seq("Wilson, Douglas B.").map(nameOnlyAgent)
     assert(extractor.contributor(xml) == expected)
   }
 


### PR DESCRIPTION
Adds value filters, split on delimiters to mapping
Fixup tests 
Adds `distinct` call on all enrichments to remove duplicate values 