### PR TITLE
Gpo migration

### DIFF
--- a/src/main/scala/dpla/ingestion3/enrichments/normalizations/StringNormalizationUtils.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/normalizations/StringNormalizationUtils.scala
@@ -209,6 +209,14 @@ object StringNormalizationUtils {
     }
 
     /**
+      * If string does not contain an closing bracket, strip all opening brackets.
+      */
+    lazy val stripUnmatchedOpeningBrackets: SingleStringEnrichment = {
+      if (value.contains("]")) value
+      else value.replace("[", "")
+    }
+
+    /**
       * Strip all double quotes from the given string
       */
     lazy val stripDblQuotes: SingleStringEnrichment = value.replaceAll("\"", "")

--- a/src/main/scala/dpla/ingestion3/enrichments/normalizations/StringNormalizationUtils.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/normalizations/StringNormalizationUtils.scala
@@ -201,6 +201,14 @@ object StringNormalizationUtils {
     }
 
     /**
+      * If string does not contain an opening bracket, strip all closing brackets.
+      */
+    lazy val stripUnmatchedClosingBrackets: SingleStringEnrichment = {
+      if (value.contains("[")) value
+      else value.replace("]", "")
+    }
+
+    /**
       * Strip all double quotes from the given string
       */
     lazy val stripDblQuotes: SingleStringEnrichment = value.replaceAll("\"", "")

--- a/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
@@ -283,12 +283,11 @@ class XmlMapper extends Mapper[NodeSeq, XmlMapping] {
 
     // MappingException may be thrown from the `rights` method in provider mapping
     // See GPO mapping
-    // Error will be logged when entire record mapping is attempted, below
-    val mappedRights: Seq[String] = Try { mapping.rights(document) } match {
-      case Success(r) => r
-      case Failure(_) => Seq()
+    try {
+      validateRights(mapping.rights(document), mapping.edmRights(document), providerId, mapping.enforceRights)
+    } catch {
+      case _:MappingException => // do nothing, error will be logged when entire record mapping is attempted, below
     }
-    validateRights(mappedRights, mapping.edmRights(document), providerId, mapping.enforceRights)
 
     // Recommended field validation
     val validatedCreator = validateRecommendedProperty(mapping.creator(document), "creator", providerId)

--- a/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
@@ -281,7 +281,14 @@ class XmlMapper extends Mapper[NodeSeq, XmlMapping] {
     val validatedOriginalId = validateOriginalId(mapping.originalId(document), providerId, mapping.enforceOriginalId)
     val validatedDplaUri = validateDplaUri(mapping.dplaUri(document), providerId, mapping.enforceDplaUri)
 
-    validateRights(mapping.rights(document), mapping.edmRights(document), providerId, mapping.enforceRights)
+    // MappingException may be thrown from the `rights` method in provider mapping
+    // See GPO mapping
+    // Error will be logged when entire record mapping is attempted, below
+    val mappedRights: Seq[String] = Try { mapping.rights(document) } match {
+      case Success(r) => r
+      case Failure(_) => Seq()
+    }
+    validateRights(mappedRights, mapping.edmRights(document), providerId, mapping.enforceRights)
 
     // Recommended field validation
     val validatedCreator = validateRecommendedProperty(mapping.creator(document), "creator", providerId)

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -334,6 +334,7 @@ class GpoMapping extends MarcXmlMapping {
     // <datafield> tag = 611                    <subfield> code = d
     (marcFields(data, Seq("600", "610", "650", "651"), Seq("y")) ++ marcFields(data, Seq("611"), Seq("d")))
       .flatMap(extractStrings)
+      .map(_.stripSuffix("."))
       .map(stringOnlyTimeSpan)
       .distinct
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -28,6 +28,7 @@ class GpoMapping extends MarcXmlMapping {
     marcFields(data, Seq("700", "710", "711"))
       .filter(filterSubfields(_, Seq("e")) // include if subfield with @code=e exists and...
         .flatMap(extractStrings)
+        .map(_.stripSuffix("."))
         .exists(_ != "author") // ...#text != "author"
       )
       .map(extractStrings)
@@ -42,6 +43,7 @@ class GpoMapping extends MarcXmlMapping {
     val creator7xx = marcFields(data, Seq("700", "710", "711"))
       .filter(filterSubfields(_, Seq("e")) // include if subfield with @code=e exists and...
         .flatMap(extractStrings)
+        .map(_.stripSuffix("."))
         .exists(_ == "author") // ...#text = "author"
       )
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -1,7 +1,7 @@
 package dpla.ingestion3.mappers.providers
 
 import dpla.ingestion3.enrichments.normalizations.StringNormalizationUtils._
-import dpla.ingestion3.mappers.utils.{Document, MarcXmlMapping}
+import dpla.ingestion3.mappers.utils.{Document, MappingException, MarcXmlMapping}
 import dpla.ingestion3.model.DplaMapData._
 import dpla.ingestion3.model._
 import dpla.ingestion3.utils.Utils
@@ -245,7 +245,7 @@ class GpoMapping extends MarcXmlMapping {
 
     // Do not map records that have incompatible rights statements.
     theRights.foreach(r =>
-      if (excludedRights.contains(r)) throw new Exception("Incompatible rights statement")
+      if (excludedRights.contains(r)) throw MappingException("Incompatible rights statement")
     )
 
     theRights

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -1,0 +1,203 @@
+package dpla.ingestion3.mappers.providers
+
+import java.net.URL
+
+import dpla.ingestion3.enrichments.normalizations.StringNormalizationUtils._
+import dpla.ingestion3.mappers.utils.{Document, JsonExtractor, XmlExtractor, XmlMapping}
+import dpla.ingestion3.model.DplaMapData._
+import dpla.ingestion3.model._
+import dpla.ingestion3.utils.{HttpUtils, Utils}
+import org.json4s.jackson.JsonMethods._
+import org.json4s.JValue
+import org.json4s.JsonDSL._
+
+import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
+import scala.xml._
+
+
+class GpoMapping extends XmlMapping with XmlExtractor {
+
+  val isShownAtPrefix: String = ???
+
+  // ID minting functions
+  override def useProviderName: Boolean = true
+
+  override def getProviderName: String = "gpo"
+
+  override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] = ???
+
+  // SourceResource mapping
+
+  override def contributor(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
+    // <datafield> tag = 700, 710, or 711
+    marcFields(data, Seq("700", "710", "711"))
+      .filterNot(filterSubfields(_, Seq("e")) // exclude if subfield with @code=e exists and...
+        .flatMap(extractStrings)
+        .exists(_ == "author") // ...#text = "author"
+      )
+      .map(extractStrings)
+      .map(_.mkString(" "))
+      .map(nameOnlyAgent)
+
+  override def creator(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
+    // <datafield> tag = 100, 110, or 111
+    marcFields(data, Seq("100", "110", "111"))
+      .filter(filterSubfields(_, Seq("e")) // include if subfield with @code=e exists and...
+        .flatMap(extractStrings)
+        .exists(_ == "author") // ...#text = "author"
+      )
+      .map(extractStrings)
+      .map(_.mkString(" "))
+      .map(nameOnlyAgent)
+
+  override def date(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] =
+    // <datafield> tag = 260 or 264   <subfield> code = c
+    // <datafield> tag = 262
+    (marcFields(data, Seq("260", "264"), Seq("c")) ++ marcFields(data, Seq("262")))
+      .flatMap(extractStrings)
+      .map(stringOnlyTimeSpan)
+
+  override def description(data: Document[NodeSeq]): ZeroToMany[String] = ???
+
+  override def extent(data: Document[NodeSeq]): ZeroToMany[String] =
+    // <datafield> tag = 300  <subfield> code = a
+    marcFields(data, Seq("300"), Seq("a"))
+      .flatMap(extractStrings)
+      .map(_.stripSuffix(":"))
+
+  override def format(data: Document[NodeSeq]): ZeroToMany[String] = ???
+
+  override def identifier(data: Document[NodeSeq]): ZeroToMany[String] =
+    // <datafield> tag = 001, 020, or 022
+    // <datafield> tag = 035, 050, 074, 082, or 086  <subfield> code = a
+    (marcFields(data, Seq("001", "020", "022")) ++ marcFields(data, Seq("035", "050", "074", "082", "086"), Seq("a")))
+      .flatMap(extractStrings)
+
+  override def language(data: Document[NodeSeq]): ZeroToMany[SkosConcept] = ???
+
+  override def place(data: Document[NodeSeq]): ZeroToMany[DplaPlace] = ???
+
+  override def publisher(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
+    // <datafield> tag = 260 or 264   <subfield> code = a or b
+    marcFields(data, Seq("260", "264"), Seq("a, b"))
+      .flatMap(extractStrings)
+      .map(nameOnlyAgent)
+
+  override def relation(data: Document[NodeSeq]): ZeroToMany[LiteralOrUri] = ???
+
+  override def rights(data: Document[NodeSeq]): AtLeastOne[String] = ???
+
+  override def subject(data: Document[NodeSeq]): ZeroToMany[SkosConcept] = ???
+
+  override def temporal(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] = ???
+
+  override def title(data: Document[NodeSeq]): ZeroToMany[String] = ???
+
+  override def `type`(data: Document[NodeSeq]): ZeroToMany[String] = ???
+
+  // OreAggregation
+  override def dplaUri(data: Document[NodeSeq]): ZeroToOne[URI] = mintDplaItemUri(data)
+
+  override def dataProvider(data: Document[NodeSeq]): ZeroToMany[EdmAgent] = ???
+
+  override def isShownAt(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] = ???
+
+  override def originalRecord(data: Document[NodeSeq]): ExactlyOne[String] = Utils.formatXml(data)
+
+  override def preview(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] = ???
+
+  override def provider(data: Document[NodeSeq]): ExactlyOne[EdmAgent] = agent
+
+  override def sidecar(data: Document[NodeSeq]): JValue =
+    ("prehashId" -> buildProviderBaseId()(data)) ~ ("dplaId" -> mintDplaId(data))
+
+  // Helper method
+  def agent = EdmAgent(
+    name = Some("United States Government Publishing Office (GPO)"),
+    uri = Some(URI("http://dp.la/api/contributor/gpo"))
+  )
+
+  /**
+    * Get <dataset><subfield> nodes by tag and code
+    *
+    * @param data   Document
+    * @param tags   Seq[String] tags for <dataset>
+    * @param codes  Seq[String] codes for <subfield> (if empty or undefined, all <subfield> nodes will be returned)
+    * @return       Seq[NodeSeq] <subfield> nodes
+    */
+  private def marcFields(data: Document[NodeSeq], tags: Seq[String], codes: Seq[String] = Seq()): Seq[NodeSeq] = {
+    val sub: Seq[NodeSeq] = datafield(data, tags).map(n => n \ "subfield")
+    if (codes.nonEmpty) sub.map(n => filterSubfields(n, codes)) else sub
+  }
+
+  /**
+    * Get <dataset> nodes by tag
+    *
+    * @param data   Document
+    * @param tags   Seq[String] tags for <dataset>
+    * @return       NodeSeq <dataset> nodes
+    */
+  private def datafield(data: Document[NodeSeq], tags: Seq[String]): NodeSeq =
+    (data \ "datafield").flatMap(n => getByAttributeListOptions(n, "tag", tags))
+
+  /**
+    * Filter <subfield> nodes by code
+    *
+    * @param subfields  NodeSeq <subfield> nodes
+    * @param codes      Seq[String] codes for <subfield>
+    * @return           NodeSeq <subfield> nodes
+    */
+  private def filterSubfields(subfields: NodeSeq, codes: Seq[String]): NodeSeq =
+    subfields.flatMap(n => getByAttributeListOptions(n, "code", codes))
+
+  /**
+    * Get <controlfield> nodes by code
+    *
+    * @param data   Document
+    * @param tags   Seq[String] codes for <controlfield>
+    * @return       NodeSeq <controlfield> nodes
+    */
+  private def controlfield(data: Document[NodeSeq], tags: Seq[String]): NodeSeq =
+    (data \ "controlfield").flatMap(n => getByAttributeListOptions(n, "tag", tags))
+
+  /**
+    * Get the character at a specified index of a <controlfield> node
+    *
+    * @param data   Document
+    * @param tag    String tag for <controlfield> node
+    * @param index  Int index of the desired character
+    * @return       Option[Char] character if found
+    */
+  private def controlAt(data: Document[NodeSeq], tag: String, index: Int): Seq[Char] =
+    Try {
+      controlfield(data, Seq(tag))
+        .flatMap(extractStrings)
+        .map(_.charAt(index))
+    } match {
+      case Success(c) => c
+      case _ => Seq()
+    }
+
+  /**
+    * Get <leader> node
+    *
+    * @param data   Document
+    * @return       String text value of <leader> (empty String if leader not found)
+    */
+  private def leader(data: Document[NodeSeq]): String =
+    extractStrings(data \ "leader").headOption.getOrElse("")
+
+  /**
+    * Get the character at a specified index of the <leader> text
+    *
+    * @param data   Document
+    * @param index  Int index of the desired character
+    * @return       Option[Char] character if found
+    */
+  private def leaderAt(data: Document[NodeSeq], index: Int): Option[Char] = {
+    Try {
+      leader(data).charAt(index)
+    }.toOption
+  }
+}

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -213,9 +213,10 @@ class GpoMapping extends MarcXmlMapping {
       "public_domain_copyright_notice.htm"
 
   override def subject(data: Document[NodeSeq]): ZeroToMany[SkosConcept] =
-    // <datafield> tag = 600, 610, 611, 630, 650, or 651
+    // <datafield> tag = 600, 610, 611, 630, 650, or 651  <subfield> code is a letter (not a number)
     marcFields(data, Seq("600", "610", "611", "630", "650", "651"))
-      .flatMap(extractStrings)
+      .flatten
+      .map(extractMarcSubject)
       .map(nameOnlyConcept)
 
   override def temporal(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] =

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -325,8 +325,7 @@ class GpoMapping extends MarcXmlMapping {
 
   override def subject(data: Document[NodeSeq]): ZeroToMany[SkosConcept] =
     // <datafield> tag = 600, 610, 611, 630, 650, or 651  <subfield> code is a letter (not a number)
-    marcFields(data, Seq("600", "610", "611", "630", "650", "651"))
-      .flatten
+    datafield(data, Seq("600", "610", "611", "630", "650", "651"))
       .map(extractMarcSubject)
       .map(nameOnlyConcept)
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -255,11 +255,21 @@ class GpoMapping extends MarcXmlMapping {
       .map(extractStrings)
       .map(_.mkString(" "))
 
-  override def `type`(data: Document[NodeSeq]): ZeroToMany[String] =
-    // <datafield> tag = 337  <subfield> code = a
+  override def `type`(data: Document[NodeSeq]): ZeroToMany[String] = {
+    // <leader>                     #text characters at index 6 and 7
+    // <controlfield> tag = 007_01  #text at index 1
+    // <controlfield> tag = 008_21  #text at index 21
+    // <datafield> tag = 337        <subfield> code = a
     // <datafield> tag = 655
-    (marcFields(data, Seq("337"), Seq("a")) ++ marcFields(data, Seq("655")))
-      .flatMap(extractStrings)
+    // Only map <datafield> if <leader> and <controlfield> have no type value
+    val lType = extractMarcLeaderType(data)
+
+    if (lType.isDefined)
+      lType.toSeq
+    else
+      (marcFields(data, Seq("337"), Seq("a")) ++ marcFields(data, Seq("655")))
+        .flatMap(extractStrings)
+  }
 
   // OreAggregation
   override def dplaUri(data: Document[NodeSeq]): ZeroToOne[URI] = mintDplaItemUri(data)

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -209,7 +209,7 @@ class GpoMapping extends MarcXmlMapping {
 
   override def publisher(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
     // <datafield> tag = 260 or 264   <subfield> code = a or b
-    marcFields(data, Seq("260", "264"), Seq("a, b"))
+    marcFields(data, Seq("260", "264"), Seq("a", "b"))
       .map(extractStrings)
       .map(_.mkString(" "))
       .map(nameOnlyAgent)
@@ -246,6 +246,70 @@ class GpoMapping extends MarcXmlMapping {
       "and is in the public domain. For more information " +
       "please see http://www.gpo.gov/help/index.html#" +
       "public_domain_copyright_notice.htm"
+
+  private val excludedRights = Array(
+    "Access may require a library card.",
+
+    "Access restricted to U.S. military service members and Dept. " +
+      "of Defense employees; the only issues available are those " +
+      "from Monday of the prior week through Friday of current week.",
+
+    "Access to data provided for a fee except for requests " +
+      "generated from Internet domains of .gov, .edu, .k12, .us, " +
+      "and .mil.",
+
+    "Access to issues published prior to 2001 restricted to " +
+      "Picatinny Arsenal users.",
+
+    "Access to some volumes or items may be restricted",
+
+    "Document removed from the GPO Permanent Access Archive at " +
+      "agency request",
+
+    "FAA employees only.",
+
+    "First nine issues (Apr.-Dec. 2002) were law enforcement " +
+      "restricted publications and are not available to the general " +
+      "public.",
+
+    "Free to users at U.S. Federal depository libraries; other " +
+      "users are required to pay a fee.",
+
+    "Full text available to subscribers only.",
+
+    "Login and password required to access web page where " +
+      "electronic files may be downloaded.",
+
+    "Login and password required to access web page where " +
+      "electronic formats may be downloaded.",
+
+    "Not available for external use as of Monday, Oct. 20, 2003.",
+
+    "Personal registration and/or payment required to access some " +
+      "features.",
+
+    "Restricted access for security reasons",
+
+    "Restricted to Federal depository libraries and other users " +
+      "with valid user accounts.",
+
+    "Restricted to federal depository libraries with valid user " +
+      "IDs and passwords.",
+
+    "Restricted to institutions with a site license to the USA " +
+      "trade online database. Free to users at federal depository " +
+      "libraries.",
+
+    "Some components of this directory may not be publicly " +
+      "accessible.",
+
+    "Some v. are for official use only, i.e. distribution of Oct. " +
+      "1998 v. 2 is restricted.",
+
+    "Special issue for Oct./Dec. 2007 for official use only.",
+
+    "Subscription required for access."
+  )
 
   override def subject(data: Document[NodeSeq]): ZeroToMany[SkosConcept] =
     // <datafield> tag = 600, 610, 611, 630, 650, or 651  <subfield> code is a letter (not a number)
@@ -321,69 +385,5 @@ class GpoMapping extends MarcXmlMapping {
   def agent = EdmAgent(
     name = Some("United States Government Publishing Office (GPO)"),
     uri = Some(URI("http://dp.la/api/contributor/gpo"))
-  )
-
-  val excludedRights = Array(
-    "Access may require a library card.",
-
-    "Access restricted to U.S. military service members and Dept. " +
-    "of Defense employees; the only issues available are those " +
-    "from Monday of the prior week through Friday of current week.",
-
-    "Access to data provided for a fee except for requests " +
-    "generated from Internet domains of .gov, .edu, .k12, .us, " +
-    "and .mil.",
-
-    "Access to issues published prior to 2001 restricted to " +
-    "Picatinny Arsenal users.",
-
-    "Access to some volumes or items may be restricted",
-
-    "Document removed from the GPO Permanent Access Archive at " +
-    "agency request",
-
-    "FAA employees only.",
-
-    "First nine issues (Apr.-Dec. 2002) were law enforcement " +
-    "restricted publications and are not available to the general " +
-    "public.",
-
-    "Free to users at U.S. Federal depository libraries; other " +
-    "users are required to pay a fee.",
-
-    "Full text available to subscribers only.",
-
-    "Login and password required to access web page where " +
-    "electronic files may be downloaded.",
-
-    "Login and password required to access web page where " +
-    "electronic formats may be downloaded.",
-
-    "Not available for external use as of Monday, Oct. 20, 2003.",
-
-    "Personal registration and/or payment required to access some " +
-    "features.",
-
-    "Restricted access for security reasons",
-
-    "Restricted to Federal depository libraries and other users " +
-    "with valid user accounts.",
-
-    "Restricted to federal depository libraries with valid user " +
-    "IDs and passwords.",
-
-    "Restricted to institutions with a site license to the USA " +
-    "trade online database. Free to users at federal depository " +
-    "libraries.",
-
-    "Some components of this directory may not be publicly " +
-    "accessible.",
-
-    "Some v. are for official use only, i.e. distribution of Oct. " +
-    "1998 v. 2 is restricted.",
-
-    "Special issue for Oct./Dec. 2007 for official use only.",
-
-    "Subscription required for access."
   )
 }

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -337,13 +337,16 @@ class GpoMapping extends MarcXmlMapping {
       .map(stringOnlyTimeSpan)
       .distinct
 
-  override def title(data: Document[NodeSeq]): ZeroToMany[String] =
+  override def title(data: Document[NodeSeq]): ZeroToMany[String] = {
     // <datafield> tag = 245  <subfield> code != (c or h)
-    marcFields(data, Seq("245"))
+    val joinedTitle = marcFields(data, Seq("245"))
       .flatMap(nseq => nseq.filterNot(n => filterAttribute(n, "code", "c")))
       .flatMap(nseq => nseq.filterNot(n => filterAttribute(n, "code", "h")))
-      .map(extractStrings)
-      .map(_.mkString(" "))
+      .flatMap(extractStrings)
+      .mkString(" ")
+
+    Seq(joinedTitle)
+  }
 
   override def `type`(data: Document[NodeSeq]): ZeroToMany[String] = {
     // <leader>                     #text characters at index 6 and 7

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -143,6 +143,7 @@ class GpoMapping extends MarcXmlMapping {
       .map(extractStrings)
       .map(_.mkString(" "))
       .map(_.stripSuffix(":"))
+      .map(_.stripSuffix(";"))
 
   override def format(data: Document[NodeSeq]): ZeroToMany[String] = {
     // <leader> #text character at index 6
@@ -198,6 +199,8 @@ class GpoMapping extends MarcXmlMapping {
 
     val lang546 = marcFields(data, Seq("546"))
       .flatMap(extractStrings)
+      .map(_.stripPrefix("Text in "))
+      .map(_.stripSuffix("."))
 
     val lang041 = marcFields(data, Seq("041"))
       .flatMap(extractStrings)

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -1,5 +1,6 @@
 package dpla.ingestion3.mappers.providers
 
+import dpla.ingestion3.enrichments.normalizations.StringNormalizationUtils._
 import dpla.ingestion3.mappers.utils.{Document, MarcXmlMapping}
 import dpla.ingestion3.model.DplaMapData._
 import dpla.ingestion3.model._
@@ -70,6 +71,7 @@ class GpoMapping extends MarcXmlMapping {
 
     val dDate = dDateNodes
       .flatMap(extractStrings)
+      .map(_.stripUnmatchedClosingBrackets)
       .map(_.stripSuffix("."))
       .map(stringOnlyTimeSpan)
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -88,10 +88,8 @@ class GpoMapping extends MarcXmlMapping {
     val desc583 = marcFields(data, Seq("583"), Seq("z"))
     val desc5xx = marcFields(data, descTags)
 
-    // Use 310 and/or 583 if they exist.  If not, use 5xx.
-    val baseDesc =
-      (if ((desc310 ++ desc583).nonEmpty) desc310 ++ desc583 else desc5xx)
-        .flatMap(extractStrings)
+    val baseDesc = (desc310 ++ desc583 ++ desc5xx)
+      .flatMap(extractStrings)
 
     // Add description frequency if desc310 does not exist, <leader> at index 7 = 's',
     // and a description frequency key is present in <controlfield> 008_18
@@ -106,7 +104,7 @@ class GpoMapping extends MarcXmlMapping {
     }
 
     val theDesc =
-      if (desc310.isEmpty && leader7.contains('s') && freq.isDefined)
+      if ((desc310 ++ desc583).isEmpty && leader7.contains('s') && freq.isDefined)
         freq match {
           case Some(f) => baseDesc :+ f
           case None => baseDesc

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -1,18 +1,17 @@
 package dpla.ingestion3.mappers.providers
 
 import dpla.ingestion3.enrichments.normalizations.StringNormalizationUtils._
-import dpla.ingestion3.mappers.utils.{Document, XmlExtractor, XmlMapping}
+import dpla.ingestion3.mappers.utils.{Document, MarcXmlMapping}
 import dpla.ingestion3.model.DplaMapData._
 import dpla.ingestion3.model._
 import dpla.ingestion3.utils.{Utils}
 import org.json4s.JValue
 import org.json4s.JsonDSL._
 
-import scala.util.{Success, Try}
 import scala.xml._
 
 
-class GpoMapping extends XmlMapping with XmlExtractor {
+class GpoMapping extends MarcXmlMapping {
 
   val isShownAtPrefix: String = ???
 
@@ -264,89 +263,4 @@ class GpoMapping extends XmlMapping with XmlExtractor {
     name = Some("United States Government Publishing Office (GPO)"),
     uri = Some(URI("http://dp.la/api/contributor/gpo"))
   )
-
-  // TODO MOVE TO MARC UTIL
-
-  /**
-    * Get <dataset><subfield> nodes by tag and code
-    *
-    * @param data   Document
-    * @param tags   Seq[String] tags for <dataset>
-    * @param codes  Seq[String] codes for <subfield> (if empty or undefined, all <subfield> nodes will be returned)
-    * @return       Seq[NodeSeq] <subfield> nodes
-    */
-  private def marcFields(data: Document[NodeSeq], tags: Seq[String], codes: Seq[String] = Seq()): Seq[NodeSeq] = {
-    val sub: Seq[NodeSeq] = datafield(data, tags).map(n => n \ "subfield")
-    if (codes.nonEmpty) sub.map(n => filterSubfields(n, codes)) else sub
-  }
-
-  /**
-    * Get <dataset> nodes by tag
-    *
-    * @param data   Document
-    * @param tags   Seq[String] tags for <dataset>
-    * @return       NodeSeq <dataset> nodes
-    */
-  private def datafield(data: Document[NodeSeq], tags: Seq[String]): NodeSeq =
-    (data \ "datafield").flatMap(n => getByAttributeListOptions(n, "tag", tags))
-
-  /**
-    * Filter <subfield> nodes by code
-    *
-    * @param subfields  NodeSeq <subfield> nodes
-    * @param codes      Seq[String] codes for <subfield>
-    * @return           NodeSeq <subfield> nodes
-    */
-  private def filterSubfields(subfields: NodeSeq, codes: Seq[String]): NodeSeq =
-    subfields.flatMap(n => getByAttributeListOptions(n, "code", codes))
-
-  /**
-    * Get <controlfield> nodes by code
-    *
-    * @param data   Document
-    * @param tags   Seq[String] codes for <controlfield>
-    * @return       NodeSeq <controlfield> nodes
-    */
-  private def controlfield(data: Document[NodeSeq], tags: Seq[String]): NodeSeq =
-    (data \ "controlfield").flatMap(n => getByAttributeListOptions(n, "tag", tags))
-
-  /**
-    * Get the character at a specified index of a <controlfield> node
-    *
-    * @param data   Document
-    * @param tag    String tag for <controlfield> node
-    * @param index  Int index of the desired character
-    * @return       Option[Char] character if found
-    */
-  private def controlAt(data: Document[NodeSeq], tag: String, index: Int): Seq[Char] =
-    Try {
-      controlfield(data, Seq(tag))
-        .flatMap(extractStrings)
-        .map(_.charAt(index))
-    } match {
-      case Success(c) => c
-      case _ => Seq()
-    }
-
-  /**
-    * Get <leader> node
-    *
-    * @param data   Document
-    * @return       String text value of <leader> (empty String if leader not found)
-    */
-  private def leader(data: Document[NodeSeq]): String =
-    extractStrings(data \ "leader").headOption.getOrElse("")
-
-  /**
-    * Get the character at a specified index of the <leader> text
-    *
-    * @param data   Document
-    * @param index  Int index of the desired character
-    * @return       Option[Char] character if found
-    */
-  private def leaderAt(data: Document[NodeSeq], index: Int): Option[Char] = {
-    Try {
-      leader(data).charAt(index)
-    }.toOption
-  }
 }

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -36,6 +36,7 @@ class GpoMapping extends MarcXmlMapping {
 
   override def creator(data: Document[NodeSeq]): ZeroToMany[EdmAgent] = {
     // <datafield> tag = 100, 110, or 111
+    // <datafield> tag = 700, 710, or 711
     val creator1xx = marcFields(data, Seq("100", "110", "111"))
 
     val creator7xx = marcFields(data, Seq("700", "710", "711"))
@@ -176,7 +177,7 @@ class GpoMapping extends MarcXmlMapping {
       .map("ISSN: " + _)
 
     val genericIds = (marcFields(data, Seq("001")) ++ marcFields(data, Seq("035", "074", "082", "086"), Seq("a")))
-      .flatMap(extractStrings)
+      .map(extractStrings)
       .map(_.mkString(" "))
 
     lcIds ++ isbnIds ++ issnIds ++ genericIds

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -305,7 +305,10 @@ class GpoMapping extends MarcXmlMapping {
 
   override def originalRecord(data: Document[NodeSeq]): ExactlyOne[String] = Utils.formatXml(data)
 
-  override def preview(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] = ???
+  override def preview(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
+    // every record gets the same preview thumbnail
+    Seq("http://fdlp.gov/images/gpo-tn.jpg")
+      .map(stringOnlyWebResource)
 
   override def provider(data: Document[NodeSeq]): ExactlyOne[EdmAgent] = agent
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -344,6 +344,7 @@ class GpoMapping extends MarcXmlMapping {
       .flatMap(nseq => nseq.filterNot(n => filterAttribute(n, "code", "h")))
       .flatMap(extractStrings)
       .mkString(" ")
+      .stripSuffix(".")
 
     Seq(joinedTitle)
   }

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -83,6 +83,8 @@ class GpoMapping extends XmlMapping with XmlExtractor {
       (if ((desc310 ++ desc583).nonEmpty) desc310 ++ desc583 else desc5xx)
       .flatMap(extractStrings)
 
+    // Add description frequency if desc310 does not exist, <leader> at index 7 = 's',
+    // and a description frequency key is present in <controlfield> 008_18
     val leader7: Option[Char] = leaderAt(data, 7)
     val controlKey: String = controlfield(data,Seq("008_18")).flatMap(extractStrings).headOption.getOrElse("")
     val freq: Option[String] = descFrequency.get(controlKey)

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -72,6 +72,7 @@ class GpoMapping extends MarcXmlMapping {
     val dDate = dDateNodes
       .flatMap(extractStrings)
       .map(_.stripUnmatchedClosingBrackets)
+      .map(_.stripUnmatchedOpeningBrackets)
       .map(_.stripSuffix("."))
       .map(stringOnlyTimeSpan)
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -1,18 +1,14 @@
 package dpla.ingestion3.mappers.providers
 
-import java.net.URL
-
 import dpla.ingestion3.enrichments.normalizations.StringNormalizationUtils._
-import dpla.ingestion3.mappers.utils.{Document, JsonExtractor, XmlExtractor, XmlMapping}
+import dpla.ingestion3.mappers.utils.{Document, XmlExtractor, XmlMapping}
 import dpla.ingestion3.model.DplaMapData._
 import dpla.ingestion3.model._
-import dpla.ingestion3.utils.{HttpUtils, Utils}
-import org.json4s.jackson.JsonMethods._
+import dpla.ingestion3.utils.{Utils}
 import org.json4s.JValue
 import org.json4s.JsonDSL._
 
-import scala.annotation.tailrec
-import scala.util.{Failure, Success, Try}
+import scala.util.{Success, Try}
 import scala.xml._
 
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -56,20 +56,25 @@ class GpoMapping extends MarcXmlMapping {
   override def date(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] = {
     // <datafield> tag = 362
     // <datafield> tag = 260 or 264   <subfield> code = c
+    // <controlfield> tag = 008
     val date362 = marcFields(data, Seq("362"))
     val date260 = marcFields(data, Seq("260"), Seq("c"))
     val date264 = marcFields(data, Seq("264"), Seq("c"))
 
-    val theDate =
+    val dDateNodes =
       if (date362.nonEmpty) date362
       else if (leaderAt(data, 7).contains('m'))
         if (date260.nonEmpty) date260
         else date264
       else Seq()
 
-    theDate
+    val dDate = dDateNodes
       .flatMap(extractStrings)
+      .map(_.stripSuffix("."))
       .map(stringOnlyTimeSpan)
+
+    if (dDate.nonEmpty) dDate // use datafield date if present
+    else extractMarcControlDate(data) // else use controlfield date
   }
 
   override def description(data: Document[NodeSeq]): ZeroToMany[String] = {

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -18,7 +18,8 @@ class GpoMapping extends MarcXmlMapping {
 
   override def getProviderName: String = "gpo"
 
-  override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] = ???
+  override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
+    extractString(data \ "header" \ "identifier")
 
   // SourceResource mapping
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
@@ -353,34 +353,6 @@ class HathiMapping extends MarcXmlMapping {
   private val subjectTags: Seq[String] =
     (Seq(600, 630, 650, 651) ++ (610 to 619) ++ (653 to 658) ++ (690 to 699)).map(_.toString)
 
-  private val leaderFormats: Map[Char, String] = Map(
-    'a' -> "Language material",
-    'c' -> "Notated music",
-    'd' -> "Manuscript",
-    'e' -> "Cartographic material",
-    'f' -> "Manuscript cartographic material",
-    'g' -> "Projected medium",
-    'i' -> "Nonmusical sound recording"
-  )
-
-  private val controlFormats: Map[Char, String] = Map(
-    'a' -> "Map",
-    'c' -> "Electronic resource",
-    'd' -> "Globe",
-    'f' -> "Tactile material",
-    'g' -> "Projected graphic",
-    'h' -> "Microform",
-    'k' -> "Nonprojected graphic",
-    'm' -> "Motion picture",
-    'o' -> "Kit",
-    'q' -> "Notated music",
-    'r' -> "Remote-sensing image",
-    's' -> "Sound recording",
-    't' -> "Text",
-    'v' -> "Videorecording",
-    'z' -> "Unspecified"
-  )
-
   // type and genre mappings, derived from <leader> and <controlfield>
   private val leaderTypes: Map[String, (Option[String], Option[String])] = Map(
     "am" -> (Some("Book"), Some("Text")),

--- a/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
@@ -34,7 +34,7 @@ class HathiMapping extends XmlMapping with XmlExtractor {
   // SourceResource mapping
 
   override def contributor(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
-   // <datafield> tag = 700, 710, 711, or 720
+    // <datafield> tag = 700, 710, 711, or 720
     marcFields(data, Seq("700", "710", "711", "720"))
       .filterNot(filterSubfields(_, Seq("e")) // exclude subfields with @code=e and...
       .flatMap(extractStrings)

--- a/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
@@ -62,30 +62,7 @@ class HathiMapping extends MarcXmlMapping {
       .map(stringOnlyTimeSpan)
 
     if (dDate.nonEmpty) dDate // use datafield date if present
-    else {                    // if not, use controlfield date
-
-      val control: String = controlfield(data, Seq("008")).flatMap(extractStrings).headOption.getOrElse("")
-
-      // character at index 6 indicates type of date
-      val dateType = control.slice(6,7)
-
-      val cDate: Seq[String] = dateType match {
-        case "s" | "r" | "t" | "c" =>
-          // year
-          Seq(control.slice(7, 11))
-        case "m" | "q" | "d" =>
-          // year-year
-          val begin = control.slice(7, 11) + "-"
-          val end = control.slice(11, 15)
-          if (end == "9999") Seq(begin) else Seq(begin + end)
-        case "e" =>
-          // year-month-day
-          Seq(control.slice(7, 11) + "-" + control.slice(11, 13) + "-" + control.slice(13, 15))
-        case _ => Seq()
-      }
-
-      cDate.map(stringOnlyTimeSpan)
-    }
+    else extractMarcControlDate(data) // else use controlfield date
   }
 
   override def description(data: Document[NodeSeq]): ZeroToMany[String] =

--- a/src/main/scala/dpla/ingestion3/mappers/utils/MarcXmlMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/MarcXmlMapping.scala
@@ -26,7 +26,7 @@ trait MarcXmlMapping extends XmlMapping with XmlExtractor {
     * @return       NodeSeq <dataset> nodes
     */
   def datafield(data: Document[NodeSeq], tags: Seq[String]): NodeSeq =
-    (data \ "datafield").flatMap(n => getByAttributeListOptions(n, "tag", tags))
+    (data \\ "datafield").flatMap(n => getByAttributeListOptions(n, "tag", tags))
 
   /**
     * Filter <subfield> nodes by code
@@ -46,7 +46,7 @@ trait MarcXmlMapping extends XmlMapping with XmlExtractor {
     * @return       NodeSeq <controlfield> nodes
     */
   def controlfield(data: Document[NodeSeq], tags: Seq[String]): NodeSeq =
-    (data \ "controlfield").flatMap(n => getByAttributeListOptions(n, "tag", tags))
+    (data \\ "controlfield").flatMap(n => getByAttributeListOptions(n, "tag", tags))
 
   /**
     * Get the character at a specified index of a <controlfield> node
@@ -73,7 +73,7 @@ trait MarcXmlMapping extends XmlMapping with XmlExtractor {
     * @return       String text value of <leader> (empty String if leader not found)
     */
   def leader(data: Document[NodeSeq]): String =
-    extractStrings(data \ "leader").headOption.getOrElse("")
+    extractStrings(data \\ "leader").headOption.getOrElse("")
 
   /**
     * Get the character at a specified index of the <leader> text
@@ -147,7 +147,7 @@ trait MarcXmlMapping extends XmlMapping with XmlExtractor {
   def extractMarcSubject(node: Node): String = {
     val tag: String = node \@ "tag" // get tag for this datafield
 
-    (node \ "subfield")
+    (node \\ "subfield")
       .filter(n => ('a' to 'z').toList.map(_.toString).contains(n \@ "code")) // reject subfields with numeric codes
       .flatMap(subfield => {  // iterate through subfields
 

--- a/src/main/scala/dpla/ingestion3/mappers/utils/MarcXmlMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/MarcXmlMapping.scala
@@ -174,7 +174,7 @@ trait MarcXmlMapping extends XmlMapping with XmlExtractor {
 
       // strip trailing punctuation
       val text: String =
-        if (delimiter == ".") subfield.text.stripSuffix(",").stripSuffix(".")
+        if (delimiter == ". ") subfield.text.stripSuffix(",").stripSuffix(".")
         else subfield.text.stripSuffix(",")
 
       // return delimiter and text - note that the delimiter goes before the text

--- a/src/main/scala/dpla/ingestion3/mappers/utils/MarcXmlMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/MarcXmlMapping.scala
@@ -1,0 +1,89 @@
+package dpla.ingestion3.mappers.utils
+
+import scala.util.{Success, Try}
+import scala.xml.NodeSeq
+
+trait MarcXmlMapping extends XmlMapping with XmlExtractor {
+  /**
+    * Get <dataset><subfield> nodes by tag and code
+    *
+    * @param data   Document
+    * @param tags   Seq[String] tags for <dataset>
+    * @param codes  Seq[String] codes for <subfield> (if empty or undefined, all <subfield> nodes will be returned)
+    * @return       Seq[NodeSeq] <subfield> nodes
+    */
+  def marcFields(data: Document[NodeSeq], tags: Seq[String], codes: Seq[String] = Seq()): Seq[NodeSeq] = {
+    val sub: Seq[NodeSeq] = datafield(data, tags).map(n => n \ "subfield")
+    if (codes.nonEmpty) sub.map(n => filterSubfields(n, codes)) else sub
+  }
+
+  /**
+    * Get <dataset> nodes by tag
+    *
+    * @param data   Document
+    * @param tags   Seq[String] tags for <dataset>
+    * @return       NodeSeq <dataset> nodes
+    */
+  def datafield(data: Document[NodeSeq], tags: Seq[String]): NodeSeq =
+    (data \ "datafield").flatMap(n => getByAttributeListOptions(n, "tag", tags))
+
+  /**
+    * Filter <subfield> nodes by code
+    *
+    * @param subfields  NodeSeq <subfield> nodes
+    * @param codes      Seq[String] codes for <subfield>
+    * @return           NodeSeq <subfield> nodes
+    */
+  def filterSubfields(subfields: NodeSeq, codes: Seq[String]): NodeSeq =
+    subfields.flatMap(n => getByAttributeListOptions(n, "code", codes))
+
+  /**
+    * Get <controlfield> nodes by code
+    *
+    * @param data   Document
+    * @param tags   Seq[String] codes for <controlfield>
+    * @return       NodeSeq <controlfield> nodes
+    */
+  def controlfield(data: Document[NodeSeq], tags: Seq[String]): NodeSeq =
+    (data \ "controlfield").flatMap(n => getByAttributeListOptions(n, "tag", tags))
+
+  /**
+    * Get the character at a specified index of a <controlfield> node
+    *
+    * @param data   Document
+    * @param tag    String tag for <controlfield> node
+    * @param index  Int index of the desired character
+    * @return       Option[Char] character if found
+    */
+  def controlAt(data: Document[NodeSeq], tag: String, index: Int): Seq[Char] =
+    Try {
+      controlfield(data, Seq(tag))
+        .flatMap(extractStrings)
+        .map(_.charAt(index))
+    } match {
+      case Success(c) => c
+      case _ => Seq()
+    }
+
+  /**
+    * Get <leader> node
+    *
+    * @param data   Document
+    * @return       String text value of <leader> (empty String if leader not found)
+    */
+  def leader(data: Document[NodeSeq]): String =
+    extractStrings(data \ "leader").headOption.getOrElse("")
+
+  /**
+    * Get the character at a specified index of the <leader> text
+    *
+    * @param data   Document
+    * @param index  Int index of the desired character
+    * @return       Option[Char] character if found
+    */
+  def leaderAt(data: Document[NodeSeq], index: Int): Option[Char] = {
+    Try {
+      leader(data).charAt(index)
+    }.toOption
+  }
+}

--- a/src/main/scala/dpla/ingestion3/mappers/utils/MarcXmlMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/MarcXmlMapping.scala
@@ -1,7 +1,7 @@
 package dpla.ingestion3.mappers.utils
 
 import scala.util.{Success, Try}
-import scala.xml.NodeSeq
+import scala.xml.{Node, NodeSeq}
 
 trait MarcXmlMapping extends XmlMapping with XmlExtractor {
   /**
@@ -85,5 +85,47 @@ trait MarcXmlMapping extends XmlMapping with XmlExtractor {
     Try {
       leader(data).charAt(index)
     }.toOption
+  }
+
+  /**
+    * Extract a subject string from a Node
+    *
+    * @param node Node containing subject data
+    * @return     String
+    */
+  def extractMarcSubject(node: Node): String = {
+    val tag: String = node \@ "tag" // get tag for this datafield
+
+    (node \ "subfield")
+      .filter(n => ('a' to 'z').toList.map(_.toString).contains(n \@ "code")) // reject subfields with numeric codes
+      .flatMap(subfield => {  // iterate through subfields
+
+      val code: String = subfield \@ "code"
+
+      // choose appropriate delimiter based on tag and/or code values
+      val delimiter =
+        if (tag == "658")
+          code match {
+            case "b" => ":"
+            case "c" => ", "
+            case "d" => "--"
+            case _ => ". "
+          }
+        else if (tag == "653") "--"
+        else if ((690 to 699).map(_.toString).contains(tag)) "--"
+        else if (Seq("654", "655").contains(tag) && code == "b") "--"
+        else if (Seq("v", "x", "y", "z").contains(code)) "--"
+        else if (code == "d") ", "
+        else ". "
+
+      // strip trailing punctuation
+      val text: String =
+        if (delimiter == ".") subfield.text.stripSuffix(",").stripSuffix(".")
+        else subfield.text.stripSuffix(",")
+
+      // return delimiter and text - note that the delimiter goes before the text
+      Seq(delimiter, text)
+
+    }).drop(1).mkString("").stripSuffix(".") // drop leading delimiter and join substrings
   }
 }

--- a/src/main/scala/dpla/ingestion3/mappers/utils/MarcXmlMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/MarcXmlMapping.scala
@@ -87,6 +87,34 @@ trait MarcXmlMapping extends XmlMapping with XmlExtractor {
     }.toOption
   }
 
+  val leaderFormats: Map[Char, String] = Map(
+    'a' -> "Language material",
+    'c' -> "Notated music",
+    'd' -> "Manuscript",
+    'e' -> "Cartographic material",
+    'f' -> "Manuscript cartographic material",
+    'g' -> "Projected medium",
+    'i' -> "Nonmusical sound recording"
+  )
+
+  val controlFormats: Map[Char, String] = Map(
+    'a' -> "Map",
+    'c' -> "Electronic resource",
+    'd' -> "Globe",
+    'f' -> "Tactile material",
+    'g' -> "Projected graphic",
+    'h' -> "Microform",
+    'k' -> "Nonprojected graphic",
+    'm' -> "Motion picture",
+    'o' -> "Kit",
+    'q' -> "Notated music",
+    'r' -> "Remote-sensing image",
+    's' -> "Sound recording",
+    't' -> "Text",
+    'v' -> "Videorecording",
+    'z' -> "Unspecified"
+  )
+
   /**
     * Extract a subject string from a Node
     *

--- a/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
+++ b/src/main/scala/dpla/ingestion3/profiles/ProviderProfiles.scala
@@ -77,6 +77,16 @@ class GettyProfile extends XmlProfile {
 }
 
 /**
+  * United States Government Publishing Office (GPO)
+  */
+class GpoProfile extends XmlProfile {
+  type Mapping = GpoMapping
+
+  override def getHarvester = classOf[OaiHarvester]
+  override def getMapping = new GpoMapping
+}
+
+/**
   * Digital Library of Georgia
   */
 class DlgProfile extends JsonProfile {

--- a/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
+++ b/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
@@ -51,6 +51,7 @@ object ProviderRegistry {
     "esdn" -> Register(profile = new EsdnProfile),
     "florida" -> Register(profile = new FlProfile),
     "getty" -> Register(profile = new GettyProfile),
+    "gpo" -> Register(profile = new GpoProfile),
     "harvard" -> Register(profile = new HarvardProfile),
     "hathi" -> Register(profile = new HathiProfile),
     "ia" -> Register(profile = new IaProfile),

--- a/src/test/resources/gpo.xml
+++ b/src/test/resources/gpo.xml
@@ -1,0 +1,119 @@
+<record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.openarchives.org/OAI/2.0/">
+    <header>
+        <identifier>oai:catalog.gpo.gov:GPO01-000003356</identifier>
+        <datestamp>2014-07-11T06:00:23Z</datestamp>
+        <setSpec>PURL_ALL</setSpec>
+    </header>
+    <metadata>
+        <marc:record xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:marc="http://www.loc.gov/MARC21/slim">
+            <marc:leader>     cam  2200421Ia 4500</marc:leader>
+            <marc:controlfield tag="001">000003356</marc:controlfield>
+            <marc:controlfield tag="005">20070515142212.0</marc:controlfield>
+            <marc:controlfield tag="008">760625s1975    dcua     b   f000 0 eng d</marc:controlfield>
+            <marc:datafield ind2=" " ind1="9" tag="035">
+                <marc:subfield code="a">gp^76003356</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1=" " tag="035">
+                <marc:subfield code="a">(OCoLC)2281659</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1=" " tag="040">
+                <marc:subfield code="a">GPO</marc:subfield>
+                <marc:subfield code="c">GPO</marc:subfield>
+                <marc:subfield code="d">OCLCQ</marc:subfield>
+                <marc:subfield code="d">GPO</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1=" " tag="043">
+                <marc:subfield code="a">n-us---</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2="4" ind1=" " tag="050">
+                <marc:subfield code="a">RC1075</marc:subfield>
+                <marc:subfield code="b">.U68 no.75-8</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1=" " tag="074">
+                <marc:subfield code="a">0431-E-04</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1=" " tag="074">
+                <marc:subfield code="a">0431-E-04 (online)</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1="0" tag="086">
+                <marc:subfield code="a">TD 4.210:75-8</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1="1" tag="100">
+                <marc:subfield code="a">Thackray, Richard I.</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2="0" ind1="1" tag="245">
+                <marc:subfield code="a">Physiological, subjective, and performance correlates of reported boredom and monotony while performing a simulated radar control task /</marc:subfield>
+                <marc:subfield code="c">Richard I. Thackray, J. Powell Bailey, R. Mark Touchstone.</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1=" " tag="260">
+                <marc:subfield code="a">Washington, D.C. :</marc:subfield>
+                <marc:subfield code="b">U.S. Dept. of Transportation, Federal Aviation Administration, Office of Aviation Medicine,</marc:subfield>
+                <marc:subfield code="c">1975.</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1=" " tag="300">
+                <marc:subfield code="a">9 p. :</marc:subfield>
+                <marc:subfield code="b">ill. ;</marc:subfield>
+                <marc:subfield code="c">26 cm.</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1=" " tag="500">
+                <marc:subfield code="a">Cover title.</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1=" " tag="500">
+                <marc:subfield code="a">&quot;FAA-AM-75-8.&quot;</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1=" " tag="500">
+                <marc:subfield code="a">Prepared by Civil Aeromedical Institute, Oklahoma City, under task AM-C-75-PSY-48.</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1=" " tag="590">
+                <marc:subfield code="a">[pbk. $3.00, mf $0.95, 7 cds]</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1=" " tag="530">
+                <marc:subfield code="a">Also available via Internet from the FAA web site. Address as of 5/15/07: http://www.faa.gov/library/reports/medical/oamtechreports/1970s/media/AM75-08.pdf; current access is available via PURL.</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1=" " tag="504">
+                <marc:subfield code="a">Includes bibliographical references (p. 9).</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2="0" ind1=" " tag="650">
+                <marc:subfield code="a">Radar operators</marc:subfield>
+                <marc:subfield code="z">United States.</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2="0" ind1=" " tag="650">
+                <marc:subfield code="a">Radar air traffic control systems.</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2="0" ind1=" " tag="650">
+                <marc:subfield code="a">Aviation medicine</marc:subfield>
+                <marc:subfield code="x">Research.</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1="1" tag="700">
+                <marc:subfield code="a">Bailey, J. Powell.</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1="1" tag="700">
+                <marc:subfield code="a">Touchstone, R. Mark.</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1="1" tag="710">
+                <marc:subfield code="a">United States.</marc:subfield>
+                <marc:subfield code="b">Office of Aviation Medicine.</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1="2" tag="710">
+                <marc:subfield code="a">Civil Aeromedical Institute.</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2="1" ind1="4" tag="856">
+                <marc:subfield code="u">http://purl.access.gpo.gov/GPO/LPS81536</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1=" " tag="856">
+                <marc:subfield code="3">(paper, online)</marc:subfield>
+                <marc:subfield code="u">http://catalog.gpo.gov/fdlpdir/locate.jsp?ItemNumber=0431-E-04&amp;SYS=000003356</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1=" " tag="994">
+                <marc:subfield code="a">C0</marc:subfield>
+                <marc:subfield code="b">GPO</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1=" " tag="049">
+                <marc:subfield code="a">GPOO</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1=" " tag="955">
+                <marc:subfield code="a">bcb37 20070515</marc:subfield>
+            </marc:datafield>
+        </marc:record>
+    </metadata>
+</record>

--- a/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
@@ -247,6 +247,25 @@ class GpoMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.title(xml) === expected)
   }
 
+  it should "join title strings" in {
+    val xml =
+      <record>
+        <metadata>
+          <marc:record>
+            <marc:datafield ind2="0" ind1="1" tag="245">
+              <marc:subfield code="a">Radical responses to radical regimes</marc:subfield>
+              <marc:subfield code="h">[microform] :</marc:subfield>
+              <marc:subfield code="b">evaluating preemptive counter-proliferation /</marc:subfield>
+              <marc:subfield code="c">Barry R. Schneider.</marc:subfield>
+            </marc:datafield>
+          </marc:record>
+        </metadata>
+      </record>
+
+    val expected = Seq("Radical responses to radical regimes evaluating preemptive counter-proliferation /")
+    assert(extractor.title(Document(xml)) == expected)
+  }
+
   it should "extract the correct types from leader" in {
     val expected = Seq("Text")
     assert(extractor.`type`(xml) === expected)

--- a/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
@@ -30,7 +30,7 @@ class GpoMappingTest extends FlatSpec with BeforeAndAfter {
   }
 
 //  it should "extract the correct contributor" in {
-//    val expected = Seq("Everhart, Benjamin Matlock, 1818-1904.", "Academy of Natural Sciences of Philadelphia.")
+//    val expected = Seq("")
 //      .map(nameOnlyAgent)
 //    assert(extractor.contributor(xml) == expected)
 //  }
@@ -79,7 +79,7 @@ class GpoMappingTest extends FlatSpec with BeforeAndAfter {
   }
 
 //  it should "extract the correct language" in {
-//    val expected = Seq("ger", "eng").map(nameOnlyConcept)
+//    val expected = Seq("").map(nameOnlyConcept)
 //    assert(extractor.language(xml) == expected)
 //  }
 
@@ -95,12 +95,12 @@ class GpoMappingTest extends FlatSpec with BeforeAndAfter {
 
 //  it should "extract the correct relation" in {
 //    val expected =
-//      Seq("Online version:. Howard, Clifford, 1868-1942. What happened at Olenberg. Chicago : The Reilly & Britton Co., 1911. (OCoLC)656701318").map(eitherStringOrUri)
+//      Seq("").map(eitherStringOrUri)
 //    assert(extractor.relation(xml) === expected)
 //  }
 
 //  it should "extract the correct rights" in {
-//    val expected = Seq("This is a rights statement")
+//    val expected = Seq("")
 //    assert(extractor.rights(xml) === expected)
 //  }
 
@@ -124,6 +124,18 @@ class GpoMappingTest extends FlatSpec with BeforeAndAfter {
   }
 
 //  it should "throw exception for invalid rights statement" in {
+//    val xml =
+//      <record>
+//        <metadata>
+//          <marc:record>
+//            <marc:datafield tag="506">
+//              <marc:subfield>Subscription required for access.</marc:subfield>
+//            </marc:datafield>
+//          </marc:record>
+//        </metadata>
+//      </record>
+//
+//    //assert extractor.rights(Document(xml)) will throw exception
 //
 //  }
 
@@ -139,7 +151,7 @@ class GpoMappingTest extends FlatSpec with BeforeAndAfter {
   }
 
 //  it should "extract the correct temporal" in {
-//    val expected = Seq("1603 - 1714", "fast", "Stuarts, 1603-1714").map(stringOnlyTimeSpan)
+//    val expected = Seq("").map(stringOnlyTimeSpan)
 //    assert(extractor.temporal(xml) === expected)
 //  }
 

--- a/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
@@ -1,6 +1,6 @@
 package dpla.ingestion3.mappers.providers
 
-import dpla.ingestion3.mappers.utils.Document
+import dpla.ingestion3.mappers.utils.{Document, MappingException}
 import dpla.ingestion3.messages.{IngestMessage, MessageCollector}
 import dpla.ingestion3.model._
 import dpla.ingestion3.utils.FlatFileIO
@@ -212,7 +212,7 @@ class GpoMappingTest extends FlatSpec with BeforeAndAfter {
         </metadata>
       </record>
 
-    assertThrows[Exception] { extractor.rights(Document(xml)) }
+    assertThrows[MappingException] { extractor.rights(Document(xml)) }
   }
 
   it should "extract the correct subject" in {

--- a/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
@@ -224,6 +224,28 @@ class GpoMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.subject(xml) === expected)
   }
 
+  it should "strip trailing period in subjects when delimiter is period" in {
+    val xml =
+      <record>
+        <metadata>
+          <marc:record>
+            <marc:datafield ind2="0" ind1="1" tag="610">
+              <marc:subfield code="a">United States.</marc:subfield>
+              <marc:subfield code="b">National Aeronautics and Space Administration</marc:subfield>
+              <marc:subfield code="x">Management</marc:subfield>
+              <marc:subfield code="v">Bibliography</marc:subfield>
+              <marc:subfield code="v">Periodicals.</marc:subfield>
+            </marc:datafield>
+          </marc:record>
+        </metadata>
+      </record>
+
+    val expected = Seq("United States. National Aeronautics and Space Administration--Management--Bibliography--Periodicals")
+      .map(nameOnlyConcept)
+    
+    assert(extractor.subject(Document(xml)) == expected)
+  }
+
   it should "extract the correct temporal" in {
     val xml =
       <record>

--- a/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
@@ -29,11 +29,27 @@ class GpoMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.dplaUri(xml) === expected)
   }
 
-//  it should "extract the correct contributor" in {
-//    val expected = Seq("")
-//      .map(nameOnlyAgent)
-//    assert(extractor.contributor(xml) == expected)
-//  }
+  it should "extract the correct contributor" in {
+    val xml =
+      <record>
+        <metadata>
+          <marc:record>
+            <marc:datafield ind2=" " ind1="1" tag="700">
+              <marc:subfield code="a">Rezey, Maribeth L.,</marc:subfield>
+              <marc:subfield code="e">author.</marc:subfield>
+            </marc:datafield>
+            <marc:datafield ind2=" " ind1="1" tag="710">
+              <marc:subfield code="a">United States.</marc:subfield>
+              <marc:subfield code="b">Bureau of Justice Statistics,</marc:subfield>
+              <marc:subfield code="e">issuing body.</marc:subfield>
+            </marc:datafield>
+          </marc:record>
+        </metadata>
+      </record>
+    val expected = Seq("United States. Bureau of Justice Statistics, issuing body.")
+      .map(nameOnlyAgent)
+    assert(extractor.contributor(Document(xml)) == expected)
+  }
 
   it should "extract the correct creator" in {
     val expected = Seq("Thackray, Richard I.").map(nameOnlyAgent)
@@ -78,10 +94,36 @@ class GpoMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.identifier(xml) == expected)
   }
 
-//  it should "extract the correct language" in {
-//    val expected = Seq("").map(nameOnlyConcept)
-//    assert(extractor.language(xml) == expected)
-//  }
+  it should "extract the correct language (free text)" in {
+    val xml =
+      <record>
+        <metadata>
+          <marc:record>
+            <marc:datafield ind2=" " ind1=" " tag="546">
+              <marc:subfield code="a">Text in Spanish.</marc:subfield>
+            </marc:datafield>
+          </marc:record>
+        </metadata>
+      </record>
+    val expected = Seq("Text in Spanish.").map(nameOnlyConcept)
+    assert(extractor.language(Document(xml)) == expected)
+  }
+
+  it should "extract the correct language (code)" in {
+    val xml =
+      <record>
+        <metadata>
+          <marc:record>
+            <marc:datafield ind2=" " ind1="0" tag="041">
+              <marc:subfield code="a">eng</marc:subfield>
+              <marc:subfield code="a">spa</marc:subfield>
+            </marc:datafield>
+          </marc:record>
+        </metadata>
+      </record>
+    val expected = Seq("eng", "spa").map(nameOnlyConcept)
+    assert(extractor.language(Document(xml)) == expected)
+  }
 
   it should "extract the correct place" in {
     val expected = Seq("United States").map(nameOnlyPlace)
@@ -93,16 +135,37 @@ class GpoMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.publisher(xml) === expected)
   }
 
-//  it should "extract the correct relation" in {
-//    val expected =
-//      Seq("").map(eitherStringOrUri)
-//    assert(extractor.relation(xml) === expected)
-//  }
+  it should "extract the correct relation" in {
+    val xml =
+      <record>
+        <metadata>
+          <marc:record>
+            <marc:datafield ind2=" " ind1="1" tag="490">
+              <marc:subfield code="a">DHHS (NIOSH) publication ;</marc:subfield>
+              <marc:subfield code="v">no. 90-100</marc:subfield>
+            </marc:datafield>
+          </marc:record>
+        </metadata>
+      </record>
+    val expected =
+      Seq("DHHS (NIOSH) publication ;. no. 90-100.").map(eitherStringOrUri)
+    assert(extractor.relation(Document(xml)) === expected)
+  }
 
-//  it should "extract the correct rights" in {
-//    val expected = Seq("")
-//    assert(extractor.rights(xml) === expected)
-//  }
+  it should "extract the correct rights" in {
+    val xml =
+      <record>
+        <metadata>
+          <marc:record>
+            <marc:datafield ind2=" " ind1=" " tag="506">
+              <marc:subfield code="a">For official use only, v. 3.</marc:subfield>
+            </marc:datafield>
+          </marc:record>
+        </metadata>
+      </record>
+    val expected = Seq("For official use only, v. 3.")
+    assert(extractor.rights(Document(xml)) === expected)
+  }
 
   it should "provide default rights statement" in {
     val xml =
@@ -123,21 +186,20 @@ class GpoMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.rights(Document(xml)) === expected)
   }
 
-//  it should "throw exception for invalid rights statement" in {
-//    val xml =
-//      <record>
-//        <metadata>
-//          <marc:record>
-//            <marc:datafield tag="506">
-//              <marc:subfield>Subscription required for access.</marc:subfield>
-//            </marc:datafield>
-//          </marc:record>
-//        </metadata>
-//      </record>
-//
-//    //assert extractor.rights(Document(xml)) will throw exception
-//
-//  }
+  it should "throw exception for invalid rights statement" in {
+    val xml =
+      <record>
+        <metadata>
+          <marc:record>
+            <marc:datafield tag="506">
+              <marc:subfield>Subscription required for access.</marc:subfield>
+            </marc:datafield>
+          </marc:record>
+        </metadata>
+      </record>
+
+    assertThrows[Exception] { extractor.rights(Document(xml)) }
+  }
 
   it should "extract the correct subject" in {
     val expected = Seq(
@@ -150,10 +212,23 @@ class GpoMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.subject(xml) === expected)
   }
 
-//  it should "extract the correct temporal" in {
-//    val expected = Seq("").map(stringOnlyTimeSpan)
-//    assert(extractor.temporal(xml) === expected)
-//  }
+  it should "extract the correct temporal" in {
+    val xml =
+      <record>
+        <metadata>
+          <marc:record>
+            <marc:datafield ind2="0" ind1="2" tag="611">
+              <marc:subfield code="a">Olympic Winter Games</marc:subfield>
+              <marc:subfield code="n">(19th :</marc:subfield>
+              <marc:subfield code="d">2002 :</marc:subfield>
+              <marc:subfield code="c">Salt Lake City, Utah)</marc:subfield>
+            </marc:datafield>
+          </marc:record>
+        </metadata>
+      </record>
+    val expected = Seq("2002 :").map(stringOnlyTimeSpan)
+    assert(extractor.temporal(Document(xml)) === expected)
+  }
 
   it should "extract the correct titles" in {
     val expected = Seq("Physiological, subjective, and performance correlates of reported boredom and monotony while performing a simulated radar control task /")

--- a/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
@@ -77,4 +77,79 @@ class GpoMappingTest extends FlatSpec with BeforeAndAfter {
       "TD 4.210:75-8")
     assert(extractor.identifier(xml) == expected)
   }
+
+//  it should "extract the correct language" in {
+//    val expected = Seq("ger", "eng").map(nameOnlyConcept)
+//    assert(extractor.language(xml) == expected)
+//  }
+
+  it should "extract the correct place" in {
+    val expected = Seq("United States").map(nameOnlyPlace)
+    assert(extractor.place(xml) === expected)
+  }
+
+  it should "extract the correct publisher" in {
+    val expected = Seq("Washington, D.C. : U.S. Dept. of Transportation, Federal Aviation Administration, Office of Aviation Medicine,").map(nameOnlyAgent)
+    assert(extractor.publisher(xml) === expected)
+  }
+
+//  it should "extract the correct relation" in {
+//    val expected =
+//      Seq("Online version:. Howard, Clifford, 1868-1942. What happened at Olenberg. Chicago : The Reilly & Britton Co., 1911. (OCoLC)656701318").map(eitherStringOrUri)
+//    assert(extractor.relation(xml) === expected)
+//  }
+
+//  it should "extract the correct rights" in {
+//    val expected = Seq("This is a rights statement")
+//    assert(extractor.rights(xml) === expected)
+//  }
+
+  it should "provide default rights statement" in {
+    val xml =
+      <record>
+        <metadata>
+          <marc:record>
+          </marc:record>
+        </metadata>
+      </record>
+
+    val default = "Pursuant to Title 17 Section 105 of the United States " +
+      "Code, this file is not subject to copyright protection " +
+      "and is in the public domain. For more information " +
+      "please see http://www.gpo.gov/help/index.html#" +
+      "public_domain_copyright_notice.htm"
+
+    val expected = Seq(default)
+    assert(extractor.rights(Document(xml)) === expected)
+  }
+
+//  it should "throw exception for invalid rights statement" in {
+//
+//  }
+
+  it should "extract the correct subject" in {
+    val expected = Seq(
+      "Radar operators",
+      "United States",
+      "Radar air traffic control systems",
+      "Aviation medicine",
+      "Research"
+    ).map(nameOnlyConcept)
+    assert(extractor.subject(xml) === expected)
+  }
+
+//  it should "extract the correct temporal" in {
+//    val expected = Seq("1603 - 1714", "fast", "Stuarts, 1603-1714").map(stringOnlyTimeSpan)
+//    assert(extractor.temporal(xml) === expected)
+//  }
+
+  it should "extract the correct titles" in {
+    val expected = Seq("Physiological, subjective, and performance correlates of reported boredom and monotony while performing a simulated radar control task /")
+    assert(extractor.title(xml) === expected)
+  }
+
+  it should "extract the correct types from leader" in {
+    val expected = Seq("Text")
+    assert(extractor.`type`(xml) === expected)
+  }
 }

--- a/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
@@ -1,0 +1,80 @@
+package dpla.ingestion3.mappers.providers
+
+import dpla.ingestion3.mappers.utils.Document
+import dpla.ingestion3.messages.{IngestMessage, MessageCollector}
+import dpla.ingestion3.model._
+import dpla.ingestion3.utils.FlatFileIO
+import org.scalatest.{BeforeAndAfter, FlatSpec}
+
+import scala.xml.{NodeSeq, XML}
+
+class GpoMappingTest extends FlatSpec with BeforeAndAfter {
+
+  implicit val msgCollector: MessageCollector[IngestMessage] = new MessageCollector[IngestMessage]
+  val shortName = "gpo"
+  val xmlString: String = new FlatFileIO().readFileAsString("/gpo.xml")
+  val xml: Document[NodeSeq] = Document(XML.loadString(xmlString))
+  val extractor = new GpoMapping
+
+  it should "use the provider shortname in minting IDs " in
+    assert(extractor.useProviderName)
+
+  it should "extract the correct original identifier " in {
+    val expected = Some("oai:catalog.gpo.gov:GPO01-000003356")
+    assert(extractor.originalId(xml) === expected)
+  }
+
+  it should "create the correct DPLA URI" in {
+    val expected = Some(URI("http://dp.la/api/items/3bb32d23d7fef51d07bf4bb75b23ae31"))
+    assert(extractor.dplaUri(xml) === expected)
+  }
+
+//  it should "extract the correct contributor" in {
+//    val expected = Seq("Everhart, Benjamin Matlock, 1818-1904.", "Academy of Natural Sciences of Philadelphia.")
+//      .map(nameOnlyAgent)
+//    assert(extractor.contributor(xml) == expected)
+//  }
+
+  it should "extract the correct creator" in {
+    val expected = Seq("Thackray, Richard I.").map(nameOnlyAgent)
+    assert(extractor.creator(xml) == expected)
+  }
+
+  it should "extract the correct date" in {
+    val expected = Seq("1975.").map(stringOnlyTimeSpan)
+    assert(extractor.date(xml) === expected)
+  }
+
+  it should "extract the correct description" in {
+    val expected = Seq(
+      "Cover title.",
+      "\"FAA-AM-75-8.\"",
+      "Prepared by Civil Aeromedical Institute, Oklahoma City, under task AM-C-75-PSY-48.",
+      "[pbk. $3.00, mf $0.95, 7 cds]",
+      "Also available via Internet from the FAA web site. Address as of 5/15/07: http://www.faa.gov/library/reports/medical/oamtechreports/1970s/media/AM75-08.pdf; current access is available via PURL.",
+      "Includes bibliographical references (p. 9)."
+      )
+    assert(extractor.description(xml) == expected)
+  }
+
+  it should "extract the correct extent" in {
+    val expected = Seq("9 p. ")
+    assert(extractor.extent(xml) == expected)
+  }
+
+  it should "extract the correct format" in {
+    val expected = Seq("Language material")
+    assert(extractor.format(xml) == expected)
+  }
+
+  it should "extract the correct identifiers" in {
+    val expected = Seq(
+      "LC call number: RC1075",
+      "gp^76003356",
+      "(OCoLC)2281659",
+      "0431-E-04",
+      "0431-E-04 (online)",
+      "TD 4.210:75-8")
+    assert(extractor.identifier(xml) == expected)
+  }
+}

--- a/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
@@ -217,11 +217,9 @@ class GpoMappingTest extends FlatSpec with BeforeAndAfter {
 
   it should "extract the correct subject" in {
     val expected = Seq(
-      "Radar operators",
-      "United States",
+      "Radar operators--United States",
       "Radar air traffic control systems",
-      "Aviation medicine",
-      "Research"
+      "Aviation medicine--Research"
     ).map(nameOnlyConcept)
     assert(extractor.subject(xml) === expected)
   }

--- a/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
@@ -57,8 +57,22 @@ class GpoMappingTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "extract the correct date" in {
-    val expected = Seq("1975.").map(stringOnlyTimeSpan)
+    val expected = Seq("1975").map(stringOnlyTimeSpan)
     assert(extractor.date(xml) === expected)
+  }
+
+  it should "extract the correct controlfield date" in {
+    val xml =
+      <record>
+        <metadata>
+          <marc:record>
+            <marc:controlfield tag="008">120815c20129999mdu x w o    f0    2eng c</marc:controlfield>
+          </marc:record>
+        </metadata>
+      </record>
+
+    val expected = Seq("2012").map(stringOnlyTimeSpan)
+    assert(extractor.date(Document(xml)) == expected)
   }
 
   it should "extract the correct description" in {

--- a/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/GpoMappingTest.scala
@@ -108,7 +108,7 @@ class GpoMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.identifier(xml) == expected)
   }
 
-  it should "extract the correct language (free text)" in {
+  it should "extract the correct language (text)" in {
     val xml =
       <record>
         <metadata>
@@ -119,7 +119,7 @@ class GpoMappingTest extends FlatSpec with BeforeAndAfter {
           </marc:record>
         </metadata>
       </record>
-    val expected = Seq("Text in Spanish.").map(nameOnlyConcept)
+    val expected = Seq("Spanish").map(nameOnlyConcept)
     assert(extractor.language(Document(xml)) == expected)
   }
 


### PR DESCRIPTION
This adds a mapping for GPO.

There was some common logic between GPO and Hathi (the two MARC XML mappings) that I pulled out into a trait.  

The GPO mapping throws a `MappingException` if the rights statement indicates that the record should not be included in DPLA.  I have verified that the mappings for these records fail and the exceptions are logged in the Mapping error log.

QA was done with i1 -> i3 diff reports.