### PR TITLE
NARA harvest delta

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,7 @@
-
+assemblyMergeStrategy in assembly := {
+  case "META-INF/MANIFEST.MF" => MergeStrategy.discard
+  case x => MergeStrategy.first
+}
 
 lazy val root = (project in file("."))
   .configs(IntegrationTest)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 resolvers += "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/"
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
 addSbtPlugin("com.codacy" % "sbt-codacy-coverage" % "1.3.11")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")

--- a/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
+++ b/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
@@ -46,7 +46,11 @@ class Ingestion3Conf(confFilePath: String, providerName: Option[String] = None) 
         // Properties for API harvests
         apiKey = getProp(providerConf, "harvest.apiKey"),
         rows = getProp(providerConf, "harvest.rows"),
-        query = getProp(providerConf, "harvest.query")
+        query = getProp(providerConf, "harvest.query"),
+        // Properties for FileDelta harvests
+        update = getProp(providerConf, "harvest.delta.update"),
+        previous = getProp(providerConf, "harvest.delta.previous"),
+        deletes = getProp(providerConf, "harvest.delta.deletes")
       ),
       i3Spark(
         // FIXME these should be removed
@@ -186,7 +190,12 @@ case class Harvest (
                      // API
                      rows: Option[String] = None,
                      query: Option[String] = None,
-                     apiKey: Option[String] = None
+                     apiKey: Option[String] = None,
+                     // File delta
+                     // Process NARA ingest using a incremental update of records
+                     update: Option[String] = None, // Path to delta update records
+                     previous: Option[String] = None, // Path to previously harvested records
+                     deletes: Option[String] = None // Path to deletes
                    )
 
 case class i3Conf(

--- a/src/main/scala/dpla/ingestion3/executors/HarvestExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/HarvestExecutor.scala
@@ -6,6 +6,7 @@ import com.databricks.spark.avro._
 import dpla.ingestion3.confs.i3Conf
 import dpla.ingestion3.dataStorage.OutputHelper
 import dpla.ingestion3.harvesters.Harvester
+import dpla.ingestion3.harvesters.file.NaraDeltaHarvester
 import dpla.ingestion3.harvesters.oai.OaiHarvester
 import dpla.ingestion3.harvesters.pss.PssHarvester
 import dpla.ingestion3.harvesters.resourceSync.RsHarvester
@@ -131,6 +132,8 @@ trait HarvestExecutor {
         new PssHarvester(spark, shortName, conf, logger)
       case "rs" =>
         new RsHarvester(spark, shortName, conf, logger)
+      case "nara.file.delta" =>
+        new NaraDeltaHarvester(spark, shortName, conf, logger)
       case "api" | "file" =>
         val harvesterClass = ProviderRegistry.lookupHarvesterClass(shortName) match {
           case Success(harvClass) => harvClass
@@ -141,7 +144,6 @@ trait HarvestExecutor {
         harvesterClass
           .getConstructor(classOf[SparkSession], classOf[String], classOf[i3Conf], classOf[Logger])
           .newInstance(spark, shortName, conf, logger)
-
       case _ =>
         val msg = s"Harvest type not recognized."
         logger.fatal(msg)

--- a/src/main/scala/dpla/ingestion3/harvesters/file/AvroFileFilter.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/AvroFileFilter.scala
@@ -1,0 +1,7 @@
+package dpla.ingestion3.harvesters.file
+
+import java.io.{File, FileFilter}
+
+class AvroFileFilter extends FileFilter {
+  override def accept(pathname: File): Boolean = pathname.getName.endsWith("avro")
+}

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NaraDeltaHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NaraDeltaHarvester.scala
@@ -1,0 +1,319 @@
+package dpla.ingestion3.harvesters.file
+
+import java.io.{BufferedReader, File, FileInputStream}
+import java.util.zip.GZIPInputStream
+
+import com.databricks.spark.avro._
+import dpla.ingestion3.confs.i3Conf
+import dpla.ingestion3.dataStorage.InputHelper
+import dpla.ingestion3.harvesters.{AvroHelper, Harvester}
+import dpla.ingestion3.utils.{FlatFileIO, Utils}
+import org.apache.avro.Schema
+import org.apache.avro.file.DataFileWriter
+import org.apache.avro.generic.{GenericData, GenericRecord}
+import org.apache.commons.io.{FileUtils, IOUtils}
+import org.apache.hadoop.fs.Path
+import org.apache.log4j.Logger
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.tools.bzip2.CBZip2InputStream
+import org.apache.tools.tar.TarInputStream
+
+import scala.util.{Failure, Success, Try}
+import scala.xml._
+
+class NaraDeltaHarvester(
+                         spark: SparkSession,
+                         shortName: String,
+                         conf: i3Conf,
+                         logger: Logger)
+  extends Harvester(spark, shortName, conf, logger) {
+
+  /**
+    * Case class hold the parsed value from a given FileResult
+    */
+  case class ParsedResult(id: String, item: String)
+
+
+  /**
+    * Case class to hold the results of a file
+    *
+    * @param entryName    Path of the entry in the file
+    * @param data         Holds the data for the entry, or None if it's a directory.
+    * @param bufferedData Holds a buffered reader for the entry if it's too
+    *                     large to be held in memory.
+    */
+  case class FileResult(entryName: String,
+                        data: Option[Array[Byte]],
+                        bufferedData: Option[BufferedReader] = None)
+
+
+  // FIXME revert to originalSchema
+  lazy val naraSchema: Schema =
+    new Schema.Parser().parse(new FlatFileIO().readFileAsString("/avro/NaraOriginalRecord.avsc"))
+
+  val avroWriterNara: DataFileWriter[GenericRecord] =
+    AvroHelper.avroWriter(shortName, naraTmp, naraSchema)
+
+  // Temporary output path.
+  lazy val naraTmp: String = new File(FileUtils.getTempDirectory, shortName).getAbsolutePath
+
+  def mimeType: String = "application_xml"
+
+  /**
+    * Loads .gz, .tgz, .bz, and .tbz2, and plain old .tar files.
+    *
+    * @param file File to parse
+    * @return TarInputstream of the tar contents
+    */
+  def getInputStream(file: File): Option[TarInputStream] =
+    file.getName match {
+      case gzName if gzName.endsWith("gz") || gzName.endsWith("tgz") =>
+        Some(new TarInputStream(new GZIPInputStream(new FileInputStream(file))))
+
+      case bz2name if bz2name.endsWith("bz2") || bz2name.endsWith("tbz2") =>
+        val inputStream = new FileInputStream(file)
+        inputStream.skip(2)
+        Some(new TarInputStream(new CBZip2InputStream(inputStream)))
+
+      case tarName if tarName.endsWith("tar") =>
+        Some(new TarInputStream(new FileInputStream(file)))
+
+      case _ => None
+    }
+
+  /**
+    * Takes care of parsing an xml file into a list of Nodes each representing an item
+    *
+    * @param xml Root of the xml document
+    * @return List of Options of id/item pairs.
+    */
+  def handleXML(xml: Node): List[Option[ParsedResult]] = {
+    for {
+      //three different types of nodes contain children that represent records
+      items <- xml \\ "item" :: xml \\ "itemAv" :: xml \\ "fileUnit" :: Nil
+      item <- items
+      if (item \ "digitalObjectArray" \ "digitalObject").nonEmpty
+    } yield item match {
+      case record: Node =>
+        val id = (record \ "digitalObjectArray" \ "digitalObject" \ "objectIdentifier").text.toString
+        val outputXML = xmlToString(record)
+        val label = item.label
+        Some(ParsedResult(id, outputXML))
+      case _ =>
+        logger.warn("Got weird result back for item path: " + item.getClass)
+        None
+    }
+  }
+
+  /**
+    * Main logic for handling individual entries in the tar.
+    *
+    * @param tarResult  Case class representing extracted item from the tar
+    * @return Count of metadata items found.
+    */
+  def handleFile(tarResult: FileResult,
+                 unixEpoch: Long,
+                 filename: String): Try[Int] =
+    tarResult.data match {
+      case None =>
+        Success(0) //a directory, no results
+
+      case Some(data) =>
+        Try {
+          val dataString = new String(data).replaceAll("<\\?xml.*\\?>", "").trim
+          val xml = XML.loadString(dataString)
+
+          val items = handleXML(xml)
+
+          val counts = for {
+            itemOption <- items
+            item <- itemOption // filters out the Nones
+          } yield {
+            writeOutNara(unixEpoch, item, filename)
+            1
+          }
+          counts.sum
+        }
+    }
+
+  def getAvroWriterNara: DataFileWriter[GenericRecord] = avroWriterNara
+
+  /**
+    * Writes item out
+    *
+    * @param unixEpoch Timestamp of the harvest
+    * @param item Harvested record
+    *
+    */
+  def writeOutNara(unixEpoch: Long, item: ParsedResult, file: String): Unit = {
+    val avroWriter = getAvroWriterNara
+    val schema = naraSchema
+
+    val genericRecord = new GenericData.Record(schema)
+    genericRecord.put("id", item.id)
+    genericRecord.put("ingestDate", unixEpoch)
+    genericRecord.put("provider", shortName)
+    genericRecord.put("document", item.item)
+    genericRecord.put("filename", file) // Used to order records by date updated.
+    genericRecord.put("mimetype", mimeType)
+
+    avroWriter.append(genericRecord)
+
+  }
+
+  /**
+    * Implements a stream of files from the tar.
+    * Can't use @tailrec here because the compiler can't recognize it as tail recursive,
+    * but this won't blow the stack.
+    *
+    * @param tarInputStream
+    * @return Lazy stream of tar records
+    */
+  def iter(tarInputStream: TarInputStream): Stream[FileResult] =
+    Option(tarInputStream.getNextEntry) match {
+      case None =>
+        Stream.empty
+
+      case Some(entry) =>
+        val filename = Try {
+          entry.getName
+        }.getOrElse("")
+
+        val result =
+          if (entry.isDirectory || filename.contains("._")) // drop OSX hidden files
+            None
+          else if (filename.endsWith(".xml")) // only read xml files
+            Some(IOUtils.toByteArray(tarInputStream, entry.getSize))
+          else
+            None
+
+        FileResult(entry.getName, result) #:: iter(tarInputStream)
+    }
+
+  /**
+    * Executes the nara harvest
+    */
+  def localHarvest(): DataFrame = {
+    val harvestTime = System.currentTimeMillis()
+    val unixEpoch = harvestTime  / 1000L
+
+    logger.info(s"Writing harvest tmp output to $naraTmp")
+
+    // The incremental update file
+    val deltaIn = new File(conf.harvest.update.getOrElse("in"))
+    // Get the most recent harvest data defined by the `in` parameter in the i3 configuration file
+    val previous = conf.harvest.previous.getOrElse("previous")
+
+    val previousHarvestIn: String = InputHelper.isActivityPath(previous) match {
+      case true => previous
+      case false => InputHelper.mostRecent(previous)
+        .getOrElse(throw new RuntimeException(s"Unable to load previous harvest data from $previous"))
+    }
+
+    // Deletes
+    val deletes = new File(conf.harvest.deletes.getOrElse("deletes"))
+
+    logger.info(s"Using previous harvest data from $previousHarvestIn")
+    logger.info(s"Using deletes data from ${deletes.getAbsolutePath}")
+
+    if (deltaIn.isDirectory)
+      for (file: File <- deltaIn.listFiles(new GzFileFilter).sorted) {
+        logger.info(s"Harvesting NARA delta changes from ${file.getName}")
+        harvestFile(file, unixEpoch)
+      }
+    else
+      harvestFile(deltaIn, unixEpoch)
+
+    // flush writes
+   avroWriterNara.flush()
+
+    // Get the absolute path of the avro file written to naraTmp directory
+    // TODO I think this is no longer required because it won't ever use HDFS...
+    val naraTempFile = new File(naraTmp)
+      .listFiles(new AvroFileFilter)
+      .headOption
+      .getOrElse(throw new RuntimeException(s"Unable to load avro file in $naraTmp directory. Unable to continue"))
+      .getAbsolutePath
+
+    val localSrcPath = new Path(naraTempFile)
+    val dfDeltaRecords = spark.read.avro(localSrcPath.toString)
+
+    // Read most recent harvest data file
+    val dfLastNaraHarvest: DataFrame = spark.read.avro(previousHarvestIn)
+
+    logger.info(s"Read ${dfLastNaraHarvest.count()} records from previous harvest")
+
+    // Create temp views of DataFrames for update DF
+    dfDeltaRecords.createOrReplaceTempView("delta")
+    dfLastNaraHarvest.createOrReplaceTempView("lastHarvest")
+
+    val updateDF = spark.sql("select lastHarvest.* from lastHarvest join delta on lastHarvest.id = delta.id")
+    val df = dfLastNaraHarvest.except(updateDF).union(dfDeltaRecords).toDF()
+
+    // process deletes
+    if (deletes.exists()) {
+      val deleteDf = getIdsToDelete(deletes)
+      logger.info(s"${deleteDf.size} records to delete in ${deletes.getAbsolutePath}")
+      df.where(!col("id").isin(deleteDf:_*))
+    } else {
+      logger.info("No deletes files specified. Removing no records from NARA data export")
+      df
+    }
+  }
+
+  /**
+    * Collect IDs from file(s) to be deleted from NARA harvest. This does not currently support adding records back
+    * which had previously been deleted.
+    *
+    * @param file File      Path to file or folder the defines which NARA IDs should be deleted
+    * @return Seq[String]   IDs to delete
+    */
+  def getIdsToDelete(file: File): Seq[String] = {
+    import spark.implicits._
+
+    val files = if (file.isDirectory) file.listFiles(new XmlFileFilter).sorted else Array(file)
+
+    files.flatMap(file => {
+      val xml = XML.loadFile(file)
+      (xml \\ "naId").map(_.text)
+    }).distinct
+      .toSeq
+  }
+
+  override def cleanUp(): Unit = {
+    logger.info(s"Cleaning up $naraTmp directory and files")
+    avroWriterNara.flush()
+    avroWriterNara.close()
+    // Delete temporary output directory and files.
+    Utils.deleteRecursively(new File(naraTmp))
+  }
+
+  private def harvestFile(file: File, unixEpoch: Long): Unit = {
+    val inputStream = getInputStream(file)
+      .getOrElse(throw new IllegalArgumentException(s"Couldn't load tar file: ${file.getAbsolutePath}"))
+
+    val recordCount = (for (tarResult <- iter(inputStream)) yield {
+      handleFile(tarResult, unixEpoch, file.getName) match {
+        case Failure(exception) =>
+          logger.error(s"Caught exception on ${tarResult.entryName}.", exception)
+          0
+        case Success(count) =>
+          count
+      }
+    }).sum
+
+    logger.info(s"Harvested $recordCount records from ${file.getName}")
+
+    IOUtils.closeQuietly(inputStream)
+  }
+
+  /**
+    * Converts a Node to an xml string
+    *
+    * @param node The root of the tree to write to a string
+    * @return a String containing xml
+    */
+  def xmlToString(node: Node): String =
+    Utility.serialize(node, minimizeTags = MinimizeMode.Always).toString
+}

--- a/src/main/scala/dpla/ingestion3/harvesters/file/XmlFileFilter.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/XmlFileFilter.scala
@@ -1,0 +1,7 @@
+package dpla.ingestion3.harvesters.file
+
+import java.io.{File, FileFilter}
+
+class XmlFileFilter extends FileFilter {
+  override def accept(pathname: File): Boolean = pathname.getName.endsWith("xml")
+}

--- a/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
@@ -341,7 +341,7 @@ class XmlMapper extends Mapper[NodeSeq, XmlMapping] {
         sidecar = mapping.sidecar(document),
         tags = mapping.tags(document),
         iiifManifest = validatedIIIFManifest,
-        mediaMaster = mapping.hotdog(document),
+        mediaMaster = mapping.mediaMaster(document),
         sourceResource = DplaSourceResource(
           alternateTitle = mapping.alternateTitle(document),
           collection = mapping.collection(document),
@@ -430,7 +430,7 @@ class JsonMapper extends Mapper[JValue, JsonMapping] {
         sidecar = mapping.sidecar(document),
         tags = mapping.tags(document),
         iiifManifest = validatedIIIFManifest,
-        mediaMaster = mapping.hotdog(document),
+        mediaMaster = mapping.mediaMaster(document),
         sourceResource = DplaSourceResource(
           alternateTitle = mapping.alternateTitle(document),
           collection = mapping.collection(document),

--- a/src/main/scala/dpla/ingestion3/mappers/providers/NaraMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/NaraMapping.scala
@@ -45,6 +45,9 @@ class NaraMapping extends XmlMapping with XmlExtractor {
   override def isShownAt(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
     Seq(uriOnlyWebResource(itemUri(data)))
 
+  override def mediaMaster(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
+    extractPreview(data)
+
   override def `object`(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
     extractPreview(data)
 

--- a/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
@@ -21,7 +21,7 @@ trait Mapping[T] {
   def isShownAt(data: Document[T]): ZeroToMany[EdmWebResource] = emptySeq
   def `object`(data: Document[T]): ZeroToMany[EdmWebResource] = emptySeq // full size image
   def preview(data: Document[T]): ZeroToMany[EdmWebResource] = emptySeq // thumbnail
-  def hotdog(data: Document[T]): ZeroToMany[EdmWebResource] = emptySeq // master media, ignore `object`
+  def mediaMaster(data: Document[T]): ZeroToMany[EdmWebResource] = emptySeq // master media, ignore `object`
   def iiifManifest(data: Document[T]): ZeroToMany[URI] = emptySeq // URL for IIIF presentation manifest
 
   def provider(data: Document[T]): ExactlyOne[EdmAgent] = emptyEdmAgent

--- a/src/test/scala/dpla/ingestion3/mappers/providers/NaraMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/NaraMappingTest.scala
@@ -196,6 +196,32 @@ class NaraMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.preview(Document(xml)) === Seq())
   }
 
+
+  it should "map multiple mediaMaster URLs that begin with https://opaexport-conv.s3.amazonaws.com/" in {
+    val xml = <item>
+      <naId>51046777</naId>
+      <digitalObjectArray>
+        <digitalObject>
+          <accessFilename>https://opaexport-conv.s3.amazonaws.com/TB149/Civil_War_Service_Index/M545-CW_ServRecdIndexUnion_MI/M545_0042/images/2514.jpg</accessFilename>
+          <objectType>
+            <termName>Image (JPG)</termName>
+          </objectType>
+        </digitalObject>
+        <digitalObject>
+          <accessFilename>https://opaexport-conv.s3.amazonaws.com/TB149/Civil_War_Service_Index/M545-CW_ServRecdIndexUnion_MI/M545_0042/images/2516.jpg</accessFilename>
+          <objectType>
+            <termName>Image (JPG)</termName>
+          </objectType>
+        </digitalObject>
+      </digitalObjectArray>
+    </item>
+
+    val correctUrls = Seq("https://catalog.archives.gov/OpaAPI/media/51046777/content/TB149/Civil_War_Service_Index/M545-CW_ServRecdIndexUnion_MI/M545_0042/images/2514.jpg",
+      "https://catalog.archives.gov/OpaAPI/media/51046777/content/TB149/Civil_War_Service_Index/M545-CW_ServRecdIndexUnion_MI/M545_0042/images/2516.jpg")
+    assert(extractor.preview(Document(xml)) === correctUrls.map(stringOnlyWebResource))
+  }
+
+
   it should "extract dataProvider from records with fileUnitPhysicalOccurrence" in {
     val xml = <item><physicalOccurrenceArray>
       <fileUnitPhysicalOccurrence>


### PR DESCRIPTION
* Add merge strategy to build.sbt

* Add XML file filter 

* Add AVRO file filter 

* Now allows for providing multiple files which define IDs to be removed. Files should be provided in a `/deletes/` folder along side data to be harvested. 
**Note** this still does not support adding back a record that was previously marked for deletion. That feature will require a more substantial rewrite to this harvester. 
```
./nara_original_records/
./nara_original_records/20191104-nara-delta.tar.gz
./nara_original_records/deletes/201905_deletes.xml
./nara_original_records/deletes/NAC_Deletes_0001.xml
```

