### PR TITLE
Fix: Map all harvested records.

### DIFF
--- a/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/MappingExecutor.scala
@@ -68,12 +68,12 @@ trait MappingExecutor extends Serializable with IngestMessageTemplates {
     // Get distinct harvest records
     val distinctHarvest: DataFrame = harvestedRecords.distinct
 
-    // For reporting purposes, caluclate number of duplicate harvest records
+    // For reporting purposes, calculate number of duplicate harvest records
     val duplicateHarvest: Long = harvestedRecords.count - distinctHarvest.count
 
     // Run the mapping over the Dataframe
     // Transformation only
-    val mappingResults: RDD[OreAggregation] = distinctHarvest
+    val mappingResults: RDD[OreAggregation] = harvestedRecords
       .select("document")
       .as[String]
       .rdd


### PR DESCRIPTION
Fixup bug in MappingExecutor where the distinct harvest records were being mapped instead of the complete set. This led to a count mismatch between harvest records and distinct harvest records but no duplicate ID errors being logged because the duplicates were not included in the mapped data set.