### PR TITLE
Stage 1 IIIF

### DIFF
--- a/src/main/resources/avro/MAPRecord.avsc
+++ b/src/main/resources/avro/MAPRecord.avsc
@@ -930,9 +930,10 @@
 
     {
       "name": "object",
-      "type": [
-        "null",
-        {
+      "type": {
+        "name": "ObjectEdmWebResourceArray",
+        "type": "array",
+        "items": {
           "name": "ObjectEdmWebResource",
           "type": "record",
           "fields": [
@@ -965,7 +966,7 @@
             }
           ]
         }
-      ]
+      }
     },
     {
       "name": "preview",
@@ -1132,6 +1133,13 @@
             "type": "array",
             "items": "string"
         }
+    },
+    {
+      "name": "iiifManifest",
+      "type": [
+        "null",
+        "string"
+      ]
     }
   ]
 }

--- a/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
@@ -119,11 +119,11 @@ trait Mapper[T, +E] extends IngestMessageTemplates {
     * @return Option[EdmWebResource]      object EdmWebResource
     */
   def validateObject(values: ZeroToMany[EdmWebResource], providerId: String, enforce: Boolean)
-                       (implicit collector: MessageCollector[IngestMessage]): ZeroToOne[EdmWebResource] = {
+                       (implicit collector: MessageCollector[IngestMessage]): ZeroToMany[EdmWebResource] = {
     if (values.size > 1) {
       collector.add(moreThanOneValueMsg(providerId, "object", values.toString(), msg = None, enforce))
     }
-    values.headOption
+    values
   }
 
   /**
@@ -316,6 +316,7 @@ class XmlMapper extends Mapper[NodeSeq, XmlMapping] {
         provider = mapping.provider(document),
         sidecar = mapping.sidecar(document),
         tags = mapping.tags(document),
+        iiifManifest = mapping.iiifManifest(document),
         sourceResource = DplaSourceResource(
           alternateTitle = mapping.alternateTitle(document),
           collection = mapping.collection(document),
@@ -396,6 +397,7 @@ class JsonMapper extends Mapper[JValue, JsonMapping] {
         provider = mapping.provider(document),
         sidecar = mapping.sidecar(document),
         tags = mapping.tags(document),
+        iiifManifest = mapping.iiifManifest(document),
         sourceResource = DplaSourceResource(
           alternateTitle = mapping.alternateTitle(document),
           collection = mapping.collection(document),

--- a/src/main/scala/dpla/ingestion3/mappers/rdf/DplaRdfMapper.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/rdf/DplaRdfMapper.scala
@@ -2,7 +2,7 @@ package dpla.ingestion3.mappers.rdf
 
 
 import dpla.ingestion3.model._
-import org.eclipse.rdf4j.model.{IRI, Model, Resource}
+import org.eclipse.rdf4j.model.{Model, Resource}
 
 /**
   * This class handles mapping DplaMapData to the RDF4J Model domain
@@ -50,8 +50,8 @@ class DplaRdfMapper(doc: OreAggregation) extends RdfBuilderUtils {
     map(edm.hasView, oreAggregation.hasView)
 
     //big image
-    if (oreAggregation.`object`.isDefined)
-      map(edm.`object`, edmWebResource(oreAggregation.`object`.get))
+    if (oreAggregation.`object`.nonEmpty)
+      map(edm.`object`, oreAggregation.`object`.map(edmWebResource))
 
     //thumbnail
     if (oreAggregation.preview.isDefined)

--- a/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
@@ -19,8 +19,9 @@ trait Mapping[T] {
   def intermediateProvider(data: Document[T]): ZeroToOne[EdmAgent] = None
 
   def isShownAt(data: Document[T]): ZeroToMany[EdmWebResource] = emptySeq
-  def `object`(data: Document[T]): ZeroToMany[EdmWebResource] = emptySeq // full size image
+  def `object`(data: Document[T]): ZeroToMany[EdmWebResource] = emptySeq // full size image(s)
   def preview(data: Document[T]): ZeroToMany[EdmWebResource] = emptySeq // thumbnail
+  def iiifManifest(data: Document[T]): ZeroToOne[URI] = None // IIIF Manifest for presentation API
 
   def provider(data: Document[T]): ExactlyOne[EdmAgent] = emptyEdmAgent
   def edmRights(data: Document[T]): ZeroToMany[URI] = emptySeq

--- a/src/main/scala/dpla/ingestion3/model/DplaMapData.scala
+++ b/src/main/scala/dpla/ingestion3/model/DplaMapData.scala
@@ -33,14 +33,15 @@ case class OreAggregation(
                            hasView: ZeroToMany[EdmWebResource] = Seq(),
                            intermediateProvider: ZeroToOne[EdmAgent] = None,
                            isShownAt: ExactlyOne[EdmWebResource],
-                           `object`: ZeroToOne[EdmWebResource] = None, // full size image
-                           preview: ZeroToOne[EdmWebResource] = None, // thumbnail
+                           `object`: ZeroToMany[EdmWebResource] = Seq(), // full size image(s), does not export to JSON-L
+                           preview: ZeroToOne[EdmWebResource] = None, // thumbnail, maps to `object` prop in JSON-L export
                            provider: ExactlyOne[EdmAgent],
                            edmRights: ZeroToOne[URI] = None,
                            sidecar: JValue = JNothing,
                            messages: ZeroToMany[IngestMessage] = Seq[IngestMessage](),
                            originalId: ExactlyOne[String],
-                           tags: ZeroToMany[URI] = Seq[URI]()
+                           tags: ZeroToMany[URI] = Seq[URI](),
+                           iiifManifest: ZeroToOne[URI] = None // iiif manifest uri
                          )
 
 /**
@@ -80,9 +81,10 @@ case class DplaSourceResource(
 case class EdmWebResource(
                            uri: ExactlyOne[URI],
                            fileFormat: ZeroToMany[String] = Seq(),
-                           dcRights: ZeroToMany[String] = Seq(),
-                           edmRights: ZeroToOne[String] = None, //todo should be a URI?
-                           isReferencedBy: ZeroToOne[URI] = None
+                           dcRights: ZeroToMany[String] = Seq(), // todo should be removed?
+                           edmRights: ZeroToOne[String] = None, //todo should be a URI? or should be removed?
+                           isReferencedBy: ZeroToOne[URI] = None  // should be iiif manifest according to MAP spec
+                                                                  // but in practice see oreAgg.iiifManifest
                          )
 
 

--- a/src/main/scala/dpla/ingestion3/model/ModelConverter.scala
+++ b/src/main/scala/dpla/ingestion3/model/ModelConverter.scala
@@ -27,14 +27,15 @@ object ModelConverter {
     hasView = toRows(row, 4).map(toEdmWebResource),
     intermediateProvider = Option(row.getStruct(5)).map(toEdmAgent),
     isShownAt = toEdmWebResource(row.getStruct(6)),
-    `object` = toOptionEdmWebResource(row.getStruct(7)),
+    `object` = toMulti(row, 7, toEdmWebResource),
     preview = toOptionEdmWebResource(row.getStruct(8)),
     provider = toEdmAgent(row.getStruct(9)),
     edmRights = optionalUri(row, 10),
     sidecar = optionalJValue(row, 11),
     messages = toMulti(row, 12, toIngestMessage),
     originalId = potentiallyMissingStringField(row, 13).getOrElse("MISSING"),
-    tags = potentiallyMissingArrayOfUrisField(row, 14)
+    tags = potentiallyMissingArrayOfUrisField(row, 14),
+    iiifManifest = optionalUri(row, 15)
   )
 
   private[model] def toSourceResource(row: Row): DplaSourceResource = DplaSourceResource(

--- a/src/main/scala/dpla/ingestion3/model/RowConverter.scala
+++ b/src/main/scala/dpla/ingestion3/model/RowConverter.scala
@@ -29,14 +29,15 @@ object RowConverter {
         oreAggregation.hasView.map(fromEdmWebResource), //4
         oreAggregation.intermediateProvider.map(fromEdmAgent).orNull, //5
         fromEdmWebResource(oreAggregation.isShownAt), //6
-        oreAggregation.`object`.map(fromEdmWebResource).orNull, //7
+        oreAggregation.`object`.map(fromEdmWebResource), //7
         oreAggregation.preview.map(fromEdmWebResource).orNull, //8
         fromEdmAgent(oreAggregation.provider), //9
         oreAggregation.edmRights.map(_.toString).orNull, //10
         compact(render(oreAggregation.sidecar)), //11
         oreAggregation.messages.map(fromIngestMessage), //12
         oreAggregation.originalId, //13
-        oreAggregation.tags.map(_.toString) //14
+        oreAggregation.tags.map(_.toString), //14
+        oreAggregation.iiifManifest.map(_.toString).orNull //15
       ),
       sqlSchema
     )

--- a/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
+++ b/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
@@ -1,7 +1,6 @@
 package dpla.ingestion3.data
 
 import dpla.ingestion3.model._
-import org.json4s.jackson.JsonMethods.parse
 import org.json4s.JsonDSL._
 
 object EnrichedRecordFixture {
@@ -21,7 +20,7 @@ object EnrichedRecordFixture {
       intermediateProvider = Some(
         EdmAgent(name = Some("The Intermediate Provider"))
       ),
-      `object` = Some(
+      `object` = Seq(
         EdmWebResource(uri = new URI("https://example.org/record/123.html"))
       ),
       preview = Some(
@@ -110,7 +109,7 @@ object EnrichedRecordFixture {
       intermediateProvider = Some(
         EdmAgent(name = Some("The Intermediate Provider"))
       ),
-      `object` = Some(
+      `object` = Seq(
         EdmWebResource(uri = new URI("https://example.org/record/123.html"))
       ),
       preview = Some(

--- a/src/test/scala/dpla/ingestion3/model/ModelConverterTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/ModelConverterTest.scala
@@ -255,20 +255,22 @@ class ModelConverterTest extends FlatSpec with BeforeAndAfter {
   it should "convert an OreAggregation" in {
     val testResult1 = ModelConverter.toModel(
       Row(
-        urlString1,
-        testSourceResource,
-        testEdmAgent,
-        "an original record",
-        Seq(testEdmWebResource, testEdmWebResource),
-        testEdmAgent,
-        testEdmWebResource,
-        testEdmWebResource,
-        testEdmWebResource,
-        testEdmAgent,
-        urlString1,
-        """"{"field": "value"}""",
-        Seq(testIngestMessage),
-        "an original ID"
+        urlString1, // dplaUri
+        testSourceResource, // sourceResource
+        testEdmAgent, // dataProvider
+        "an original record", // originalRecord
+        Seq(testEdmWebResource, testEdmWebResource), // hasView
+        testEdmAgent, // intermediateProvider
+        testEdmWebResource, // isShownAt
+        Seq(testEdmWebResource), // object
+        testEdmWebResource, // preview
+        testEdmAgent, // provider
+        urlString1, // edmRights
+        """"{"field": "value"}""", // sidecar
+        Seq(testIngestMessage), // messages
+        "an original ID" // originalId
+        // todo add tags
+        // todo add iiifManifest
       )
     )
 
@@ -280,11 +282,14 @@ class ModelConverterTest extends FlatSpec with BeforeAndAfter {
     assert(testResult1.originalRecord === "an original record" )
     assert(testResult1.hasView === Seq(edmWebResource, edmWebResource))
     assert(testResult1.intermediateProvider === Some(edmAgent))
-    assert(testResult1.`object` === Some(edmWebResource))
+    assert(testResult1.`object` === Seq(edmWebResource))
     assert(testResult1.preview === Some(edmWebResource))
     assert(testResult1.provider === edmAgent)
     assert(testResult1.edmRights === Some(URI(urlString1)))
     assert(testResult1.originalId === "an original ID")
+
+    // todo asset tags
+    // todo assert iiifManifest
   }
 
   it should "convert an EdmWebResource" in {

--- a/src/test/scala/dpla/ingestion3/model/RowConverterTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/RowConverterTest.scala
@@ -220,7 +220,7 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
       hasView = Seq(edmWebResource, edmWebResource),
       intermediateProvider = Some(edmAgent),
       isShownAt = edmWebResource,
-      `object` = Some(edmWebResource),
+      `object` = Seq(edmWebResource),
       preview = Some(edmWebResource),
       provider = edmAgent,
       edmRights = Some(uri1),
@@ -234,7 +234,7 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
     assert(row(4) === oreAggregation.hasView.map(RowConverter.fromEdmWebResource))
     assert(row(5) === oreAggregation.intermediateProvider.map(RowConverter.fromEdmAgent).orNull)
     assert(row(6) === RowConverter.fromEdmWebResource(oreAggregation.isShownAt))
-    assert(row(7) === oreAggregation.`object`.map(RowConverter.fromEdmWebResource).orNull)
+    assert(row(7) === oreAggregation.`object`.map(RowConverter.fromEdmWebResource))
     assert(row(8) === oreAggregation.preview.map(RowConverter.fromEdmWebResource).orNull)
     assert(row(9) === RowConverter.fromEdmAgent(oreAggregation.provider))
     assert(row(10) === oreAggregation.edmRights.map(_.toString).orNull)


### PR DESCRIPTION
All changes implemented stop short of changing what JSON is written for the index. 
* Make `object` multi-valued
* Add dedicated, optional, single-valued URI field for IIIF manifest, `iiifManifest`
* Update row and model converters with these changes
* Update row and model converter tests 
* Update MAP AVRO schema 
* Add comments 