### PR TITLE
Nara fixes

### DIFF
--- a/src/main/resources/avro/MAPRecord.avsc
+++ b/src/main/resources/avro/MAPRecord.avsc
@@ -1145,7 +1145,39 @@
       "type": {
         "name": "mediaMasterArray",
         "type": "array",
-        "items": "string"
+        "items": {
+          "name": "MediaMasterEdmWebResource",
+          "type": "record",
+          "fields": [
+            {
+              "name": "uri",
+              "type": "string"
+            },
+            {
+              "name": "fileFormat",
+              "type": {
+              "name": "fileFormatsArray",
+              "type": "array",
+              "items": "string"
+            }
+            },
+            {
+              "name": "dcRights",
+              "type": {
+              "name": "dcRightsArray",
+              "type": "array",
+              "items": "string"
+            }
+            },
+            {
+              "name": "edmRights",
+              "type": [
+              "null",
+              "string"
+              ]
+            }
+          ]
+        }
       }
     }
   ]


### PR DESCRIPTION
- Fixup `mediaMaster` in Avro schema

- Fix legacy issues in `NaraDeltaHarvester`
Use common `OrignalRecord` Avro schema, `filename` column is no longer required because updates to existing records are handled by the union of last full harvest and the delta harvest
Drop `filename` column from writeAvro