### PR TITLE
fix travis jdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 scala:
   - 2.11.2
 jdk:
-  - oraclejdk8
+  - openjdk8
 sbt: 0.13.12
 script:
   - sbt clean coverage test


### PR DESCRIPTION
This fixes the testing suite, which was failing b/c `oraclejdk8` is no longer available.