### PR TITLE
Maryland migration

### DIFF
--- a/src/main/scala/dpla/ingestion3/entries/reports/ReporterMain.scala
+++ b/src/main/scala/dpla/ingestion3/entries/reports/ReporterMain.scala
@@ -25,6 +25,7 @@ object ReporterMain {
     "isShownAt",
     "edmRights",
     "intermediateProvider",
+    "preview",
     "sourceResource.collection.title",
     "sourceResource.contributor.name",
     "sourceResource.creator.name",

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MarylandMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MarylandMapping.scala
@@ -1,0 +1,74 @@
+package dpla.ingestion3.mappers.providers
+
+import dpla.ingestion3.enrichments.normalizations.StringNormalizationUtils._
+import dpla.ingestion3.mappers.utils.{Document, XmlMapping, XmlExtractor}
+import dpla.ingestion3.model.DplaMapData._
+import dpla.ingestion3.model._
+import dpla.ingestion3.utils.Utils
+import org.json4s.JValue
+import org.json4s.JsonDSL._
+
+import scala.xml._
+
+
+class MarylandMapping extends XmlMapping with XmlExtractor {
+
+  // ID minting functions
+  override def useProviderName: Boolean = true
+
+  override def getProviderName: String = "maryland"
+
+  override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] = ???
+
+  // SourceResource mapping
+
+  override def collection(data: Document[NodeSeq]): ZeroToMany[DcmiTypeCollection] = ???
+
+  override def contributor(data: Document[NodeSeq]): ZeroToMany[EdmAgent] = ???
+
+  override def creator(data: Document[NodeSeq]): ZeroToMany[EdmAgent] = ???
+
+  override def date(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] = ???
+
+  override def description(data: Document[NodeSeq]): ZeroToMany[String] = ???
+
+  override def format(data: Document[NodeSeq]): ZeroToMany[String] = ???
+
+  override def language(data: Document[NodeSeq]): ZeroToMany[SkosConcept] = ???
+
+  override def publisher(data: Document[NodeSeq]): ZeroToMany[EdmAgent] = ???
+
+  override def rights(data: Document[NodeSeq]): AtLeastOne[String] = ??? // NOT IN I1
+
+  override def subject(data: Document[NodeSeq]): ZeroToMany[SkosConcept] = ???
+
+  override def temporal(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] = ???
+
+  override def title(data: Document[NodeSeq]): ZeroToMany[String] = ???
+
+  override def `type`(data: Document[NodeSeq]): ZeroToMany[String] = ???
+
+  // OreAggregation
+  override def dplaUri(data: Document[NodeSeq]): ZeroToOne[URI] = mintDplaItemUri(data)
+
+  override def dataProvider(data: Document[NodeSeq]): ZeroToMany[EdmAgent] = ???
+
+  override def edmRights(data: Document[NodeSeq]): ZeroToMany[URI] = ???
+
+  override def isShownAt(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] = ???
+
+  override def originalRecord(data: Document[NodeSeq]): ExactlyOne[String] = Utils.formatXml(data)
+
+  override def preview(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] = ???
+
+  override def provider(data: Document[NodeSeq]): ExactlyOne[EdmAgent] = agent
+
+  override def sidecar(data: Document[NodeSeq]): JValue =
+    ("prehashId" -> buildProviderBaseId()(data)) ~ ("dplaId" -> mintDplaId(data))
+
+  // Helper method
+  def agent = EdmAgent(
+    name = Some("Digital Maryland"),
+    uri = Some(URI("http://dp.la/api/contributor/maryland"))
+  )
+}

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MarylandMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MarylandMapping.scala
@@ -10,7 +10,6 @@ import org.json4s.JsonDSL._
 
 import scala.xml._
 
-
 class MarylandMapping extends XmlMapping with XmlExtractor {
 
   // ID minting functions
@@ -33,7 +32,6 @@ class MarylandMapping extends XmlMapping with XmlExtractor {
       .flatMap(_.splitAtDelimiter(";"))
       .map(nameOnlyAgent)
 
-  // TODO: VALIDATE
   override def date(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] =
     extractStrings(data \ "metadata" \\ "date")
       .flatMap(_.splitAtDelimiter(";"))
@@ -41,12 +39,10 @@ class MarylandMapping extends XmlMapping with XmlExtractor {
 
   override def description(data: Document[NodeSeq]): ZeroToMany[String] =
     extractStrings(data \ "metadata" \\ "description")
-      .map(_.stripDblQuotes)
 
-  // TODO: VALIDATE
   override def format(data: Document[NodeSeq]): ZeroToMany[String] =
     extractStrings(data \ "metadata" \\ "format")
-      .flatMap(_.splitAtDelimiter(";"))
+      .map(_.stripSuffix(";"))
 
   override def language(data: Document[NodeSeq]): ZeroToMany[SkosConcept] =
     extractStrings(data \ "metadata" \\ "language")
@@ -55,10 +51,9 @@ class MarylandMapping extends XmlMapping with XmlExtractor {
 
   override def publisher(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
     extractStrings(data \ "metadata" \\ "publisher")
-      .map(_.cleanupEndingPunctuation)
+      .flatMap(_.splitAtDelimiter(";"))
       .map(nameOnlyAgent)
 
-  // TODO: VALIDATE
   override def subject(data: Document[NodeSeq]): ZeroToMany[SkosConcept] =
     extractStrings(data \ "metadata" \\ "subject")
       .flatMap(_.splitAtDelimiter(";"))
@@ -90,7 +85,6 @@ class MarylandMapping extends XmlMapping with XmlExtractor {
     extractStrings(data \ "metadata" \\ "rights")
       .map(URI)
 
-  // TODO: VALIDATE
   override def isShownAt(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
     extractStrings(data \ "metadata" \\ "identifier")
       .map(stringOnlyWebResource)
@@ -98,7 +92,6 @@ class MarylandMapping extends XmlMapping with XmlExtractor {
 
   override def originalRecord(data: Document[NodeSeq]): ExactlyOne[String] = Utils.formatXml(data)
 
-  // TODO: VALIDATE
   override def preview(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] = {
     val url: Option[String] = extractStrings(data \ "metadata" \\ "identifier").lift(1) // get second instance
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MarylandMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MarylandMapping.scala
@@ -23,9 +23,6 @@ class MarylandMapping extends XmlMapping with XmlExtractor {
 
   // SourceResource mapping
 
-  // Not in harvested data
-//  override def collection(data: Document[NodeSeq]): ZeroToMany[DcmiTypeCollection] = ???
-
   override def contributor(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
     extractStrings(data \ "metadata" \\ "contributor")
       .flatMap(_.splitAtDelimiter(";"))
@@ -36,15 +33,20 @@ class MarylandMapping extends XmlMapping with XmlExtractor {
       .flatMap(_.splitAtDelimiter(";"))
       .map(nameOnlyAgent)
 
+  // TODO: VALIDATE
   override def date(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] =
     extractStrings(data \ "metadata" \\ "date")
+      .flatMap(_.splitAtDelimiter(";"))
       .map(stringOnlyTimeSpan)
 
   override def description(data: Document[NodeSeq]): ZeroToMany[String] =
     extractStrings(data \ "metadata" \\ "description")
+      .map(_.stripDblQuotes)
 
+  // TODO: VALIDATE
   override def format(data: Document[NodeSeq]): ZeroToMany[String] =
     extractStrings(data \ "metadata" \\ "format")
+      .flatMap(_.splitAtDelimiter(";"))
 
   override def language(data: Document[NodeSeq]): ZeroToMany[SkosConcept] =
     extractStrings(data \ "metadata" \\ "language")
@@ -53,9 +55,10 @@ class MarylandMapping extends XmlMapping with XmlExtractor {
 
   override def publisher(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
     extractStrings(data \ "metadata" \\ "publisher")
-      .flatMap(_.splitAtDelimiter(";"))
+      .map(_.cleanupEndingPunctuation)
       .map(nameOnlyAgent)
 
+  // TODO: VALIDATE
   override def subject(data: Document[NodeSeq]): ZeroToMany[SkosConcept] =
     extractStrings(data \ "metadata" \\ "subject")
       .flatMap(_.splitAtDelimiter(";"))
@@ -68,6 +71,7 @@ class MarylandMapping extends XmlMapping with XmlExtractor {
 
   override def title(data: Document[NodeSeq]): ZeroToMany[String] =
     extractStrings(data \ "metadata" \\ "title")
+      .map(_.stripSuffix("."))
 
   override def `type`(data: Document[NodeSeq]): ZeroToMany[String] =
     extractStrings(data \ "metadata" \\ "type")
@@ -86,6 +90,7 @@ class MarylandMapping extends XmlMapping with XmlExtractor {
     extractStrings(data \ "metadata" \\ "rights")
       .map(URI)
 
+  // TODO: VALIDATE
   override def isShownAt(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
     extractStrings(data \ "metadata" \\ "identifier")
       .map(stringOnlyWebResource)
@@ -93,6 +98,7 @@ class MarylandMapping extends XmlMapping with XmlExtractor {
 
   override def originalRecord(data: Document[NodeSeq]): ExactlyOne[String] = Utils.formatXml(data)
 
+  // TODO: VALIDATE
   override def preview(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] = {
     val url: Option[String] = extractStrings(data \ "metadata" \\ "identifier").lift(1) // get second instance
 

--- a/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
+++ b/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
@@ -117,6 +117,16 @@ class LocProfile extends JsonProfile {
 }
 
 /**
+  * Digital Maryland
+  */
+class MarylandProfile extends XmlProfile {
+  type Mapping = MarylandMapping
+
+  override def getHarvester: Class[_ <: Harvester] = classOf[MdlHarvester]
+  override def getMapping = new MarylandMapping
+}
+
+/**
   * Minnesota Digital Library
   */
 class MdlProfile extends JsonProfile {

--- a/src/main/scala/dpla/ingestion3/reports/PropertyValueReport.scala
+++ b/src/main/scala/dpla/ingestion3/reports/PropertyValueReport.scala
@@ -86,10 +86,17 @@ class PropertyValueReport (
           PropertyValueRpt(
             dplaUri = oreAggregation.dplaUri.toString,
             localUri = oreAggregation.isShownAt.uri.toString,
-            value = extractValue(Seq(oreAggregation.isShownAt))
+            value = extractValue(Seq(oreAggregation.isShownAt.uri.toString))
           )
         })
-
+      case "preview" =>
+        ds.map(oreAggregation => {
+          PropertyValueRpt(
+            dplaUri = oreAggregation.dplaUri.toString,
+            localUri = oreAggregation.isShownAt.uri.toString,
+            value = extractValue(Seq(oreAggregation.preview.map(_.uri.toString)))
+          )
+        })
       case "sourceResource.alternateTitle" =>
         ds.map(oreAggregation => {
           PropertyValueRpt(

--- a/src/main/scala/dpla/ingestion3/reports/PropertyValueReport.scala
+++ b/src/main/scala/dpla/ingestion3/reports/PropertyValueReport.scala
@@ -94,7 +94,7 @@ class PropertyValueReport (
           PropertyValueRpt(
             dplaUri = oreAggregation.dplaUri.toString,
             localUri = oreAggregation.isShownAt.uri.toString,
-            value = extractValue(Seq(oreAggregation.preview.map(_.uri.toString)))
+            value = extractValue(oreAggregation.preview.map(_.uri.toString).toSeq)
           )
         })
       case "sourceResource.alternateTitle" =>

--- a/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
+++ b/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
@@ -54,6 +54,7 @@ object ProviderRegistry {
     "ia" -> Register(profile = new IaProfile),
     "in" -> Register(profile = new InProfile),
     "lc" -> Register(profile = new LocProfile),
+    "maryland" -> Register(profile = new MarylandProfile),
     "mi" -> Register(profile = new MiProfile),
     "minnesota" -> Register(profile = new MdlProfile),
     "missouri" -> Register(profile = new MissouriProfile),

--- a/src/test/resources/maryland.xml
+++ b/src/test/resources/maryland.xml
@@ -1,0 +1,22 @@
+<record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.openarchives.org/OAI/2.0/">
+    <header>
+        <identifier>oai:collections.digitalmaryland.org:mamo/29817</identifier>
+        <datestamp>2017-11-21</datestamp>
+        <setSpec>mamo</setSpec></header>
+    <metadata>
+        <oai_qdc:qualifieddc xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+            <dc:identifier>mamo036830</dc:identifier>
+            <dc:title>Lieutenant Governor Anthony Brown at the Winning with Asthma Program Kick Off Event</dc:title>
+            <dc:creator>O'Dell, Mark;</dc:creator>
+            <dc:subject>Brown, Anthony G., 1961-; Governors--Maryland; Maryland--Politics and government; Asthma;</dc:subject>
+            <dc:description>Photograph of Lieutenant Governor Anthony Brown at the Winning with Asthma Program Kick Off Event on October 21, 2008.</dc:description>
+            <dc:source>Maryland State Archives;</dc:source>
+            <dc:date>2008-10-21</dc:date>
+            <dc:type>Image;</dc:type>
+            <dc:format>Color digital photograph/jpeg </dc:format>
+            <dc:rights>http://rightsstatements.org/vocab/NoC-OKLR/1.0/ </dc:rights>
+            <dcterms:accessRights>This work is licensed under a Creative Commons Attribution-NoDerivs 3.0 Unported License. When this material is used, in whole or in part, proper citation and credit must be attributed to the Maryland State Archives. For more information go to http://histpics.msa.maryland.gov/pages/Search.aspx </dcterms:accessRights>
+            <dc:identifier>http://collections.digitalmaryland.org/cdm/ref/collection/mamo/id/29817</dc:identifier>
+        </oai_qdc:qualifieddc>
+    </metadata>
+</record>

--- a/src/test/resources/maryland.xml
+++ b/src/test/resources/maryland.xml
@@ -7,16 +7,20 @@
         <oai_qdc:qualifieddc xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
             <dc:identifier>mamo036830</dc:identifier>
             <dc:title>Lieutenant Governor Anthony Brown at the Winning with Asthma Program Kick Off Event</dc:title>
+            <dc:contributor>Hayden, Edwin Parsons, 1811-1850; Jessop, Charles; Jessop, William; Shipley, Nathan;</dc:contributor>
             <dc:creator>O'Dell, Mark;</dc:creator>
             <dc:subject>Brown, Anthony G., 1961-; Governors--Maryland; Maryland--Politics and government; Asthma;</dc:subject>
             <dc:description>Photograph of Lieutenant Governor Anthony Brown at the Winning with Asthma Program Kick Off Event on October 21, 2008.</dc:description>
-            <dc:source>Maryland State Archives;</dc:source>
+            <dc:source>Maryland State Archives; foo</dc:source>
             <dc:date>2008-10-21</dc:date>
             <dc:type>Image;</dc:type>
             <dc:format>Color digital photograph/jpeg </dc:format>
             <dc:rights>http://rightsstatements.org/vocab/NoC-OKLR/1.0/ </dc:rights>
             <dcterms:accessRights>This work is licensed under a Creative Commons Attribution-NoDerivs 3.0 Unported License. When this material is used, in whole or in part, proper citation and credit must be attributed to the Maryland State Archives. For more information go to http://histpics.msa.maryland.gov/pages/Search.aspx </dcterms:accessRights>
             <dc:identifier>http://collections.digitalmaryland.org/cdm/ref/collection/mamo/id/29817</dc:identifier>
+            <dc:publisher>Alfred A. Knopf, Inc.;</dc:publisher>
+            <dcterms:temporal>1970-1979;</dcterms:temporal>
+            <dc:language>English;</dc:language>
         </oai_qdc:qualifieddc>
     </metadata>
 </record>

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MarylandMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MarylandMappingTest.scala
@@ -46,7 +46,7 @@ class MarylandMappingTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "extract the correct format" in {
-    val expected = Seq("Color digital photograph/jpeg ")
+    val expected = Seq("Color digital photograph/jpeg")
     assert(extractor.format(xml) == expected)
   }
 

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MarylandMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MarylandMappingTest.scala
@@ -20,98 +20,89 @@ class MarylandMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.useProviderName)
 
   it should "extract the correct original identifier " in {
-    val expected = Some("???")
+    val expected = Some("oai:collections.digitalmaryland.org:mamo/29817")
     assert(extractor.originalId(xml) === expected)
   }
 
-  it should "extract the correct collection titles" in {
-    val expected = Seq("???")
-      .map(nameOnlyCollection)
-    assert(extractor.collection(xml) === expected)
-  }
-
   it should "extract the correct contributor" in {
-    val expected = Seq("???").map(nameOnlyAgent)
+    val expected = Seq("Hayden, Edwin Parsons, 1811-1850", "Jessop, Charles", "Jessop, William", "Shipley, Nathan")
+      .map(nameOnlyAgent)
     assert(extractor.contributor(xml) == expected)
   }
 
   it should "extract the correct creator" in {
-    val expected = Seq("???").map(nameOnlyAgent)
+    val expected = Seq("O'Dell, Mark").map(nameOnlyAgent)
     assert(extractor.creator(xml) == expected)
   }
 
   it should "extract the correct date" in {
-    val expected = Seq("???").map(stringOnlyTimeSpan)
+    val expected = Seq("2008-10-21").map(stringOnlyTimeSpan)
     assert(extractor.date(xml) === expected)
   }
 
   it should "extract the correct description" in {
-    val expected = Seq("???")
+    val expected = Seq("Photograph of Lieutenant Governor Anthony Brown at the Winning with Asthma Program Kick Off Event on October 21, 2008.")
     assert(extractor.description(xml) == expected)
   }
 
-  it should "extract the correct extent" in {
-    val expected = Seq("???")
-    assert(extractor.extent(xml) == expected)
-  }
-
   it should "extract the correct format" in {
-    val expected = Seq("???")
+    val expected = Seq("Color digital photograph/jpeg ")
     assert(extractor.format(xml) == expected)
   }
 
   it should "extract the correct language" in {
-    val expected = Seq("???").map(nameOnlyConcept)
+    val expected = Seq("English").map(nameOnlyConcept)
     assert(extractor.language(xml) == expected)
   }
 
   it should "extract the correct publisher" in {
-    val expected = Seq("???").map(nameOnlyAgent)
+    val expected = Seq("Alfred A. Knopf, Inc.").map(nameOnlyAgent)
     assert(extractor.publisher(xml) === expected)
   }
 
   it should "extract the correct subjects" in {
-    val expected = Seq("???").map(nameOnlyConcept)
+    val expected = Seq("Brown, Anthony G., 1961-", "Governors--Maryland", "Maryland--Politics and government", "Asthma")
+      .map(nameOnlyConcept)
     assert(extractor.subject(xml) === expected)
   }
 
   it should "extract the correct temporal" in {
-    val expected = Seq("???").map(stringOnlyTimeSpan)
+    val expected = Seq("1970-1979").map(stringOnlyTimeSpan)
     assert(extractor.temporal(xml) === expected)
   }
 
-  it should "extract the correct titles" in {
-    val expected = Seq("???")
+  it should "extract the correct title" in {
+    val expected = Seq("Lieutenant Governor Anthony Brown at the Winning with Asthma Program Kick Off Event")
     assert(extractor.title(xml) === expected)
   }
 
   it should "extract the correct type" in {
-    val expected = Seq("???")
+    val expected = Seq("Image")
     assert(extractor.`type`(xml) === expected)
   }
 
   it should "extract the correct dataProvider" in {
-    val expected = Seq(nameOnlyAgent("???"))
+    val expected = Seq(nameOnlyAgent("Maryland State Archives"))
     assert(extractor.dataProvider(xml) === expected)
   }
 
   it should "extract the correct edmRights" in {
-    val expected = Seq(URI("???"))
+    val expected = Seq(URI("http://rightsstatements.org/vocab/NoC-OKLR/1.0/ "))
     assert(extractor.edmRights(xml) === expected)
   }
 
   it should "extract the correct isShownAt" in {
-    val expected = Seq(uriOnlyWebResource(URI("???")))
+    val expected = Seq(stringOnlyWebResource("http://collections.digitalmaryland.org/cdm/ref/collection/mamo/id/29817"))
     assert(extractor.isShownAt(xml) === expected)
   }
 
   it should "extract the correct preview" in {
-    val expected = Seq("???").map(stringOnlyWebResource)
+    val expected = Seq(stringOnlyWebResource("http://webconfig.digitalmaryland.org/utils/getthumbnail/collection/mamo/id/29817"))
     assert(extractor.preview(xml) === expected)
   }
 
   it should "create the correct DPLA URI" in {
-    val expected = Some(URI("???"))
+    val expected = Some(URI("http://dp.la/api/items/5db1d7b6c61b021fadcffdca899a4d69"))
     assert(extractor.dplaUri(xml) === expected)
   }
 }

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MarylandMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MarylandMappingTest.scala
@@ -46,7 +46,7 @@ class MarylandMappingTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "extract the correct format" in {
-    val expected = Seq("Color digital photograph/jpeg")
+    val expected = Seq("Color digital photograph/jpeg ")
     assert(extractor.format(xml) == expected)
   }
 

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MarylandMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MarylandMappingTest.scala
@@ -1,0 +1,117 @@
+package dpla.ingestion3.mappers.providers
+
+import dpla.ingestion3.mappers.utils.Document
+import dpla.ingestion3.messages.{IngestMessage, MessageCollector}
+import dpla.ingestion3.model._
+import dpla.ingestion3.utils.FlatFileIO
+import org.scalatest.{BeforeAndAfter, FlatSpec}
+
+import scala.xml.{NodeSeq, XML}
+
+class MarylandMappingTest extends FlatSpec with BeforeAndAfter {
+
+  implicit val msgCollector: MessageCollector[IngestMessage] = new MessageCollector[IngestMessage]
+  val shortName = "maine"
+  val xmlString: String = new FlatFileIO().readFileAsString("/maryland.xml")
+  val xml: Document[NodeSeq] = Document(XML.loadString(xmlString))
+  val extractor = new MarylandMapping
+
+  it should "use the provider shortname in minting IDs " in
+    assert(extractor.useProviderName)
+
+  it should "extract the correct original identifier " in {
+    val expected = Some("???")
+    assert(extractor.originalId(xml) === expected)
+  }
+
+  it should "extract the correct collection titles" in {
+    val expected = Seq("???")
+      .map(nameOnlyCollection)
+    assert(extractor.collection(xml) === expected)
+  }
+
+  it should "extract the correct contributor" in {
+    val expected = Seq("???").map(nameOnlyAgent)
+    assert(extractor.contributor(xml) == expected)
+  }
+
+  it should "extract the correct creator" in {
+    val expected = Seq("???").map(nameOnlyAgent)
+    assert(extractor.creator(xml) == expected)
+  }
+
+  it should "extract the correct date" in {
+    val expected = Seq("???").map(stringOnlyTimeSpan)
+    assert(extractor.date(xml) === expected)
+  }
+
+  it should "extract the correct description" in {
+    val expected = Seq("???")
+    assert(extractor.description(xml) == expected)
+  }
+
+  it should "extract the correct extent" in {
+    val expected = Seq("???")
+    assert(extractor.extent(xml) == expected)
+  }
+
+  it should "extract the correct format" in {
+    val expected = Seq("???")
+    assert(extractor.format(xml) == expected)
+  }
+
+  it should "extract the correct language" in {
+    val expected = Seq("???").map(nameOnlyConcept)
+    assert(extractor.language(xml) == expected)
+  }
+
+  it should "extract the correct publisher" in {
+    val expected = Seq("???").map(nameOnlyAgent)
+    assert(extractor.publisher(xml) === expected)
+  }
+
+  it should "extract the correct subjects" in {
+    val expected = Seq("???").map(nameOnlyConcept)
+    assert(extractor.subject(xml) === expected)
+  }
+
+  it should "extract the correct temporal" in {
+    val expected = Seq("???").map(stringOnlyTimeSpan)
+    assert(extractor.temporal(xml) === expected)
+  }
+
+  it should "extract the correct titles" in {
+    val expected = Seq("???")
+    assert(extractor.title(xml) === expected)
+  }
+
+  it should "extract the correct type" in {
+    val expected = Seq("???")
+    assert(extractor.`type`(xml) === expected)
+  }
+
+  it should "extract the correct dataProvider" in {
+    val expected = Seq(nameOnlyAgent("???"))
+    assert(extractor.dataProvider(xml) === expected)
+  }
+
+  it should "extract the correct edmRights" in {
+    val expected = Seq(URI("???"))
+    assert(extractor.edmRights(xml) === expected)
+  }
+
+  it should "extract the correct isShownAt" in {
+    val expected = Seq(uriOnlyWebResource(URI("???")))
+    assert(extractor.isShownAt(xml) === expected)
+  }
+
+  it should "extract the correct preview" in {
+    val expected = Seq("???").map(stringOnlyWebResource)
+    assert(extractor.preview(xml) === expected)
+  }
+
+  it should "create the correct DPLA URI" in {
+    val expected = Some(URI("???"))
+    assert(extractor.dplaUri(xml) === expected)
+  }
+}


### PR DESCRIPTION
This adds a mapping for Maryland, migrated from ingestion1.  The mapping has been tested thoroughly with automated reports.  A property value report for `preview` is added to assist with automated testing. The property value report for `isShownAt` is fixed.

One significant change from ingestion1 is that there is no collection mapping.  This is because there doesn't appear to be collection data Maryland's records anymore.  None of the harvested records contained any collection data.