### PR TITLE
North Carolina rights mapping fix

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/NcMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/NcMapping.scala
@@ -87,7 +87,7 @@ class NcMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
   override def rights(data: Document[NodeSeq]): AtLeastOne[String] =
   // <accessCondition type="local rights statements">
     (data \\ "mods" \ "accessCondition")
-      .filter(node => filterAttribute(node, "type", "local rights statements"))
+      .filterNot(node => filterAttribute(node, "type", "use and reproduction"))
       .flatMap(extractStrings)
 
   override def subject(data: Document[NodeSeq]): Seq[SkosConcept] =

--- a/src/main/scala/dpla/ingestion3/mappers/providers/NcMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/NcMapping.scala
@@ -85,7 +85,7 @@ class NcMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
       .map(eitherStringOrUri)
 
   override def rights(data: Document[NodeSeq]): AtLeastOne[String] =
-  // <accessCondition type="local rights statements">
+  // all values except <accessCondition type="use and reproduction">
     (data \\ "mods" \ "accessCondition")
       .filterNot(node => filterAttribute(node, "type", "use and reproduction"))
       .flatMap(extractStrings)

--- a/src/test/scala/dpla/ingestion3/mappers/providers/NcMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/NcMappingTest.scala
@@ -103,6 +103,20 @@ class NcMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.publisher(xml) == expected)
   }
 
+  it should "extract the correct rights when accessCondition has not attributes" in {
+    val xml =
+      <record>
+        <metadata>
+          <mods>
+            <mods:accessCondition>rights statement.</mods:accessCondition>
+          </mods>
+        </metadata>
+      </record>
+
+    val expected = Seq("rights statement.")
+    assert(extractor.rights(Document(xml)) == expected)
+  }
+
   it should "extract the correct rights" in {
     val expected = Seq("Copyright Campbell University. The materials in this collection are made available for use in research, teaching and private study. Images and text may not be used for any commercial purposes without prior permission from Campbell University.")
     assert(extractor.rights(xml) == expected)


### PR DESCRIPTION
Change dc:rights mapping to use all `accessCondition` values other than rightsstatements.org values (e.g. everything except `<accessCondition type='use and reproduction'>`