### PR TITLE
Toggle duplicate ID validation

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/MaMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MaMapping.scala
@@ -15,6 +15,8 @@ import scala.xml._
 
 class MaMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates {
 
+  override val enforceDuplicateIds: Boolean = false
+
   val formatBlockList: Set[String] =
     DigitalSurrogateBlockList.termList ++
       FormatTypeValuesBlockList.termList

--- a/src/main/scala/dpla/ingestion3/mappers/providers/NaraMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/NaraMapping.scala
@@ -15,6 +15,8 @@ import scala.xml.{Node, NodeSeq}
 
 class NaraMapping extends XmlMapping with XmlExtractor {
 
+  override val enforceDuplicateIds: Boolean = false
+
   // ID minting functions
   override def useProviderName(): Boolean = true
 

--- a/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
@@ -54,6 +54,8 @@ trait Mapping[T] {
   def `type`(data: Document[T]): ZeroToMany[String] = emptySeq
 
 
+  val enforceDuplicateIds: Boolean   = true
+
   /**
     Define the defaults for required field validations
   */

--- a/src/main/scala/dpla/ingestion3/messages/IngestMessageTemplates.scala
+++ b/src/main/scala/dpla/ingestion3/messages/IngestMessageTemplates.scala
@@ -66,10 +66,10 @@ trait IngestMessageTemplates {
       value = "both rights and edmRights are defined"
     )
 
-  def duplicateOriginalId(id: String): IngestMessage =
+  def duplicateOriginalId(id: String, enforce: Boolean): IngestMessage =
     IngestMessage(
       message = "Duplicate",
-      level = IngestLogLevel.error,
+      level = if (enforce) IngestLogLevel.error else IngestLogLevel.warn,
       id = id,
       field = "originalId",
       value = "at least one other record shares this originalId"


### PR DESCRIPTION
Allows provider mappings to toggle the validation of duplicate IDs. For some providers we want to allow a "last one wins" approach when exporting records to the search index rather than failing all records which share a "unique" identifier. 

Impacts MA [records belong to multiple OAI sets] and NARA [duplicate records existed in previous harvests]