### PR TITLE
Feature/iiif v2

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
@@ -341,7 +341,7 @@ class XmlMapper extends Mapper[NodeSeq, XmlMapping] {
         sidecar = mapping.sidecar(document),
         tags = mapping.tags(document),
         iiifManifest = validatedIIIFManifest,
-        hotdog = mapping.hotdog(document),
+        mediaMaster = mapping.hotdog(document),
         sourceResource = DplaSourceResource(
           alternateTitle = mapping.alternateTitle(document),
           collection = mapping.collection(document),
@@ -430,7 +430,7 @@ class JsonMapper extends Mapper[JValue, JsonMapping] {
         sidecar = mapping.sidecar(document),
         tags = mapping.tags(document),
         iiifManifest = validatedIIIFManifest,
-        hotdog = mapping.hotdog(document),
+        mediaMaster = mapping.hotdog(document),
         sourceResource = DplaSourceResource(
           alternateTitle = mapping.alternateTitle(document),
           collection = mapping.collection(document),

--- a/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
@@ -21,6 +21,8 @@ trait Mapping[T] {
   def isShownAt(data: Document[T]): ZeroToMany[EdmWebResource] = emptySeq
   def `object`(data: Document[T]): ZeroToMany[EdmWebResource] = emptySeq // full size image
   def preview(data: Document[T]): ZeroToMany[EdmWebResource] = emptySeq // thumbnail
+  def hotdog(data: Document[T]): ZeroToMany[EdmWebResource] = emptySeq // master media, ignore `object`
+  def iiifManifest(data: Document[T]): ZeroToMany[URI] = emptySeq // URL for IIIF presentation manifest
 
   def provider(data: Document[T]): ExactlyOne[EdmAgent] = emptyEdmAgent
   def edmRights(data: Document[T]): ZeroToMany[URI] = emptySeq
@@ -77,6 +79,7 @@ trait Mapping[T] {
   val enforcePublisher: Boolean     = true
   val enforceSubject: Boolean       = true
   val enforceType: Boolean          = true
+  val enforceIIIF: Boolean          = true
 
   // Base item uri
   private val baseDplaItemUri = "http://dp.la/api/items/"

--- a/src/main/scala/dpla/ingestion3/model/DplaMapData.scala
+++ b/src/main/scala/dpla/ingestion3/model/DplaMapData.scala
@@ -40,7 +40,10 @@ case class OreAggregation(
                            sidecar: JValue = JNothing,
                            messages: ZeroToMany[IngestMessage] = Seq[IngestMessage](),
                            originalId: ExactlyOne[String],
-                           tags: ZeroToMany[URI] = Seq[URI]()
+                           tags: ZeroToMany[URI] = Seq[URI](),
+                           iiifManifest: ZeroToOne[URI] = None, // URL for IIIF presentation manifest
+                           hotdog: ZeroToMany[EdmWebResource] = Seq() // master media representation of artifact
+
                          )
 
 /**

--- a/src/main/scala/dpla/ingestion3/model/DplaMapData.scala
+++ b/src/main/scala/dpla/ingestion3/model/DplaMapData.scala
@@ -42,7 +42,7 @@ case class OreAggregation(
                            originalId: ExactlyOne[String],
                            tags: ZeroToMany[URI] = Seq[URI](),
                            iiifManifest: ZeroToOne[URI] = None, // URL for IIIF presentation manifest
-                           hotdog: ZeroToMany[EdmWebResource] = Seq() // master media representation of artifact
+                           mediaMaster: ZeroToMany[EdmWebResource] = Seq() // master media representation of artifact
 
                          )
 

--- a/src/main/scala/dpla/ingestion3/model/ModelConverter.scala
+++ b/src/main/scala/dpla/ingestion3/model/ModelConverter.scala
@@ -34,7 +34,9 @@ object ModelConverter {
     sidecar = optionalJValue(row, 11),
     messages = toMulti(row, 12, toIngestMessage),
     originalId = potentiallyMissingStringField(row, 13).getOrElse("MISSING"),
-    tags = potentiallyMissingArrayOfUrisField(row, 14)
+    tags = potentiallyMissingArrayOfUrisField(row, 14),
+    iiifManifest = optionalUri(row, 15),
+    hotdog = toRows(row, 16).map(toEdmWebResource)
   )
 
   private[model] def toSourceResource(row: Row): DplaSourceResource = DplaSourceResource(

--- a/src/main/scala/dpla/ingestion3/model/ModelConverter.scala
+++ b/src/main/scala/dpla/ingestion3/model/ModelConverter.scala
@@ -36,7 +36,7 @@ object ModelConverter {
     originalId = potentiallyMissingStringField(row, 13).getOrElse("MISSING"),
     tags = potentiallyMissingArrayOfUrisField(row, 14), // FIXME with potentiallyMissing[T]
     iiifManifest = optionalUri(row, 15),
-    hotdog = potentiallyMissing(row, 16, toEdmWebResource)
+    mediaMaster = potentiallyMissing(row, 16, toEdmWebResource)
   )
 
   private[model] def toSourceResource(row: Row): DplaSourceResource = DplaSourceResource(

--- a/src/main/scala/dpla/ingestion3/model/ModelConverter.scala
+++ b/src/main/scala/dpla/ingestion3/model/ModelConverter.scala
@@ -34,9 +34,9 @@ object ModelConverter {
     sidecar = optionalJValue(row, 11),
     messages = toMulti(row, 12, toIngestMessage),
     originalId = potentiallyMissingStringField(row, 13).getOrElse("MISSING"),
-    tags = potentiallyMissingArrayOfUrisField(row, 14),
+    tags = potentiallyMissingArrayOfUrisField(row, 14), // FIXME with potentiallyMissing[T]
     iiifManifest = optionalUri(row, 15),
-    hotdog = toRows(row, 16).map(toEdmWebResource)
+    hotdog = potentiallyMissing(row, 16, toEdmWebResource)
   )
 
   private[model] def toSourceResource(row: Row): DplaSourceResource = DplaSourceResource(
@@ -162,7 +162,7 @@ object ModelConverter {
     row.getSeq[String](fieldPosition)
 
   private[model] def uriSeq(row: Row, fieldPosition: Integer): Seq[URI] =
-    stringSeq(row, fieldPosition).map(new URI(_))
+    stringSeq(row, fieldPosition).map(URI)
 
   private[model] def optionalJValue(row: Row, fieldPosition: Integer): JValue =
     Try {
@@ -181,5 +181,10 @@ object ModelConverter {
   private[model] def potentiallyMissingArrayOfUrisField(row: Row, fieldPosition: Integer): Seq[URI] =
     Try {
       uriSeq(row, fieldPosition)
+    }.getOrElse(Seq())
+
+  private[model] def potentiallyMissing[T](row: Row, fieldPosition: Integer, f: (Row) => T): Seq[T] =
+    Try {
+      toMulti(row, fieldPosition, f)
     }.getOrElse(Seq())
 }

--- a/src/main/scala/dpla/ingestion3/model/RowConverter.scala
+++ b/src/main/scala/dpla/ingestion3/model/RowConverter.scala
@@ -38,7 +38,7 @@ object RowConverter {
         oreAggregation.originalId, //13
         oreAggregation.tags.map(_.toString), //14
         oreAggregation.iiifManifest.map(_.toString).orNull, //15
-        oreAggregation.hotdog.map(fromEdmWebResource) //16
+        oreAggregation.mediaMaster.map(fromEdmWebResource) //16
       ),
       sqlSchema
     )

--- a/src/main/scala/dpla/ingestion3/model/RowConverter.scala
+++ b/src/main/scala/dpla/ingestion3/model/RowConverter.scala
@@ -36,7 +36,9 @@ object RowConverter {
         compact(render(oreAggregation.sidecar)), //11
         oreAggregation.messages.map(fromIngestMessage), //12
         oreAggregation.originalId, //13
-        oreAggregation.tags.map(_.toString) //14
+        oreAggregation.tags.map(_.toString), //14
+        oreAggregation.iiifManifest.map(_.toString).orNull, //15
+        oreAggregation.hotdog.map(fromEdmWebResource) //16
       ),
       sqlSchema
     )

--- a/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
+++ b/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
@@ -33,7 +33,7 @@ object EnrichedRecordFixture {
       sidecar = ("prehashId" -> "oai:somestate:id123") ~ ("dplaId" -> "4b1bd605bd1d75ee23baadb0e1f24457"),
       originalId = "The original ID",
       iiifManifest = Some(URI("http://iiif.example/1/")),
-      hotdog = Seq(stringOnlyWebResource("http://example.fullframe.com/1/")),
+      mediaMaster = Seq(stringOnlyWebResource("http://example.fullframe.com/1/")),
       sourceResource = DplaSourceResource(
         collection = Seq(DcmiTypeCollection(
           title = Some("The Collection"),

--- a/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
+++ b/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
@@ -1,7 +1,6 @@
 package dpla.ingestion3.data
 
 import dpla.ingestion3.model._
-import org.json4s.jackson.JsonMethods.parse
 import org.json4s.JsonDSL._
 
 object EnrichedRecordFixture {
@@ -33,6 +32,8 @@ object EnrichedRecordFixture {
       ),
       sidecar = ("prehashId" -> "oai:somestate:id123") ~ ("dplaId" -> "4b1bd605bd1d75ee23baadb0e1f24457"),
       originalId = "The original ID",
+      iiifManifest = Some(URI("http://iiif.example/1/")),
+      hotdog = Seq(stringOnlyWebResource("http://example.fullframe.com/1/")),
       sourceResource = DplaSourceResource(
         collection = Seq(DcmiTypeCollection(
           title = Some("The Collection"),

--- a/src/test/scala/dpla/ingestion3/model/ModelConverterTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/ModelConverterTest.scala
@@ -19,6 +19,7 @@ class ModelConverterTest extends FlatSpec with BeforeAndAfter {
   val urlString2 = "http://google.com"
   val urlString3 = "http://yahoo.com"
   val urlisRefBy = "http://isRefd.by/"
+  val urlTags = "http://dp.la/tag/1"
 
   val testEdmAgent = Row(
     urlString1,
@@ -268,7 +269,10 @@ class ModelConverterTest extends FlatSpec with BeforeAndAfter {
         urlString1,
         """"{"field": "value"}""",
         Seq(testIngestMessage),
-        "an original ID"
+        "an original ID",
+        urlTags, // tags
+        urlString1, // iiif
+        Seq(testEdmWebResource) // hotdog
       )
     )
 

--- a/src/test/scala/dpla/ingestion3/model/ModelConverterTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/ModelConverterTest.scala
@@ -272,7 +272,7 @@ class ModelConverterTest extends FlatSpec with BeforeAndAfter {
         "an original ID",
         urlTags, // tags
         urlString1, // iiif
-        Seq(testEdmWebResource) // hotdog
+        Seq(testEdmWebResource) // mediaMaster
       )
     )
 

--- a/src/test/scala/dpla/ingestion3/model/RowConverterTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/RowConverterTest.scala
@@ -224,7 +224,10 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
       preview = Some(edmWebResource),
       provider = edmAgent,
       edmRights = Some(uri1),
-      originalId = "original ID"
+      originalId = "original ID",
+      tags = Seq(uri1), // tags
+      iiifManifest = Some(uri1), // iiif
+      hotdog = Seq(edmWebResource) // hotdog
     )
     val row = RowConverter.toRow(oreAggregation, sparkSchema)
     assert(row(0) === oreAggregation.dplaUri.toString)
@@ -239,6 +242,9 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
     assert(row(9) === RowConverter.fromEdmAgent(oreAggregation.provider))
     assert(row(10) === oreAggregation.edmRights.map(_.toString).orNull)
     assert(row(13) === oreAggregation.originalId)
+    assert(row(14) === oreAggregation.tags.map(_.toString)) // 14, tags
+    assert(row(15) === oreAggregation.iiifManifest.map(_.toString).orNull) // 15, iiifManifest
+    assert(row(16) === oreAggregation.hotdog.map(RowConverter.fromEdmWebResource)) // 16, hotdog
   }
 
   it should "convert a SourceResource" in {

--- a/src/test/scala/dpla/ingestion3/model/RowConverterTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/RowConverterTest.scala
@@ -227,7 +227,7 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
       originalId = "original ID",
       tags = Seq(uri1), // tags
       iiifManifest = Some(uri1), // iiif
-      hotdog = Seq(edmWebResource) // hotdog
+      mediaMaster = Seq(edmWebResource) // mediaMaster
     )
     val row = RowConverter.toRow(oreAggregation, sparkSchema)
     assert(row(0) === oreAggregation.dplaUri.toString)
@@ -244,7 +244,7 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
     assert(row(13) === oreAggregation.originalId)
     assert(row(14) === oreAggregation.tags.map(_.toString)) // 14, tags
     assert(row(15) === oreAggregation.iiifManifest.map(_.toString).orNull) // 15, iiifManifest
-    assert(row(16) === oreAggregation.hotdog.map(RowConverter.fromEdmWebResource)) // 16, hotdog
+    assert(row(16) === oreAggregation.mediaMaster.map(RowConverter.fromEdmWebResource)) // 16, mediaMaster
   }
 
   it should "convert a SourceResource" in {


### PR DESCRIPTION
Add new fields 
- `iiifManifest: ZeroToOne[URI]` - The IIIF manifest for presentation API, expects single value. Validates only one value provided
- `hotdog: ZeroToMany[EdmWebResource]` - Zero to many master media records

Update model and row converter and converter tests 
Add `tags` fields to model and row converter tests 

Will rename `hotdog` on PR approval. 