### PR TITLE
Add IIIF manifest extraction to TN  mapping

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/TnMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/TnMapping.scala
@@ -233,17 +233,21 @@ class TnMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
 
   override def `object`(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
     // <location><url access="raw object">
+    ((data \\ "mods" \ "location" \ "url")
+      .flatMap(node => getByAttribute(node, "access", "raw object"))
+      .flatMap(extractStrings) ++
+    // Add IIIF manifests
     (data \\ "mods" \ "location" \ "url")
-      .flatMap(node => getByAttribute(node.asInstanceOf[Elem], "access", "raw object"))
+      .flatMap(node => getByAttribute(node, "note", "iiif-manifest"))
       .flatMap(extractStrings)
-      .map(stringOnlyWebResource)
+    ).map(stringOnlyWebResource)
 
   override def originalRecord(data: Document[NodeSeq]): ExactlyOne[String] = Utils.formatXml(data)
 
   override def preview(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
   // <location><url access="preview">
     (data \\ "mods" \ "location" \ "url")
-      .flatMap(node => getByAttribute(node.asInstanceOf[Elem], "access", "preview"))
+      .flatMap(node => getByAttribute(node, "access", "preview"))
       .flatMap(extractStrings)
       .map(stringOnlyWebResource)
 

--- a/src/test/resources/tn.xml
+++ b/src/test/resources/tn.xml
@@ -74,6 +74,7 @@
                 <mods:url usage="primary" access="object in context">http://cdm15138.contentdm.oclc.org/cdm/ref/collection/agricult/id/62</mods:url>
                 <mods:url access="preview">http://cdm15138.contentdm.oclc.org/utils/getthumbnail/collection/agricult/id/62</mods:url>
                 <mods:url access="raw object">http://cdm15138.contentdm.oclc.org/utils/getthumbnail/collection/agricult/id/62</mods:url>
+                <mods:url note="iiif-manifest">http://tn.us/item/1/iiif/</mods:url>
                 <mods:physicalLocation>Tennessee State Library and Archives</mods:physicalLocation>
             </mods:location>
             <mods:subject authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85002415">

--- a/src/test/scala/dpla/ingestion3/mappers/providers/TnMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/TnMappingTest.scala
@@ -175,7 +175,7 @@ class TnMappingTest extends FlatSpec with BeforeAndAfter {
 
   // object
   it should "extract the correct object" in {
-    val expected = List("http://cdm15138.contentdm.oclc.org/utils/getthumbnail/collection/agricult/id/62")
+    val expected = List("http://cdm15138.contentdm.oclc.org/utils/getthumbnail/collection/agricult/id/62", "http://tn.us/item/1/iiif/")
       .map(stringOnlyWebResource)
     assert(extractor.`object`(xml) === expected)
   }
@@ -184,7 +184,7 @@ class TnMappingTest extends FlatSpec with BeforeAndAfter {
   it should "extract the correct preview" in {
     val expected = List("http://cdm15138.contentdm.oclc.org/utils/getthumbnail/collection/agricult/id/62")
       .map(stringOnlyWebResource)
-    assert(extractor.`object`(xml) === expected)
+    assert(extractor.preview(xml) === expected)
   }
 
 }

--- a/src/test/scala/dpla/ingestion3/mappers/providers/TnMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/TnMappingTest.scala
@@ -175,7 +175,7 @@ class TnMappingTest extends FlatSpec with BeforeAndAfter {
 
   // object
   it should "extract the correct object" in {
-    val expected = List("http://cdm15138.contentdm.oclc.org/utils/getthumbnail/collection/agricult/id/62", "http://tn.us/item/1/iiif/")
+    val expected = List("http://cdm15138.contentdm.oclc.org/utils/getthumbnail/collection/agricult/id/62")
       .map(stringOnlyWebResource)
     assert(extractor.`object`(xml) === expected)
   }


### PR DESCRIPTION
This maps the IIIF manifests provided by TN to a sidecar property of `iiif`.

This will require further work after implementing the MAPv5 model in ingestion3 as the edmWebResource class will have additional properties of `IIIF Manifest` and `IIIF Base URL` which are the proper destinations for the manifest value currently mapped to the sidecar.

https://drive.google.com/file/d/1fJEWhnYy5Ch7_ef_-V48-FAViA72OieG/view
