### PR TITLE
Feature/validate mapped fields only

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
@@ -154,12 +154,14 @@ trait Mapper[T, +E] extends IngestMessageTemplates {
     *
     * @param values Seq[T]                Values
     * @param field String                 Name of field being validated
+    * @param enforce Boolean              True   Enforce this validation and logs a warning for records missing this field
+    *                                     False  Does not perform any kind of checking for this field
     * @param providerId String            Local provider identifier
     * @param collector MessageCollector   Ingest message collector
     */
-  def validateRecommendedProperty[T](values: ZeroToMany[T], field: String, providerId: String)
+  def validateRecommendedProperty[T](values: ZeroToMany[T], field: String, providerId: String, enforce: Boolean)
                                 (implicit collector: MessageCollector[IngestMessage]): ZeroToMany[T] = {
-    if (values.isEmpty) {
+    if (values.isEmpty & enforce) {
       collector.add(missingRecommendedFieldMsg(providerId, field))
     }
     values
@@ -290,15 +292,15 @@ class XmlMapper extends Mapper[NodeSeq, XmlMapping] {
     }
 
     // Recommended field validation
-    val validatedCreator = validateRecommendedProperty(mapping.creator(document), "creator", providerId)
-    val validatedDate = validateRecommendedProperty(mapping.date(document), "date", providerId)
-    val validatedDescription = validateRecommendedProperty(mapping.description(document), "description", providerId)
-    val validatedFormat = validateRecommendedProperty(mapping.format(document), "format", providerId)
-    val validatedLanguage = validateRecommendedProperty(mapping.language(document), "language", providerId)
-    val validatedPlace = validateRecommendedProperty(mapping.place(document), "place", providerId)
-    val validatedPublisher = validateRecommendedProperty(mapping.publisher(document), "publisher", providerId)
-    val validatedSubject = validateRecommendedProperty(mapping.subject(document), "subject", providerId)
-    val validatedType = validateRecommendedProperty(mapping.`type`(document), "type", providerId)
+    val validatedCreator = validateRecommendedProperty(mapping.creator(document), "creator", providerId, mapping.enforceCreator)
+    val validatedDate = validateRecommendedProperty(mapping.date(document), "date", providerId, mapping.enforceDate)
+    val validatedDescription = validateRecommendedProperty(mapping.description(document), "description", providerId, mapping.enforceDescription)
+    val validatedFormat = validateRecommendedProperty(mapping.format(document), "format", providerId, mapping.enforceFormat)
+    val validatedLanguage = validateRecommendedProperty(mapping.language(document), "language", providerId, mapping.enforceLanguage)
+    val validatedPlace = validateRecommendedProperty(mapping.place(document), "place", providerId, mapping.enforcePlace)
+    val validatedPublisher = validateRecommendedProperty(mapping.publisher(document), "publisher", providerId, mapping.enforcePublisher)
+    val validatedSubject = validateRecommendedProperty(mapping.subject(document), "subject", providerId, mapping.enforceSubject)
+    val validatedType = validateRecommendedProperty(mapping.`type`(document), "type", providerId, mapping.enforceType)
 
     Try {
       OreAggregation(
@@ -370,15 +372,15 @@ class JsonMapper extends Mapper[JValue, JsonMapping] {
     validateRights(mapping.rights(document), mapping.edmRights(document), providerId, mapping.enforceRights)
 
     // Recommended field validation
-    val validatedCreator = validateRecommendedProperty(mapping.creator(document), "creator", providerId)
-    val validatedDate = validateRecommendedProperty(mapping.date(document), "date", providerId)
-    val validatedDescription = validateRecommendedProperty(mapping.description(document), "description", providerId)
-    val validatedFormat = validateRecommendedProperty(mapping.format(document), "format", providerId)
-    val validatedLanguage = validateRecommendedProperty(mapping.language(document), "language", providerId)
-    val validatedPlace = validateRecommendedProperty(mapping.place(document), "place", providerId)
-    val validatedPublisher = validateRecommendedProperty(mapping.publisher(document), "publisher", providerId)
-    val validatedSubject = validateRecommendedProperty(mapping.subject(document), "subject", providerId)
-    val validatedType = validateRecommendedProperty(mapping.`type`(document), "type", providerId)
+    val validatedCreator = validateRecommendedProperty(mapping.creator(document), "creator", providerId, mapping.enforceCreator)
+    val validatedDate = validateRecommendedProperty(mapping.date(document), "date", providerId, mapping.enforceDate)
+    val validatedDescription = validateRecommendedProperty(mapping.description(document), "description", providerId, mapping.enforceDescription)
+    val validatedFormat = validateRecommendedProperty(mapping.format(document), "format", providerId, mapping.enforceFormat)
+    val validatedLanguage = validateRecommendedProperty(mapping.language(document), "language", providerId, mapping.enforceLanguage)
+    val validatedPlace = validateRecommendedProperty(mapping.place(document), "place", providerId, mapping.enforcePlace)
+    val validatedPublisher = validateRecommendedProperty(mapping.publisher(document), "publisher", providerId, mapping.enforcePublisher)
+    val validatedSubject = validateRecommendedProperty(mapping.subject(document), "subject", providerId, mapping.enforceSubject)
+    val validatedType = validateRecommendedProperty(mapping.`type`(document), "type", providerId, mapping.enforceType)
 
     Try {
       OreAggregation(

--- a/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
@@ -13,43 +13,43 @@ trait Mapping[T] {
 
   // OreAggregation
   def dplaUri(data: Document[T]): ZeroToOne[URI] = None
-  def dataProvider(data: Document[T]): ZeroToMany[EdmAgent] = Seq()
-  def originalRecord(data: Document[T]): ExactlyOne[String] = ""
-  def hasView(data: Document[T]): ZeroToMany[EdmWebResource] = Seq()
+  def dataProvider(data: Document[T]): ZeroToMany[EdmAgent] = emptySeq
+  def originalRecord(data: Document[T]): ExactlyOne[String] = emptyString
+  def hasView(data: Document[T]): ZeroToMany[EdmWebResource] = emptySeq
   def intermediateProvider(data: Document[T]): ZeroToOne[EdmAgent] = None
 
-  def isShownAt(data: Document[T]): ZeroToMany[EdmWebResource] = Seq()
-  def `object`(data: Document[T]): ZeroToMany[EdmWebResource] = Seq() // full size image
-  def preview(data: Document[T]): ZeroToMany[EdmWebResource] = Seq() // thumbnail
+  def isShownAt(data: Document[T]): ZeroToMany[EdmWebResource] = emptySeq
+  def `object`(data: Document[T]): ZeroToMany[EdmWebResource] = emptySeq // full size image
+  def preview(data: Document[T]): ZeroToMany[EdmWebResource] = emptySeq // thumbnail
 
   def provider(data: Document[T]): ExactlyOne[EdmAgent] = emptyEdmAgent
-  def edmRights(data: Document[T]): ZeroToMany[URI] = Seq()
-  def sidecar(data: Document[T]): JValue = JValue()
-  def tags(data: Document[T]): ZeroToMany[URI] = Seq()
+  def edmRights(data: Document[T]): ZeroToMany[URI] = emptySeq
+  def sidecar(data: Document[T]): JValue = emptyJValue
+  def tags(data: Document[T]): ZeroToMany[URI] = emptySeq
 
   // SourceResource
-  def alternateTitle(data: Document[T]): ZeroToMany[String] = Seq()
-  def collection(data: Document[T]): ZeroToMany[DcmiTypeCollection] = Seq()
-  def contributor(data: Document[T]): ZeroToMany[EdmAgent] = Seq()
-  def creator(data: Document[T]): ZeroToMany[EdmAgent] = Seq()
-  def date(data: Document[T]): ZeroToMany[EdmTimeSpan] = Seq()
-  def description(data: Document[T]): ZeroToMany[String] = Seq()
-  def extent(data: Document[T]): ZeroToMany[String] = Seq()
-  def format(data: Document[T]): ZeroToMany[String] = Seq()
-  def genre(data: Document[T]): ZeroToMany[SkosConcept] = Seq()
-  def identifier(data: Document[T]): ZeroToMany[String] = Seq()
-  def language(data: Document[T]): ZeroToMany[SkosConcept] = Seq()
-  def place(data: Document[T]): ZeroToMany[DplaPlace] = Seq()
-  def publisher(data: Document[T]): ZeroToMany[EdmAgent] = Seq()
-  def relation(data: Document[T]): ZeroToMany[LiteralOrUri] = Seq()
-  def replacedBy(data: Document[T]): ZeroToMany[String] = Seq()
-  def replaces(data: Document[T]): ZeroToMany[String] = Seq()
-  def rights(data: Document[T]): AtLeastOne[String] = Seq()
-  def rightsHolder(data: Document[T]): ZeroToMany[EdmAgent] = Seq()
-  def subject(data: Document[T]): ZeroToMany[SkosConcept] = Seq()
-  def temporal(data: Document[T]): ZeroToMany[EdmTimeSpan] = Seq()
-  def title(data: Document[T]): AtLeastOne[String] = Seq()
-  def `type`(data: Document[T]): ZeroToMany[String] = Seq()
+  def alternateTitle(data: Document[T]): ZeroToMany[String] = emptySeq
+  def collection(data: Document[T]): ZeroToMany[DcmiTypeCollection] = emptySeq
+  def contributor(data: Document[T]): ZeroToMany[EdmAgent] = emptySeq
+  def creator(data: Document[T]): ZeroToMany[EdmAgent] = emptySeq
+  def date(data: Document[T]): ZeroToMany[EdmTimeSpan] = emptySeq
+  def description(data: Document[T]): ZeroToMany[String] = emptySeq
+  def extent(data: Document[T]): ZeroToMany[String] = emptySeq
+  def format(data: Document[T]): ZeroToMany[String] = emptySeq
+  def genre(data: Document[T]): ZeroToMany[SkosConcept] = emptySeq
+  def identifier(data: Document[T]): ZeroToMany[String] = emptySeq
+  def language(data: Document[T]): ZeroToMany[SkosConcept] = emptySeq
+  def place(data: Document[T]): ZeroToMany[DplaPlace] = emptySeq
+  def publisher(data: Document[T]): ZeroToMany[EdmAgent] = emptySeq
+  def relation(data: Document[T]): ZeroToMany[LiteralOrUri] = emptySeq
+  def replacedBy(data: Document[T]): ZeroToMany[String] = emptySeq
+  def replaces(data: Document[T]): ZeroToMany[String] = emptySeq
+  def rights(data: Document[T]): AtLeastOne[String] = emptySeq
+  def rightsHolder(data: Document[T]): ZeroToMany[EdmAgent] = emptySeq
+  def subject(data: Document[T]): ZeroToMany[SkosConcept] = emptySeq
+  def temporal(data: Document[T]): ZeroToMany[EdmTimeSpan] = emptySeq
+  def title(data: Document[T]): AtLeastOne[String] = emptySeq
+  def `type`(data: Document[T]): ZeroToMany[String] = emptySeq
 
 
   /**

--- a/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
@@ -12,19 +12,19 @@ trait Mapping[T] {
   implicit def unwrap(document: Document[T]): T = document.get
 
   // OreAggregation
-  def dplaUri(data: Document[T]): ZeroToOne[URI]
-  def dataProvider(data: Document[T]): ZeroToMany[EdmAgent]
-  def originalRecord(data: Document[T]): ExactlyOne[String]
+  def dplaUri(data: Document[T]): ZeroToOne[URI] = None
+  def dataProvider(data: Document[T]): ZeroToMany[EdmAgent] = Seq()
+  def originalRecord(data: Document[T]): ExactlyOne[String] = ""
   def hasView(data: Document[T]): ZeroToMany[EdmWebResource] = Seq()
   def intermediateProvider(data: Document[T]): ZeroToOne[EdmAgent] = None
 
-  def isShownAt(data: Document[T]): ZeroToMany[EdmWebResource]
+  def isShownAt(data: Document[T]): ZeroToMany[EdmWebResource] = Seq()
   def `object`(data: Document[T]): ZeroToMany[EdmWebResource] = Seq() // full size image
   def preview(data: Document[T]): ZeroToMany[EdmWebResource] = Seq() // thumbnail
 
-  def provider(data: Document[T]): ExactlyOne[EdmAgent]
+  def provider(data: Document[T]): ExactlyOne[EdmAgent] = emptyEdmAgent
   def edmRights(data: Document[T]): ZeroToMany[URI] = Seq()
-  def sidecar(data: Document[T]): JValue
+  def sidecar(data: Document[T]): JValue = JValue()
   def tags(data: Document[T]): ZeroToMany[URI] = Seq()
 
   // SourceResource
@@ -64,6 +64,19 @@ trait Mapping[T] {
   val enforcePreview: Boolean       = false // Do not enforce. Warn only if more than one preview URL provided in source
   val enforceRights: Boolean        = true
   val enforceTitle: Boolean         = true
+
+  /**
+    Define the defaults validating for optional fields
+  */
+  val enforceCreator: Boolean       = true
+  val enforceDate: Boolean          = true
+  val enforceDescription: Boolean   = true
+  val enforceFormat: Boolean        = true
+  val enforceLanguage: Boolean      = true
+  val enforcePlace: Boolean         = true
+  val enforcePublisher: Boolean     = true
+  val enforceSubject: Boolean       = true
+  val enforceType: Boolean          = true
 
   // Base item uri
   private val baseDplaItemUri = "http://dp.la/api/items/"

--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -57,7 +57,7 @@ package object model {
 
   def emptyEdmWebResource: EdmWebResource = stringOnlyWebResource("")
 
-  def emptyJValue: JValue = "" -> ""
+  def emptyJValue: JValue = JNothing
 
   def emptyOreAggregation = OreAggregation(
     dplaUri = URI(""),

--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -57,6 +57,8 @@ package object model {
 
   def emptyEdmWebResource: EdmWebResource = stringOnlyWebResource("")
 
+  def emptyJValue: JValue = "" -> ""
+
   def emptyOreAggregation = OreAggregation(
     dplaUri = URI(""),
     dataProvider = nameOnlyAgent(""),
@@ -69,6 +71,10 @@ package object model {
     ),
     originalId = ""
   )
+
+  def emptyString = ""
+
+  def emptySeq = Seq()
 
   lazy val ingestDate: String = {
     val now = Calendar.getInstance().getTime


### PR DESCRIPTION
Adds logic to conditionally validate recommended but optional fields in DPLA MAP. 
* creator
* date
* format
* language
* place
* publisher
* subject
* type

By default all recommended fields are checked for the presence of at least one value and if they do not have at least one value a warning message is logged. If a data provider does provide a mapping for one of these fields, the mapping should override the `enforce[Field]` value and set it to false. 

`override val enforceCreator = false // no mapping for creator provided, do not validate`