### PR TITLE
Add iiifManifest and mediaMaster to JSONL export

### DIFF
--- a/src/main/resources/avro/MAPRecord.avsc
+++ b/src/main/resources/avro/MAPRecord.avsc
@@ -1132,6 +1132,21 @@
             "type": "array",
             "items": "string"
         }
+    },
+    {
+      "name": "iiifManifest",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    {
+      "name": "mediaMaster",
+      "type": {
+        "name": "mediaMasterArray",
+        "type": "array",
+        "items": "string"
+      }
     }
   ]
 }

--- a/src/main/scala/dpla/ingestion3/model/ModelConverter.scala
+++ b/src/main/scala/dpla/ingestion3/model/ModelConverter.scala
@@ -145,10 +145,9 @@ object ModelConverter {
       .getOrElse(throw new RuntimeException(s"Couldn't parse URI in row $row, field position $fieldPosition"))
 
   private[model] def optionalUri(row: Row, fieldPosition: Integer): Option[URI] = {
-    if (row.length > fieldPosition)
+    Try {
       Option(row.getString(fieldPosition)).map(URI)
-    else
-      None
+    }.getOrElse(None)
   }
 
   private[model] def requiredString(row: Row, fieldPosition: Integer): String =

--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -119,10 +119,12 @@ package object model {
         ("@id" -> record.dplaUri.toString) ~
         ("aggregatedCHO" -> "#sourceResource") ~
         ("dataProvider" -> record.dataProvider.name) ~
+        ("iiifManifest" -> record.iiifManifest.map{o => o.toString}) ~ // IIIF Manifest URI
         ("ingestDate" -> ingestDate) ~
         ("ingestType" -> "item") ~
         ("intermediateProvider" -> record.intermediateProvider.map(p => p.name)) ~
         ("isShownAt" -> record.isShownAt.uri.toString) ~
+        ("mediaMaster" -> record.mediaMaster.map{o => o.uri.toString}) ~ // full size media
         ("object" -> record.`preview`.map{o => o.uri.toString}) ~ // in dpla map 3, object is the thumbnail
         ("rights" -> record.edmRights.map(r => r.toString)) ~
         ("originalRecord" ->

--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -119,12 +119,12 @@ package object model {
         ("@id" -> record.dplaUri.toString) ~
         ("aggregatedCHO" -> "#sourceResource") ~
         ("dataProvider" -> record.dataProvider.name) ~
-        ("iiifManifest" -> record.iiifManifest.map{o => o.toString}) ~ // IIIF Manifest URI
+        ("iiifManifest" -> record.iiifManifest.map(i => i.toString)) ~ // IIIF Manifest URI
         ("ingestDate" -> ingestDate) ~
         ("ingestType" -> "item") ~
         ("intermediateProvider" -> record.intermediateProvider.map(p => p.name)) ~
         ("isShownAt" -> record.isShownAt.uri.toString) ~
-        ("mediaMaster" -> record.mediaMaster.map{o => o.uri.toString}) ~ // full size media
+        ("mediaMaster" -> record.mediaMaster.map{m => m.uri.toString}) ~ // full size media
         ("object" -> record.`preview`.map{o => o.uri.toString}) ~ // in dpla map 3, object is the thumbnail
         ("rights" -> record.edmRights.map(r => r.toString)) ~
         ("originalRecord" ->

--- a/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
+++ b/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
@@ -32,8 +32,6 @@ object EnrichedRecordFixture {
       ),
       sidecar = ("prehashId" -> "oai:somestate:id123") ~ ("dplaId" -> "4b1bd605bd1d75ee23baadb0e1f24457"),
       originalId = "The original ID",
-      iiifManifest = Some(URI("http://iiif.example/1/")),
-      mediaMaster = Seq(stringOnlyWebResource("http://example.fullframe.com/1/")),
       sourceResource = DplaSourceResource(
         collection = Seq(DcmiTypeCollection(
           title = Some("The Collection"),
@@ -86,7 +84,9 @@ object EnrichedRecordFixture {
         title = Seq("The Title"),
         `type` = Seq("image", "text")
       ),
-      tags = Seq()
+      tags = Seq(URI("tag")),
+      iiifManifest = Some(URI("https://ark.iiif/item/manifest")),
+      mediaMaster = Seq(EdmWebResource(uri = URI("https://example.org/record/123.html")))
     )
 
   val minimalEnrichedRecord =

--- a/src/test/scala/dpla/ingestion3/model/JsonlStringTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/JsonlStringTest.scala
@@ -41,6 +41,16 @@ class JsonlStringTest extends FlatSpec {
     )
   }
 
+  it should "render a iiifManfiest " in {
+    val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord)
+    val jvalue = parse(s)
+    val iiifManifest = jvalue \ "_source" \ "iiifManifest"
+    assert(iiifManifest.isInstanceOf[JString])
+    assert(
+      compact(render(iiifManifest)) == "\"https://ark.iiif/item/manifest\""
+    )
+  }
+
   it should "not have empty arrays for fields that have no data" in {
     // Those fields that are optional are 0-n, so they will be arrays.
     val s: String = jsonlRecord(EnrichedRecordFixture.minimalEnrichedRecord)


### PR DESCRIPTION
* PR paired with sparkindexer [#17](https://github.com/dpla/sparkindexer/pull/17)
* Add `iiifManifest` and `mediaMaster`  fields to JSONL export 
* See `dpla-ma-20200413-214222` on central 