### PR TITLE
Fixup WI dc:rights mapping 

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/WiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/WiMapping.scala
@@ -83,10 +83,10 @@ class WiMapping extends XmlMapping with XmlExtractor
 
   override def rights(data: Document[NodeSeq]): Seq[String] =
     ((data \ "metadata" \\ "rights") ++
-      (data \ "metadata" \\ "accessRights")).map(rights => {
+      (data \ "metadata" \\ "accessRights")).flatMap(rights => {
         rights.prefix match {
-          case "dc" => rights.text
-          case _ => ""
+          case "dc" => Some(rights.text.trim)
+          case _ => None
         }
       })
 

--- a/src/test/scala/dpla/ingestion3/mappers/providers/WiMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/WiMappingTest.scala
@@ -29,4 +29,9 @@ class WiMappingTest extends FlatSpec with BeforeAndAfter {
     val expected = Seq(uriOnlyWebResource(URI("https://digitalgallery.bgsu.edu/collections/item/14058")))
     assert(extractor.isShownAt(xml) === expected)
   }
+
+  it should "extract Seq() and not Seq('')_if only Rights exists" in {
+    val expected = Seq()
+    assert(extractor.rights(xml) === expected)
+  }
 }


### PR DESCRIPTION
Drop empty values rather than map empty string. Matches edmRights mapping