### PR TITLE
add broadcast timeout

### DIFF
--- a/src/main/scala/dpla/ingestion3/executors/TopicModelExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/TopicModelExecutor.scala
@@ -58,6 +58,7 @@ trait TopicModelExecutor extends Serializable with IngestMessageTemplates {
     implicit val spark: SparkSession = SparkSession.builder()
       .config(sparkConf)
       .config("spark.ui.showConsoleProgress", value = false)
+      .config("spark.sql.broadcastTimeout", "600")
       .getOrCreate()
 
     spark.sparkContext.setLogLevel("WARN") // Lemmatizer is very verbose


### PR DESCRIPTION
This specifies that the broadcast timeout should be 600 seconds (the default is 300 seconds).  This fixes an error I encountered locally when running the `TopicModel` during a routine re-ingest of Recollection Wisconsin.  I tested it a few times with different values for the broadcast timeout, and so I'm pretty confident that this is a good permanent change.  