### PR TITLE
IL mapping fixes

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/IllinoisMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/IllinoisMapping.scala
@@ -25,7 +25,7 @@ class IllinoisMapping extends XmlMapping with XmlExtractor with IngestMessageTem
   override def getProviderName(): String = "il"
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
-    extractString(data \ "header" \ "identifier")
+    extractString(data \\ "header" \ "identifier")
 
   // SourceResource mapping
   override def collection(data: Document[NodeSeq]): ZeroToMany[DcmiTypeCollection] =

--- a/src/main/scala/dpla/ingestion3/mappers/providers/IllinoisMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/IllinoisMapping.scala
@@ -6,7 +6,7 @@ import dpla.ingestion3.mappers.utils.{Document, XmlExtractor, XmlMapping}
 import dpla.ingestion3.messages.IngestMessageTemplates
 import dpla.ingestion3.model.DplaMapData.{AtLeastOne, ExactlyOne, ZeroToMany, ZeroToOne}
 import dpla.ingestion3.model._
-import dpla.ingestion3.utils.{HttpUtils, Utils}
+import dpla.ingestion3.utils.Utils
 import org.json4s.JValue
 import org.json4s.JsonDSL._
 
@@ -24,12 +24,10 @@ class IllinoisMapping extends XmlMapping with XmlExtractor with IngestMessageTem
 
   override def getProviderName(): String = "il"
 
-  // FIXME Should use OAI header / identifier for ID not the first URI in dc:identifier
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
-    extractStrings(data \\ "metadata" \\ "identifier").find(s => HttpUtils.validateUrl(s))
+    extractString(data \ "header" \ "identifier")
 
   // SourceResource mapping
-  // FIXME Collection information is stored outside of individual records in the OAI setSpec / title
   override def collection(data: Document[NodeSeq]): ZeroToMany[DcmiTypeCollection] =
     extractStrings(data \\ "metadata" \\ "isPartOf")
       .map(nameOnlyCollection)

--- a/src/test/scala/dpla/ingestion3/mappers/providers/IllinoisMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/IllinoisMappingTest.scala
@@ -22,7 +22,7 @@ class IllinoisMappingTest extends FlatSpec with BeforeAndAfter {
 
   // original ID
   it should "extract the correct original ID" in {
-    val expected = Some("http://collections.carli.illinois.edu/cdm/ref/collection/uic_pic/id/5601")
+    val expected = Some("urn:dpla-repox.carli.illinois.edu:carli_uic_pic:oai:collections.carli.illinois.edu:uic_pic/5601")
     assert(extractor.originalId(xml) == expected)
   }
 


### PR DESCRIPTION
Change Illinois ID minting to use `header \ identifier`
Fixup mapping ID test
