### PR TITLE
Add MA mapping

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/MaMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MaMapping.scala
@@ -305,6 +305,6 @@ class MaMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
     uri = Some(URI("http://dp.la/api/contributor/digital-commonwealth"))
   )
 
-  private def getModsRoot(data: Document[NodeSeq]) = data \ "metadata" \ "mods"
+  private lazy val getModsRoot = (data: Document[NodeSeq]) => data \ "metadata" \ "mods"
 }
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MaMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MaMapping.scala
@@ -100,20 +100,24 @@ class MaMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
 
     props.flatMap(prop => {
       val dateCreated = (getModsRoot(data) \ "originInfo" \ prop)
+        .filterNot(node => filterAttribute(node,"point", "start") | filterAttribute(node,"point", "end"))
         .flatMap(node => getByAttribute(node, "keyDate", "yes"))
         .flatMap(node => getByAttribute(node, "encoding", "w3cdtf"))
         .flatMap(node => extractStrings(node))
+        .map(_.trim)
 
       // Get dateCreated values with a keyDate=yes attribute and point=start attribute
       val earlyDate = (getModsRoot(data) \ "originInfo" \ prop)
         .flatMap(node => getByAttribute(node, "keyDate", "yes"))
         .flatMap(node => getByAttribute(node, "point", "start"))
         .flatMap(node => extractStrings(node))
+        .map(_.trim)
 
       // Get dateCreated values with point=end attribute
       val lateDate = (getModsRoot(data) \ "originInfo" \ prop)
         .flatMap(node => getByAttribute(node, "point", "end"))
         .flatMap(node => extractStrings(node))
+        .map(_.trim)
 
       (dateCreated.nonEmpty, earlyDate.nonEmpty, lateDate.nonEmpty) match {
         case (true, _, _) => dateCreated.map(stringOnlyTimeSpan)

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MaMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MaMapping.scala
@@ -112,7 +112,6 @@ class MaMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
 
       // Get dateCreated values with point=end attribute
       val lateDate = (getModsRoot(data) \ "originInfo" \ prop)
-        .flatMap(node => getByAttribute(node, "keyDate", "yes"))
         .flatMap(node => getByAttribute(node, "point", "end"))
         .flatMap(node => extractStrings(node))
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MaMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MaMapping.scala
@@ -184,15 +184,21 @@ class MaMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
         val coordinates =  extractString(subject \ "cartographics" \ "coordinates")
 
         val hierarchy = (subject \ "hierarchicalGeographic").map(h => {
-          val city = extractString(h \ "city")
+          val cityLabel = (extractString(h \ "city"), extractString(h \ "citySection")) match {
+            case (Some(city), Some(citySection)) => Some(s"$city, $citySection")
+            case (Some(city), None) => Some(city)
+            case (None, Some(citySection)) => Some(citySection)
+            case (_, _) => None
+          }
+
           val country = extractString(h \ "country")
           val county = extractString(h \ "county")
           val state = extractString(h \ "state")
-          val name = Option(Seq(city, county, state, country).flatten.map(_.trim).mkString(", "))
+          val name = Option(Seq(cityLabel, county, state, country).flatten.map(_.trim).mkString(", "))
 
           DplaPlace(
             name = name,
-            city = city,
+            city = cityLabel,
             country = country,
             county = county,
             state = state,

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MaMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MaMapping.scala
@@ -30,17 +30,17 @@ class MaMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
   // SourceResource mapping
   override def alternateTitle(data: Document[NodeSeq]): ZeroToMany[String] =
   // <mods:titleInfo type="alternative"><mods:title>
-  // <mods:titleInfo type="translated">
-  // <mods:titleInfo type="uniform">
+  // <mods:titleInfo type="translated"><mods:title>
+  // <mods:titleInfo type="uniform"><mods:title>
     (getModsRoot(data) \ "titleInfo")
       .map(node => getByAttribute(node, "type", "alternative"))
       .flatMap(altTitle => extractStrings(altTitle \ "title")) ++
     (getModsRoot(data) \ "titleInfo")
       .map(node => getByAttribute(node, "type", "translated"))
-      .flatMap(extractStrings) ++
+      .flatMap(altTitle => extractStrings(altTitle \ "title")) ++
     (getModsRoot(data) \ "titleInfo")
       .map(node => getByAttribute(node, "type", "uniform"))
-      .flatMap(extractStrings)
+      .flatMap(altTitle => extractStrings(altTitle \ "title"))
 
   override def collection(data: Document[NodeSeq]): Seq[DcmiTypeCollection] =
   // <relatedItem type="host"><titleInfo><title>
@@ -59,7 +59,7 @@ class MaMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
       .flatMap(extractStrings)
 
     val creators: Seq[String] = names.zipWithIndex.map{ case(n, i) => {
-      if (dates.lift(i).isDefined) dates(i) + ", " + n else n
+      if (dates.lift(i).isDefined) s"$n, ${dates(i)}" else n
     }}
 
     creators.map(nameOnlyAgent)

--- a/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
+++ b/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
@@ -137,6 +137,17 @@ class LocProfile extends JsonProfile {
 }
 
 /**
+  * Massachusetts - Digital Commonwealth
+  */
+class MaProfile extends XmlProfile {
+  type Mapping = MaMapping
+
+  override def getHarvester: Class[_ <: Harvester] = classOf[OaiHarvester]
+  override def getMapping = new MaMapping
+}
+
+
+/**
   * Digital Maryland
   */
 class MarylandProfile extends XmlProfile {

--- a/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
+++ b/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
@@ -56,6 +56,7 @@ object ProviderRegistry {
     "ia" -> Register(profile = new IaProfile),
     "in" -> Register(profile = new InProfile),
     "lc" -> Register(profile = new LocProfile),
+    "ma" -> Register(profile = new MaProfile),
     "maryland" -> Register(profile = new MarylandProfile),
     "mi" -> Register(profile = new MiProfile),
     "minnesota" -> Register(profile = new MdlProfile),

--- a/src/test/resources/ma-creator.xml
+++ b/src/test/resources/ma-creator.xml
@@ -1,0 +1,381 @@
+<record
+        xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <header>
+        <identifier>oai:digitalcommonwealth.org:commonwealth:nc581732x</identifier>
+        <datestamp>2019-04-09T07:04:35Z</datestamp>
+        <setSpec>commonwealth:np193j758</setSpec>
+    </header>
+    <metadata>
+        <mods:mods
+                version="3.5" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mods="http://www.loc.gov/mods/v3">
+            <mods:titleInfo usage="primary" displayLabel="primary_display">
+                <mods:nonSort>L'</mods:nonSort>
+                <mods:title>arbre des batailles ... [etc.]</mods:title>
+            </mods:titleInfo>
+            <mods:titleInfo
+                    type="uniform" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n95026759">
+                <mods:title>Bonet, Honoré, active 1378-1398. Arbre des batailles</mods:title>
+            </mods:titleInfo>
+            <mods:name
+                    type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n87878545">
+                <mods:role>
+                    <mods:roleTerm
+                            type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/cre">
+                        Creator
+                    </mods:roleTerm>
+                </mods:role>
+                <mods:namePart>Bonet, Honoré</mods:namePart>
+                <mods:namePart type="date">active 1378-1398</mods:namePart>
+            </mods:name>
+            <mods:name type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n79117143">
+                <mods:role>
+                    <mods:roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/ctb">
+                        Contributor
+                    </mods:roleTerm>
+                </mods:role>
+                <mods:namePart>Lydgate, John</mods:namePart>
+                <mods:namePart type="date">1370?-1451?</mods:namePart>
+            </mods:name>
+            <mods:name type="personal" authority="local" authorityURI="">
+                <mods:role>
+                    <mods:roleTerm
+                            type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/scr">
+                        Scribe
+                    </mods:roleTerm>
+                </mods:role>
+                <mods:namePart>Moris, V.C.</mods:namePart>
+            </mods:name>
+            <mods:name
+                    type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n79007370">
+                <mods:role>
+                    <mods:roleTerm
+                            type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/fmo">
+                        Former owner
+                    </mods:roleTerm>
+                </mods:role>
+                <mods:namePart>Caxton, William</mods:namePart>
+                <mods:namePart type="date">approximately 1422-1491 or 1492</mods:namePart>
+            </mods:name>
+            <mods:name type="personal" authority="local" authorityURI="">
+                <mods:role>
+                    <mods:roleTerm
+                            type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/fmo">
+                        Former owner
+                    </mods:roleTerm>
+                </mods:role>
+                <mods:namePart>Sonnyng, William</mods:namePart>
+            </mods:name>
+            <mods:name type="personal" authority="local" authorityURI="">
+                <mods:role>
+                    <mods:roleTerm
+                            type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/fmo">
+                        Former owner
+                    </mods:roleTerm>
+                </mods:role>
+                <mods:namePart>Sonnyng, John</mods:namePart>
+            </mods:name>
+            <mods:name
+                    type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/no2007058416">
+                <mods:role>
+                    <mods:roleTerm
+                            type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/fmo">
+                        Former owner
+                    </mods:roleTerm>
+                </mods:role>
+                <mods:namePart>Wall, Thomas</mods:namePart>
+                <mods:namePart type="date">1504-1536</mods:namePart>
+            </mods:name>
+            <mods:name
+                    type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n79106215">
+                <mods:role>
+                    <mods:roleTerm
+                            type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/fmo">
+                        Former owner
+                    </mods:roleTerm>
+                </mods:role>
+                <mods:namePart>Spelman, Henry, Sir</mods:namePart>
+                <mods:namePart type="date">1564?-1641</mods:namePart>
+            </mods:name>
+            <mods:name type="personal" authority="local" authorityURI="">
+                <mods:role>
+                    <mods:roleTerm
+                            type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/fmo">
+                        Former owner
+                    </mods:roleTerm>
+                </mods:role>
+                <mods:namePart>Macro, Cox</mods:namePart>
+                <mods:namePart type="date">-1767</mods:namePart>
+            </mods:name>
+            <mods:name
+                    type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/no2004036230">
+                <mods:role>
+                    <mods:roleTerm
+                            type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/fmo">
+                        Former owner
+                    </mods:roleTerm>
+                </mods:role>
+                <mods:namePart>Patteson, John</mods:namePart>
+                <mods:namePart type="date">1755-1833</mods:namePart>
+            </mods:name>
+            <mods:name
+                    type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n86113546">
+                <mods:role>
+                    <mods:roleTerm
+                            type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/fmo">
+                        Former owner
+                    </mods:roleTerm>
+                </mods:role>
+                <mods:namePart>Gurney, Hudson</mods:namePart>
+                <mods:namePart type="date">1775-1864</mods:namePart>
+            </mods:name>
+            <mods:name
+                    type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/no2004030768">
+                <mods:role>
+                    <mods:roleTerm
+                            type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/fmo">
+                        Former owner
+                    </mods:roleTerm>
+                </mods:role>
+                <mods:namePart>Gurney, J. H. (John Henry)</mods:namePart>
+                <mods:namePart type="date">1848-1922</mods:namePart>
+            </mods:name>
+            <mods:name
+                    type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/no00065442">
+                <mods:role>
+                    <mods:roleTerm
+                            type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/fmo">
+                        Former owner
+                    </mods:roleTerm>
+                </mods:role>
+                <mods:namePart>Gurney, Q. E. (Quintin Edward)</mods:namePart>
+                <mods:namePart type="date">1883-</mods:namePart>
+            </mods:name>
+            <mods:name type="corporate" authority="local" authorityURI="">
+                <mods:role>
+                    <mods:roleTerm
+                            type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/bnd">
+                        Binder
+                    </mods:roleTerm>
+                </mods:role>
+                <mods:namePart>Abbaye Saint-Pierre de Hasnon (Hasnon, France)</mods:namePart>
+            </mods:name>
+            <mods:name
+                    type="corporate" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n82075696">
+                <mods:role>
+                    <mods:roleTerm
+                            type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/fmo">
+                        Former owner
+                    </mods:roleTerm>
+                </mods:role>
+                <mods:namePart>Maggs Bros.</mods:namePart>
+            </mods:name>
+            <mods:typeOfResource manuscript="yes">still image</mods:typeOfResource>
+            <mods:typeOfResource>text</mods:typeOfResource>
+            <mods:genre
+                    authority="gmgpc" authorityURI="http://id.loc.gov/vocabulary/graphicMaterials" valueURI="http://id.loc.gov/vocabulary/graphicMaterials/tgm012286" displayLabel="general">
+                Manuscripts
+            </mods:genre>
+            <mods:genre authority="rbbin" authorityURI="" displayLabel="specific">
+                Calf bindings (Binding)
+            </mods:genre>
+            <mods:genre authority="rbbin" authorityURI="" displayLabel="specific">
+                Blind tooled bindings (Binding)
+            </mods:genre>
+            <mods:genre authority="rbbin" authorityURI="" displayLabel="specific">
+                Wooden boards (Binding)
+            </mods:genre>
+            <mods:genre authority="rbprov" authorityURI="" displayLabel="specific">
+                Inscriptions (Provenance)
+            </mods:genre>
+            <mods:genre authority="rbprov" authorityURI="" displayLabel="specific">
+                Autographs (Provenance)
+            </mods:genre>
+            <mods:genre
+                    authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects" valueURI="http://id.loc.gov/authorities/subjects/sh85080735" displayLabel="specific">
+                Manuscripts, Latin (Medieval and modern)
+            </mods:genre>
+            <mods:genre
+                    authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects" valueURI="http://id.loc.gov/authorities/subjects/sh85080714" displayLabel="specific">
+                Manuscripts, French
+            </mods:genre>
+            <mods:genre
+                    authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects" valueURI="http://id.loc.gov/authorities/subjects/sh85080709" displayLabel="specific">
+                Manuscripts, English
+            </mods:genre>
+            <mods:originInfo>
+                <mods:place>
+                    <mods:placeTerm type="text">Calais [and England]</mods:placeTerm>
+                </mods:place>
+                <mods:dateCreated
+                        point="start" encoding="w3cdtf" qualifier="questionable" keyDate="yes">
+                    1450
+                </mods:dateCreated>
+                <mods:dateCreated point="end" encoding="w3cdtf" qualifier="questionable">
+                    1471
+                </mods:dateCreated>
+            </mods:originInfo>
+            <mods:tableOfContents>
+                1. ff.1-143: L'arbre des batailles / Honoré Bonet. -- 2. f. 143v: Prophecies in Latin verse (this leaf originally blank, contents written in a different 15th-century hand) -- 3. ff. 144-150: Cy ensuyvent les loys et drois et coustumes de mare. -- 4. ff. 150v-162: Cy ensuyvent les loys et coustumes de la ville et eschevinage de Calais. -- 5. ff. 162v-163: Blank. -- 6. f. 163v: Forma littera obigantur (this page originally blank, contents written in a different 15th-century hand) -- 7. ff. 164-166v: Blank. -- 8. ff. 167-184v: Lyble of Englysh polecie (the &quot;B&quot; Text, 2nd version, after 1441) -- 9. ff. 185-186v: [The Retinue of Edward III at Calais (1346)] -- 10. ff. 187-189: The churl and the bird / John Lydgate. -- 11. f. 189v: Disputation sompniorum per philosophes (ca. 15th-century addition, in Latin) -- 12. f. 190: [Medical recipes for the flux] (ca. 15th-century addition, in English) -- 13. f. 190v: [List of receipts] (ca. 15th-century addition, in English) -- 14. ff. [190+1]-[190+8]: Tipped-in, ca. mid-17th-century transcriptions of letters and journals concerning sea travel and North America, some taken from The Principal Navigations (published by Hakluyt in 1598)
+            </mods:tableOfContents>
+            <mods:language>
+                <mods:languageTerm
+                        type="text" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2" valueURI="http://id.loc.gov/vocabulary/iso639-2/fre">
+                    French
+                </mods:languageTerm>
+            </mods:language>
+            <mods:physicalDescription>
+                <mods:digitalOrigin>reformatted digital</mods:digitalOrigin>
+                <mods:extent>206 leaves : paper, ill. ; bound to 292 x 225 mm.</mods:extent>
+                <mods:note>
+                    Collation: Paper (some sheets similar to Briquet 386 and others to Piccard 86054-64), fol. iii + 166 + iii + 23 + iii + i⁸ ; iii 1-6²⁰ 7²²+¹ (f. 143=singleton) 8²⁰ iii 9¹⁶ 10¹⁰-² (innermost bifolium, between 186 and 187, wanting) i⁸ (ca. 17th-century additions) ; signed i-vii in lower left corner of first recto; first half of each quire signed ia, ib, ic.../...viia, viib, viic. Quire 8 signed &quot;i,&quot; quire 9 signed &quot;i,&quot; quire 10 unsigned. Modern arabic pencil foliation, upper/outer corner of each page.
+                </mods:note>
+                <mods:note>
+                    Layout: Part I (ff.1-143): 285 x 210 (197 x 100) mm., single column, approximately 35 lines.
+                </mods:note>
+                <mods:note>
+                    Layout: Part II (ff. 144-163): 285 x 210 (208 x 231) mm., single column, 37 lines.
+                </mods:note>
+                <mods:note>
+                    Layout: Part II (ff. 167-190): 285 x 210 (207 x 122) mm., single column, approximately 35 lines.
+                </mods:note>
+                <mods:note>
+                    Layout: Part III (ca. 17th-century additions): one or two columns, approximately 75 lines.
+                </mods:note>
+                <mods:note>
+                    Script: Parts I and II are written in a Gothic cursive in brown ink with brown rubrics by three scribes: V.C. Moris, ff. 1-143; (unidentified hand I), ff. 144-163; (unidentified hand II) ff. 164-190. Part III: written in a ca. 17th-century cursive hand in brown ink.
+                </mods:note>
+                <mods:note>
+                    Decoration: Spaces left for two- to four-line initials unfilled (guide letters only). The tree of battle illustration in brown ink on f. 5v.
+                </mods:note>
+                <mods:note>
+                    Binding: Bound ca.1471 in blind stamped calf over wooden boards. Spine with raised bands, ruled in blind. Three paper labels are present. The primary label contains a manuscript list of contents in a ca. 19th-century hand (&quot;Arbre de batailles / The libel of English / policy / &amp;c. / MS&quot;). Conservation treatment in 2018 revealed that the underside of the parchment hinge at front contains two lines in a medieval French hand. In 1936, Dr. Robin Flower, Keeper of Manuscripts at the British Museum, attributed this binding to the Abbey of St. Peter of Hasnon. Currently housed in a tan cloth box.
+                </mods:note>
+                <mods:internetMediaType>image/tiff</mods:internetMediaType>
+                <mods:internetMediaType>image/jpeg</mods:internetMediaType>
+                <mods:internetMediaType>image/jp2</mods:internetMediaType>
+            </mods:physicalDescription>
+            <mods:abstract>
+                A composite manuscript comprised of at least eight distinct pieces. Primary among these are Honoré Bonet’s L’arbre des batailles, John Lydgate’s The churl and the bird, and the anonymous 15th-century poem on English sea power, The libel of English policy. Also present are several smaller items. The two principle parts of this codex (ff. 1-163v and ff. 164-190), existed as at least three distinct manuscripts before they were bound together into the present volume in the Burgundian Netherlands/northern France during the third quarter of the 15th century. Based on geographic origin, age, contents, and three inscriptions bearing the name &quot;Will[el]mo Caston,&quot; the ownership of this volume has sometimes been attributed to William Caxton, the first English printer. See the provenance note below. Some contents also cataloged separately.
+            </mods:abstract>
+            <mods:note>Ms. composite codex.</mods:note>
+            <mods:note>
+                Title derived from contents of part I. Date range based on contents and on ownership inscription on f.1.
+            </mods:note>
+            <mods:note>
+                Origin: The contents of parts I (ff. 1-163v) and II (ff. 164-190v) were written in the mid-15th century. Part I was written in Calais by the scribe V.C. Moris (see colophon, f. 143). Part II was written in England, but on both French and Italian paper stocks. Part III consists of 8 tipped-in leaves of mid-17th-century manuscript materials in various hands, all likely produced in England. The retention of the binder's flyleaves between parts I and II suggests that each part may have previously been bound separately.
+            </mods:note>
+            <mods:note>Consult curatorial file for fuller description.</mods:note>
+            <mods:note type="acquisition">
+                Purchased by the BPL from Maggs, of London, in 1939.
+            </mods:note>
+            <mods:note type="ownership">
+                Provenance 1: This volume contains three autographs of one &quot;Willelmo Caston,&quot; conjectured by some to be William Caxton, the first English printer. These inscriptions are present on f. 1 (&quot;Iste liber co[n]stat Will[el]mo Caston&quot;), f. 143, and on the rear pastedown. N.F. Blake suggests that this autograph is more likely attributable to a different man: William Caston, a member of the English Staple at Calais, whose documented presence in the area is roughly contemporaneous to that of Caxton's time in Bruges.
+            </mods:note>
+            <mods:note type="ownership">
+                Provenance 2: In 1471 &quot;Willelmo Caston&quot; gave the volume to William Sonnyng, who appended this information to the inscription on f. 1 (&quot;...quy dedit Will[el]mo Son[n]yng An⁰ m[^i]iiij[^c]lxxj&quot;). William Sonnyng's name also appears on the front and rear pastedowns. The book was then passed to Sonnyng's son and grandson (both named John). The autograph of the elder John Sonnyng, dated &quot;anno 1522 le 23 Juin&quot; is appended to his father's autograph on the rear pastedown. In 1528, the younger John Sonnyng presented the volume to Thomas Wall, Windsor Herald, adding to the inscriptoin on f. 1: &quot;...qui genuit Johannem qui genuit Johannem quem Johannes de ordinies sancti francisci dedit istius liber thome wall alias windesor herald a⁰ 1528.&quot; Later, the volume was likely owned by Henry Spelman (d. 1641), whose collection was purchased by Cox Macro in 1709/10. The Macro collection was purchased by John Patteson. Hudson Gurney purchased the volume from Patteson in 1820 (Christie's, Feb. 1820, lot 68). H. Gurney passed it on to J.H. Gurney (his &quot;VII&quot; label on spine), who passed it on to Q.E. Gurney (d. 1932). The volume was then purchased by Maggs through Sotheby's on March 30, 1936 (lot 146).
+            </mods:note>
+            <mods:note type="language">In Latin, French, and Middle English.</mods:note>
+            <mods:note type="citation/reference">
+                Bond, W.H. Supplement to the Census of medieval and Renaissance manuscripts in the United States and Canada, page 209
+            </mods:note>
+            <mods:note type="citation/reference">
+                Schoenberg database of manuscripts, entry 18005
+            </mods:note>
+            <mods:note type="citation/reference">
+                Schoenberg database of manuscripts, entry 57041
+            </mods:note>
+            <mods:note type="bibliography">
+                Bibliography: For further information on the provenance of this volume vis-a-vis William Caxton, see: McCusker, H. &quot;A Book from Caxton's Library.&quot; More Books 15 (1940): 275-285; Sotheby &amp; Co. Catalogue of a Selected Portion of the Valuable Library and Collection of Manuscripts, the Property of Major Q.E. Gurney, D.L. London: The Firm, 1936 (lot 146, pp. 35-40); Blake, N.F. Caxton and His World. London: Andre Deutsch, 1969. pp. 36-38, 222-223; Crotch, W.J.B. The Prologues and Epilogues of William Caxton. London: Oxford University Press, 1928. pp. xvli-xlviii; Painter, G. William Caxton, a Biography. New York: Putnam, 1977. p. 161.
+            </mods:note>
+            <mods:subject
+                    valueURI="http://id.loc.gov/authorities/subjects/sh2008107781" authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects">
+                <mods:topic>Military art and science--Early works to 1800</mods:topic>
+            </mods:subject>
+            <mods:subject
+                    valueURI="http://id.loc.gov/authorities/subjects/sh2008113362" authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects">
+                <mods:topic>War (International law)--Early works to 1800</mods:topic>
+            </mods:subject>
+            <mods:subject
+                    valueURI="http://id.loc.gov/authorities/subjects/sh2009119374" authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects">
+                <mods:topic>Chivalry--Early works to 1800</mods:topic>
+            </mods:subject>
+            <mods:subject
+                    authority="tgn" valueURI="http://vocab.getty.edu/tgn/7002445" authorityURI="http://vocab.getty.edu/tgn/">
+                <mods:hierarchicalGeographic>
+                    <mods:continent>Europe</mods:continent>
+                    <mods:country>England</mods:country>
+                </mods:hierarchicalGeographic>
+                <mods:cartographics>
+                    <mods:coordinates>53,-2</mods:coordinates>
+                </mods:cartographics>
+            </mods:subject>
+            <mods:subject
+                    authority="tgn" valueURI="http://vocab.getty.edu/tgn/1000070" authorityURI="http://vocab.getty.edu/tgn/">
+                <mods:hierarchicalGeographic>
+                    <mods:continent>Europe</mods:continent>
+                    <mods:country>France</mods:country>
+                </mods:hierarchicalGeographic>
+                <mods:cartographics>
+                    <mods:coordinates>46,2</mods:coordinates>
+                </mods:cartographics>
+            </mods:subject>
+            <mods:accessCondition type="use and reproduction" displayLabel="rights">
+                No known copyright restrictions.
+            </mods:accessCondition>
+            <mods:accessCondition type="use and reproduction" displayLabel="license">
+                No known restrictions on use.
+            </mods:accessCondition>
+            <mods:accessCondition type="restriction on access">
+                Access to physical item by appointment only. Please contact Boston Public Library Rare Books and Manuscripts Department for further information.
+            </mods:accessCondition>
+            <mods:relatedItem type="host">
+                <mods:titleInfo>
+                    <mods:title>
+                        Medieval and Early Renaissance Manuscripts (Collection of Distinction)
+                    </mods:title>
+                </mods:titleInfo>
+            </mods:relatedItem>
+            <mods:location>
+                <mods:physicalLocation>Boston Public Library</mods:physicalLocation>
+                <mods:holdingSimple>
+                    <mods:copyInformation>
+                        <mods:subLocation>Rare Books Department</mods:subLocation>
+                    </mods:copyInformation>
+                </mods:holdingSimple>
+            </mods:location>
+            <mods:identifier type="local-other">
+                MS-f-Med-92_001 -  MS-f-Med-92_420
+            </mods:identifier>
+            <mods:identifier type="local-barcode">39999085232724</mods:identifier>
+            <mods:identifier type="local-call">RARE BKS MS f Med. 92</mods:identifier>
+            <mods:identifier type="local-call" invalid="yes">MS 1519</mods:identifier>
+            <mods:recordInfo>
+                <mods:recordContentSource>Boston Public Library</mods:recordContentSource>
+                <mods:recordOrigin>human prepared</mods:recordOrigin>
+                <mods:languageOfCataloging>
+                    <mods:languageTerm
+                            authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2" type="text" valueURI="http://id.loc.gov/vocabulary/iso639-2/eng">
+                        English
+                    </mods:languageTerm>
+                </mods:languageOfCataloging>
+                <mods:descriptionStandard authority="marcdescription">
+                    amremm
+                </mods:descriptionStandard>
+            </mods:recordInfo>
+            <mods:location>
+                <mods:url access="preview">
+                    https://ark.digitalcommonwealth.org/ark:/50959/nc581732x/thumbnail
+                </mods:url>
+                <mods:url usage="primary" access="object in context">
+                    https://ark.digitalcommonwealth.org/ark:/50959/nc581732x
+                </mods:url>
+                <mods:url note="iiif-manifest">
+                    https://ark.digitalcommonwealth.org/ark:/50959/nc581732x/manifest
+                </mods:url>
+            </mods:location>
+            <mods:identifier type="uri">
+                https://ark.digitalcommonwealth.org/ark:/50959/nc581732x
+            </mods:identifier>
+        </mods:mods>
+    </metadata>
+</record>

--- a/src/test/resources/ma.xml
+++ b/src/test/resources/ma.xml
@@ -1,0 +1,110 @@
+<record>
+    <header>
+        <identifier>oai:digitalcommonwealth.org:commonwealth-oai:0k225b90r</identifier>
+        <datestamp>2019-04-09T05:19:58Z</datestamp>
+        <setSpec>commonwealth-oai:r207tt62z</setSpec>
+    </header>
+    <metadata>
+        <mods:mods version="3.5" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+            <mods:recordInfo>
+                <mods:recordContentSource>Springfield College Archives and Special Collections</mods:recordContentSource>
+                <mods:recordOrigin>OAI-PMH request</mods:recordOrigin>
+            </mods:recordInfo>
+            <mods:relatedItem type="host">
+                <mods:titleInfo>
+                    <mods:title>College Archives Digital Collections</mods:title>
+                </mods:titleInfo>
+            </mods:relatedItem>
+            <mods:location>
+                <mods:physicalLocation>Springfield College Archives and Special Collections</mods:physicalLocation>
+            </mods:location>
+            <mods:titleInfo displayLabel="primary_display" usage="primary">
+                <mods:title>Art Linkletter Natatorium at Springfield College</mods:title>
+            </mods:titleInfo>
+            <mods:titleInfo type="alternative">
+                <mods:title>Alternate Title</mods:title>
+            </mods:titleInfo>
+            <mods:subject>
+                <mods:topic>Linkletter Natatorium</mods:topic>
+            </mods:subject>
+            <mods:subject authority="tgn" authorityURI="http://vocab.getty.edu/tgn/" valueURI="http://vocab.getty.edu/tgn/7014531">
+                <mods:hierarchicalGeographic>
+                    <mods:county>Hampden</mods:county>
+                    <mods:country>United States</mods:country>
+                    <mods:state>Massachusetts</mods:state>
+                    <mods:continent>North and Central America</mods:continent>
+                    <mods:city>Springfield</mods:city>
+                </mods:hierarchicalGeographic>
+                <mods:cartographics>
+                    <mods:coordinates>42.1,-72.5833</mods:coordinates>
+                </mods:cartographics>
+            </mods:subject>
+            <mods:subject>
+                <mods:topic>Springfield College</mods:topic>
+            </mods:subject>
+            <mods:subject>
+                <mods:topic>Springfield College--Buildings</mods:topic>
+            </mods:subject>
+            <mods:subject>
+                <mods:topic>Triangles</mods:topic>
+            </mods:subject>
+            <mods:subject>
+                <mods:topic>Springfield (Mass.)</mods:topic>
+            </mods:subject>
+            <mods:subject>
+                <mods:topic>Swimming pools</mods:topic>
+            </mods:subject>
+            <mods:subject>
+                <mods:topic>Autumn</mods:topic>
+            </mods:subject>
+            <mods:originInfo>
+                <mods:publisher>Springfield College</mods:publisher>
+                <mods:dateCreated encoding="w3cdtf" keyDate="yes" point="start">1967</mods:dateCreated>
+                <mods:dateCreated encoding="w3cdtf" point="end">2007</mods:dateCreated>
+            </mods:originInfo>
+            <mods:abstract>Abstract</mods:abstract>
+            <mods:note>Note</mods:note>
+            <mods:typeOfResource>still image</mods:typeOfResource>
+            <mods:identifier type="local-other">rg131-02-07-006</mods:identifier>
+            <mods:identifier type="uri">http://cdm16122.contentdm.oclc.org/cdm/ref/collection/p15370coll2/id/2977</mods:identifier>
+            <mods:accessCondition displayLabel="rights" type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC-EDU/1.0/">Text and images are owned, held, or licensed by Springfield College and are available for personal, non-commercial, and educational use, provided that ownership is properly cited. A credit line is required and should read: Courtesy of Springfield College, Babson Library, Archives and Special Collections. Any commercial use without written permission from Springfield College is strictly prohibited. Other individuals or entities other than, and in addition to, Springfield College may also own copyrights and other propriety rights. The publishing, exhibiting, or broadcasting party assumes all responsibility for clearing reproduction rights and for any infringement of United States copyright law.</mods:accessCondition>
+            <mods:accessCondition displayLabel="license" type="use and reproduction">Contact host institution for more information.</mods:accessCondition>
+            <mods:physicalDescription>
+                <mods:internetMediaType>image/jpeg</mods:internetMediaType>
+                <mods:internetMediaType>image/tiff</mods:internetMediaType>
+            </mods:physicalDescription>
+            <mods:physicalDescription>
+                <mods:extent>extent</mods:extent>
+            </mods:physicalDescription>
+            <mods:genre authority="gmgpc" authorityURI="http://id.loc.gov/vocabulary/graphicMaterials" displayLabel="general" valueURI="http://id.loc.gov/vocabulary/graphicMaterials/tgm007721">Photographs</mods:genre>
+            <mods:relatedItem type="series">
+                <mods:titleInfo>
+                    <mods:title>Art Linkletter Natatorium Records</mods:title>
+                </mods:titleInfo>
+            </mods:relatedItem>
+            <mods:subject>
+                <mods:cartographics>
+                    <mods:coordinates>42.10469,-72.55408</mods:coordinates>
+                </mods:cartographics>
+            </mods:subject>
+            <mods:location>
+                <mods:url access="object in context" usage="primary">http://cdm16122.contentdm.oclc.org/cdm/ref/collection/p15370coll2/id/2977</mods:url>
+                <mods:url access="preview">https://ark.digitalcommonwealth.org/ark:/50959/0k225b90r/thumbnail</mods:url></mods:location>
+
+            <name>
+                <namePart type="date">2000</namePart>
+                <namePart>Alfred</namePart>
+            </name>
+            <name>
+                <namePart>John</namePart>
+            </name>
+            // Is there a way to differentiate so that anyone with a “contributor”
+            <mods:name>
+                <mods:role>
+                    <mods:roleTerm authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" type="text" valueURI="http://id.loc.gov/vocabulary/relators/ctb">Contributor</mods:roleTerm>
+                </mods:role>
+                <mods:namePart>American Photo-Relief Printing Co</mods:namePart>
+            </mods:name>
+        </mods:mods>
+    </metadata>
+</record>

--- a/src/test/resources/ma.xml
+++ b/src/test/resources/ma.xml
@@ -24,6 +24,9 @@
             <mods:titleInfo type="alternative">
                 <mods:title>Alternate Title</mods:title>
             </mods:titleInfo>
+            <mods:titleInfo type="translated" lang="eng">
+                <mods:title>Kio circus</mods:title>
+            </mods:titleInfo>
             <mods:subject>
                 <mods:topic>Linkletter Natatorium</mods:topic>
             </mods:subject>

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MaMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MaMappingTest.scala
@@ -23,7 +23,7 @@ class MaMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.originalId(xml) === Some("oai:digitalcommonwealth.org:commonwealth-oai:0k225b90r"))
 
   it should "extract the correct alternate titles" in {
-    val expected = Seq("Alternate Title")
+    val expected = Seq("Alternate Title", "Kio circus")
     assert(extractor.alternateTitle(xml) === expected)
   }
 

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MaMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MaMappingTest.scala
@@ -122,4 +122,41 @@ class MaMappingTest extends FlatSpec with BeforeAndAfter {
     "Triangles", "Springfield (Mass.)", "Swimming pools", "Autumn").map(nameOnlyConcept)
     assert(extractor.subject(xml) === expected)
   }
+
+  it should "extract the correct places" in {
+    val xml: Document[NodeSeq] = Document(
+      <record>
+        <metadata>
+          <mods:mods>
+            <mods:subject authority="tgn" valueURI="http://vocab.getty.edu/tgn/7013445" authorityURI="http://vocab.getty.edu/tgn/">
+              <mods:hierarchicalGeographic>
+                <mods:county>Suffolk</mods:county>
+                <mods:country>United States</mods:country>
+                <mods:state>Massachusetts</mods:state>
+                <mods:continent>North and Central America</mods:continent>
+                <mods:city>Boston</mods:city>
+              </mods:hierarchicalGeographic>
+              <mods:cartographics>
+                <mods:coordinates>42.35,-71.05</mods:coordinates>
+              </mods:cartographics>
+            </mods:subject>
+            <mods:subject authority="tgn" valueURI="http://vocab.getty.edu/tgn/7013445" authorityURI="http://vocab.getty.edu/tgn/">
+              <geographic>A Place</geographic>
+            </mods:subject>
+          </mods:mods>
+        </metadata>
+      </record>
+    )
+
+    val expected = Seq(DplaPlace(
+      county = Some("Suffolk"),
+      country = Some("United States"),
+      state = Some("Massachusetts"),
+      city = Some("Boston"),
+      coordinates = Some("42.35,-71.05"),
+      name = Some("Boston, Suffolk, Massachusetts, United States")
+    ), nameOnlyPlace("A Place"))
+
+    assert(extractor.place(xml) === expected)
+  }
 }

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MaMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MaMappingTest.scala
@@ -164,6 +164,7 @@ class MaMappingTest extends FlatSpec with BeforeAndAfter {
                 <mods:state>Massachusetts</mods:state>
                 <mods:continent>North and Central America</mods:continent>
                 <mods:city>Boston</mods:city>
+                <mods:citySection>Back Bay</mods:citySection>
               </mods:hierarchicalGeographic>
               <mods:cartographics>
                 <mods:coordinates>42.35,-71.05</mods:coordinates>
@@ -181,9 +182,9 @@ class MaMappingTest extends FlatSpec with BeforeAndAfter {
       county = Some("Suffolk"),
       country = Some("United States"),
       state = Some("Massachusetts"),
-      city = Some("Boston"),
+      city = Some("Boston, Back Bay"),
       coordinates = Some("42.35,-71.05"),
-      name = Some("Boston, Suffolk, Massachusetts, United States")
+      name = Some("Boston, Back Bay, Suffolk, Massachusetts, United States")
     ), nameOnlyPlace("A Place"))
 
     assert(extractor.place(xml) === expected)

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MaMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MaMappingTest.scala
@@ -90,8 +90,12 @@ class MaMappingTest extends FlatSpec with BeforeAndAfter {
         <metadata>
           <mods:mods>
             <originInfo>
-              <dateCreated keyDate="yes" point="start">2010-11-31</dateCreated>
-              <dateCreated keyDate="yes" point="end">2010-12-31</dateCreated>
+              <mods:dateCreated point="start" encoding="w3cdtf" qualifier="questionable" keyDate="yes">
+                1450
+              </mods:dateCreated>
+              <mods:dateCreated point="end" encoding="w3cdtf" qualifier="questionable">
+                1471
+              </mods:dateCreated>
             </originInfo>
           </mods:mods>
         </metadata>
@@ -99,9 +103,9 @@ class MaMappingTest extends FlatSpec with BeforeAndAfter {
 
     val expected = Seq(
       EdmTimeSpan(
-        originalSourceDate = Some("2010-11-31-2010-12-31"),
-        begin = Some("2010-11-31"),
-        end = Some("2010-12-31")
+        originalSourceDate = Some("1450-1471"),
+        begin = Some("1450"),
+        end = Some("1471")
       ))
     assert(extractor.date(xml) === expected)
   }


### PR DESCRIPTION
Add mapper for MA and tests.

i3 profile 
```
# Mass / Digital Commonwealth
ma.provider="Digital Commonwealth"
ma.harvest.type="oai"
ma.harvest.blacklist="commonwealth,commonwealth-oai"
ma.harvest.endpoint="http://fedora.digitalcommonwealth.org/oaiprovider/"
ma.harvest.metadataPrefix = "mods"
ma.harvest.verb = "ListRecords"
```