### PR TITLE
Rename Smithsonian shortname from si to smithsonian 

### DIFF
--- a/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
+++ b/src/main/scala/dpla/ingestion3/utils/ProviderRegistry.scala
@@ -77,7 +77,7 @@ object ProviderRegistry {
     "sd" -> Register(profile = new SdProfile),
     "tn" -> Register(profile = new TnProfile),
     "tx" -> Register(profile = new TxProfile),
-    "si" -> Register(profile = new SiProfile),
+    "smithsonian" -> Register(profile = new SiProfile),
     "virginias" -> Register(profile = new VirginiasProfile),
     "vt" -> Register(profile = new VtProfile),
     "wisconsin" -> Register(profile = new WiProfile)


### PR DESCRIPTION
`OutputHelper.activityPath` will match existing path in S3. Also see update to i3conf