### PR TITLE
Rewrite MDL mapping because of chnages to the v2 API. 

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/MdlMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MdlMapping.scala
@@ -21,28 +21,28 @@ class MdlMapping extends JsonMapping with JsonExtractor with IngestMessageTempla
   override def getProviderName: String = "minnesota"
 
   override def originalId(implicit data: Document[JValue]): ZeroToOne[String] =
-    extractString(unwrap(data) \ "record" \ "isShownAt")
+    extractString(unwrap(data) \ "attributes" \ "metadata" \ "isShownAt")
 
   // OreAggregation
   override def dataProvider(data: Document[JValue]): ZeroToMany[EdmAgent] =
-    extractStrings(unwrap(data) \ "record" \ "dataProvider").map(nameOnlyAgent)
+    extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "dataProvider").map(nameOnlyAgent)
 
   override def dplaUri(data: Document[JValue]): ZeroToOne[URI] = mintDplaItemUri(data)
 
   override def edmRights(data: Document[json4s.JValue]): ZeroToMany[URI] =
-    extractStrings(unwrap(data) \ "record" \ "rights").map(URI)
+    extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "rights").map(URI)
 
   override def intermediateProvider(data: Document[JValue]): ZeroToOne[EdmAgent] =
-    extractString(unwrap(data) \ "record" \ "intermediateProvider").map(nameOnlyAgent)
+    extractString(unwrap(data) \ "attributes" \ "metadata" \ "intermediateProvider").map(nameOnlyAgent)
 
   override def isShownAt(data: Document[JValue]): ZeroToMany[EdmWebResource] =
-    extractStrings(unwrap(data) \ "record" \ "isShownAt").map(stringOnlyWebResource)
+    extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "isShownAt").map(stringOnlyWebResource)
 
   override def originalRecord(data: Document[JValue]): ExactlyOne[String] =
     Utils.formatJson(data)
 
   override def preview(data: Document[JValue]): ZeroToMany[EdmWebResource] =
-    extractStrings(unwrap(data) \ "record" \ "object").map(stringOnlyWebResource)
+    extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "object").map(stringOnlyWebResource)
 
   override def provider(data: Document[JValue]): ExactlyOne[EdmAgent] = agent
 
@@ -51,34 +51,34 @@ class MdlMapping extends JsonMapping with JsonExtractor with IngestMessageTempla
 
   // SourceResource
   override def collection(data: Document[JValue]): ZeroToMany[DcmiTypeCollection] =
-    extractCollection(unwrap(data) \ "record" \ "sourceResource" \ "collection")
+    extractCollection(unwrap(data) \ "attributes" \ "metadata" \ "sourceResource" \ "collection")
 
   override def contributor(data: Document[JValue]): ZeroToMany[EdmAgent] =
-    extractStrings(unwrap(data) \ "record" \ "sourceResource" \ "contributor").map(nameOnlyAgent)
+    extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "sourceResource" \ "contributor").map(nameOnlyAgent)
 
   override def creator(data: Document[JValue]): ZeroToMany[EdmAgent] =
-    extractStrings(unwrap(data)  \ "record" \ "sourceResource" \ "creator").map(nameOnlyAgent)
+    extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "sourceResource" \ "creator").map(nameOnlyAgent)
 
   override def date(data: Document[JValue]): ZeroToMany[EdmTimeSpan] =
-    extractDate(unwrap(data) \ "record" \ "sourceResource" \ "date")
+    extractDate(unwrap(data) \ "attributes" \ "metadata" \ "sourceResource" \ "date")
 
   override def description(data: Document[JValue]): ZeroToMany[String] =
-    extractStrings(unwrap(data) \ "record" \ "sourceResource" \ "description")
+    extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "sourceResource" \ "description")
 
   override def extent(data: Document[JValue]): ZeroToMany[String] =
-    extractStrings(unwrap(data) \ "record" \ "sourceResource" \ "extent")
+    extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "sourceResource" \ "extent")
 
   override def format(data: Document[JValue]): ZeroToMany[String] =
-    extractStrings(unwrap(data) \ "record" \ "sourceResource" \ "format")
+    extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "sourceResource" \ "format")
       .map(_.applyBlockFilter(formatBlockList))
       .filter(_.nonEmpty)
 
   override def genre(data: Document[JValue]): ZeroToMany[SkosConcept] =
-    extractStrings(unwrap(data) \ "record" \ "sourceResource" \ "type").map(nameOnlyConcept)
+    extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "sourceResource" \ "type").map(nameOnlyConcept)
 
   override def language(data: Document[JValue]): ZeroToMany[SkosConcept] = {
-    val codes = extractStrings(unwrap(data) \ "record" \ "sourceResource" \ "language" \ "iso639_3")
-    val names = extractStrings(unwrap(data) \ "record" \ "sourceResource" \ "language" \ "name")
+    val codes = extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "sourceResource" \ "language" \ "iso639_3")
+    val names = extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "sourceResource" \ "language" \ "name")
 
     (codes.nonEmpty, names.nonEmpty) match {
       case (true, _) => codes.map(nameOnlyConcept) // if iso639_3 is given use that value
@@ -88,22 +88,22 @@ class MdlMapping extends JsonMapping with JsonExtractor with IngestMessageTempla
   }
 
   override def place(data: Document[JValue]): ZeroToMany[DplaPlace] =
-    place(unwrap(data) \ "record" \ "sourceResource" \ "spatial")
+    place(unwrap(data) \ "attributes" \ "metadata" \ "sourceResource" \ "spatial")
 
   override def publisher(data: Document[JValue]): ZeroToMany[EdmAgent] =
-    extractStrings(unwrap(data)  \ "record" \ "sourceResource" \ "publisher").map(nameOnlyAgent)
+    extractStrings(unwrap(data)  \ "attributes" \ "metadata" \ "sourceResource" \ "publisher").map(nameOnlyAgent)
 
   override def rights(data: Document[JValue]): AtLeastOne[String] =
-    extractStrings(unwrap(data)  \ "record" \ "sourceResource" \ "rights")
+    extractStrings(unwrap(data)  \ "attributes" \ "metadata" \ "sourceResource" \ "rights")
 
   override def subject(data: Document[JValue]): ZeroToMany[SkosConcept] =
-    extractStrings(unwrap(data)  \ "record" \ "sourceResource" \ "subject" \ "name").map(nameOnlyConcept)
+    extractStrings(unwrap(data)  \ "attributes" \ "metadata" \ "sourceResource" \ "subject" \ "name").map(nameOnlyConcept)
 
   override def title(data: Document[JValue]): AtLeastOne[String] =
-    extractStrings(unwrap(data)  \ "record" \ "sourceResource" \ "title")
+    extractStrings(unwrap(data)  \ "attributes" \ "metadata" \ "sourceResource" \ "title")
 
   override def `type`(data: Document[JValue]): ZeroToMany[String] =
-    extractStrings(unwrap(data)  \ "record" \ "sourceResource" \ "type")
+    extractStrings(unwrap(data)  \ "attributes" \ "metadata" \ "sourceResource" \ "type")
 
   // Helper functions
   def extractCollection(collection: JValue): ZeroToMany[DcmiTypeCollection] = {

--- a/src/test/resources/mdl.json
+++ b/src/test/resources/mdl.json
@@ -1,52 +1,119 @@
 {
-  "record_id": "1PP792Z9DMQG9BEV7ME81BCR44",
-  "published": true,
-  "tags": [
-    "dpla_nonoai",
+  "record-hash": "00002e8fc21342f03889239b438edc3b28196031",
+  "import-job-name": "Hennepin County",
+  "import-job-id": 72,
+  "import-batch-id": 970593,
+  "import-job-tags": [
+    "dpla_oai2",
+    "oai",
     "dpla",
     "dplaingest"
   ],
-  "import_job_name": "MPR",
-  "import_job_id": 2,
-  "ingested_at": "2018-11-05T12:13:03Z",
-  "record": {
-    "rights": "www.fake.rights.url.org/public-domain",
-    "intermediateProvider": "one intermediate provider",
-    "object": "http://image.prview.org/thumb.jpg",
-    "title": "Hmong vendors learn the law on legal drug sales",
-    "format": "news bulletin",
-    "@context": "http://dp.la/api/items/context",
-    "provider": "Minnesota Digital Library",
-    "isShownAt": "https://archive.mpr.org/stories/2014/08/14/hmong-vendors-learn-the-law-on-legal-drug",
-    "identifier": "1PP792Z9DMQG9BEV7ME81BCR44",
-    "batch_param": "",
-    "record_hash": "1PP792Z9DMQG9BEV7ME81BCR44",
-    "dataProvider": "Minnesota Public Radio",
-    "originalRecord": {
-      "object": null,
+  "id": "00002e8fc21342f03889239b438edc3b28196031",
+  "type": "records",
+  "links": {
+    "self": "https://lib-metl-prd-01.oit.umn.edu/api/v2/records/00002e8fc21342f03889239b438edc3b28196031"
+  },
+  "attributes": {
+    "metadata": {
+      "rights": "www.fake.rights.url.org/public-domain",
+      "intermediateProvider": "one intermediate provider",
+      "object": "http://image.prview.org/thumb.jpg",
+      "title": "Hmong vendors learn the law on legal drug sales",
+      "format": "news bulletin",
       "@context": "http://dp.la/api/items/context",
       "provider": "Minnesota Digital Library",
       "isShownAt": "https://archive.mpr.org/stories/2014/08/14/hmong-vendors-learn-the-law-on-legal-drug",
+      "identifier": "1PP792Z9DMQG9BEV7ME81BCR44",
+      "batch_param": "",
+      "record_hash": "1PP792Z9DMQG9BEV7ME81BCR44",
       "dataProvider": "Minnesota Public Radio",
       "originalRecord": {
-        "guid": "1PP792Z9DMQG9BEV7ME81BCR44"
+        "object": null,
+        "@context": "http://dp.la/api/items/context",
+        "provider": "Minnesota Digital Library",
+        "isShownAt": "https://archive.mpr.org/stories/2014/08/14/hmong-vendors-learn-the-law-on-legal-drug",
+        "dataProvider": "Minnesota Public Radio",
+        "originalRecord": {
+          "guid": "1PP792Z9DMQG9BEV7ME81BCR44"
+        },
+        "sourceResource": {
+          "collection": [
+            "collection3",
+            "collection4"
+          ],
+          "contributor": [
+            "contrib4",
+            "contrib3"
+          ],
+          "date": {
+            "end": "2014",
+            "begin": "2014",
+            "displayDate": "faaje "
+          },
+          "title": "Hmong vendors learn the law on legal drug sales",
+          "rights": "http://minnesota.publicradio.org/about/site/terms/",
+          "creator": [
+            "fake creator"
+          ],
+          "subject": [
+            "MPR News Feature",
+            "Cultural Legacy Digitization (2016-2017)"
+          ],
+          "language": [
+            {
+              "name": "English",
+              "iso639_3": "eng"
+            }
+          ],
+          "type": [
+            "fake image"
+          ],
+          "description": "A few blocks from the state Capitol, shoppers at the Hmongtown Marketplace can buy just about anything. The bustling center of small businesses is a favorite of the city's Hmong community because if offers fresh groceries, medicinal herbs, and prepared food. But a June 2013 raid found that some vendors in the marketplace also had drugs for sale. Ramsey County Prosecutors charged 14 people with selling misbranded drugs, possessing and selling drugs that require a license, selling syringes, and unlawfully possessing poison."
+        }
       },
       "sourceResource": {
-        "collection": ["collection3", "collection4"],
-        "contributor": ["contrib4", "contrib3"],
+        "collection": [
+          {
+            "title": "collection1",
+            "description": "description1"
+          },
+          {
+            "title": "collection2"
+          }
+        ],
+        "contributor": [
+          "contrib1",
+          "contrib2"
+        ],
+        "creator": [
+          "creator1",
+          "creator2"
+        ],
         "date": {
           "end": "2014",
           "begin": "2014",
-          "displayDate": "faaje "
+          "displayDate": "2014-08-14"
         },
-        "title": "Hmong vendors learn the law on legal drug sales",
-        "rights": "http://minnesota.publicradio.org/about/site/terms/",
-        "creator": [
-          "fake creator"
+        "extent": [
+          "extent1",
+          "extent2"
         ],
+        "format": [
+          "1x2",
+          "pencil on paper"
+        ],
+        "title": "Hmong vendors learn the law on legal drug sales",
         "subject": [
-          "MPR News Feature",
-          "Cultural Legacy Digitization (2016-2017)"
+          {
+            "name": "MPR News Feature"
+          },
+          {
+            "name": "Reports"
+          },
+          {
+            "name": "Cultural Legacy Digitization (2016-2017)"
+          }
         ],
         "language": [
           {
@@ -54,61 +121,37 @@
             "iso639_3": "eng"
           }
         ],
-        "type": ["fake image"],
-        "description": "A few blocks from the state Capitol, shoppers at the Hmongtown Marketplace can buy just about anything. The bustling center of small businesses is a favorite of the city's Hmong community because if offers fresh groceries, medicinal herbs, and prepared food. But a June 2013 raid found that some vendors in the marketplace also had drugs for sale. Ramsey County Prosecutors charged 14 people with selling misbranded drugs, possessing and selling drugs that require a license, selling syringes, and unlawfully possessing poison."
+        "description": "description",
+        "type": "image",
+        "rights": [
+          "free text rights statement"
+        ],
+        "publisher": [
+          "pub1"
+        ],
+        "spatial": [
+          {
+            "name": [
+              "cincinnati",
+              "ohio"
+            ],
+            "coordinates": [
+              "1212.5151x1235.548",
+              "151lat 431long"
+            ]
+          },
+          {
+            "name": [
+              "hamilton county",
+              "ohio"
+            ],
+            "coordinates": [
+              "1.34 83.32",
+              "151lat 431long"
+            ]
+          }
+        ]
       }
-    },
-    "sourceResource": {
-      "collection": [
-        {
-          "title": "collection1",
-          "description": "description1"
-        },
-        {
-          "title": "collection2"
-        }
-      ],
-      "contributor": ["contrib1", "contrib2"],
-      "creator": ["creator1", "creator2"],
-      "date": {
-        "end": "2014",
-        "begin": "2014",
-        "displayDate": "2014-08-14"
-      },
-      "extent": ["extent1", "extent2"],
-      "format": ["1x2", "pencil on paper"],
-      "title": "Hmong vendors learn the law on legal drug sales",
-      "subject": [
-        {
-          "name": "MPR News Feature"
-        },
-        {
-          "name": "Reports"
-        },
-        {
-          "name": "Cultural Legacy Digitization (2016-2017)"
-        }
-      ],
-      "language": [
-        {
-          "name": "English",
-          "iso639_3": "eng"
-        }
-      ],
-      "description": "description",
-      "type": "image",
-      "rights": ["free text rights statement"],
-      "publisher": ["pub1"],
-      "spatial": [
-        {
-          "name": ["cincinnati", "ohio"],
-          "coordinates": ["1212.5151x1235.548", "151lat 431long"]
-        },
-        {
-          "name": ["hamilton county", "ohio"],
-          "coordinates": ["1.34 83.32", "151lat 431long"]
-        }
-      ]
     }
   }
 }


### PR DESCRIPTION
Metadata is now located in `attributes \ metadata `. 