### PR TITLE
turning off dataProvider validation for Hathi

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
@@ -19,6 +19,8 @@ class HathiMapping extends MarcXmlMapping {
 
   val isShownAtPrefix: String = "http://catalog.hathitrust.org/Record/"
 
+  override val enforceDataProvider = false;
+
   // ID minting functions
   override def useProviderName: Boolean = true
 


### PR DESCRIPTION
Until we can get more coverage of Hathi's provider codes.