### PR TITLE
Fix/si logging

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/file/SiFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/SiFileHarvester.scala
@@ -159,11 +159,13 @@ class SiFileHarvester(spark: SparkSession,
       // Format the harvested and expected counts for logging
       val fromFileFloat  = lineCount.toFloat
       val fromFilePretty = Utils.formatNumber(fromFileFloat.toLong)
-      val expectedPretty = expectedFileCounts.getOrElse(inFile.getName, "0")
+      // FIXME this is a mess
+      val expectedPretty = expectedFileCounts.getOrElse(inFile.getName.substring(0, inFile.getName.indexOf(".")), "0")
+
       val expectedFloat  = expectedPretty.replaceAll(",","").trim.toFloat // remove commas from string and make float
       val percentage     = (fromFileFloat / expectedFloat) * 100.0f match {
         case x if x.isNaN => 0.0f // account for division by 0...
-        case x if !x.isNaN => x
+        case x if !x.isNaN => x % 0.01
       }
 
       // Log a summary of the file

--- a/src/main/scala/dpla/ingestion3/harvesters/file/SiFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/SiFileHarvester.scala
@@ -159,13 +159,13 @@ class SiFileHarvester(spark: SparkSession,
       // Format the harvested and expected counts for logging
       val fromFileFloat  = lineCount.toFloat
       val fromFilePretty = Utils.formatNumber(fromFileFloat.toLong)
-      // FIXME this is a mess
-      val expectedPretty = expectedFileCounts.getOrElse(inFile.getName.substring(0, inFile.getName.indexOf(".")), "0")
-
+      val getFilenameKey = (filename: String) => filename.substring(0, inFile.getName.indexOf("."))
+      val expectedPretty = expectedFileCounts.getOrElse(getFilenameKey(inFile.getName), "0")
       val expectedFloat  = expectedPretty.replaceAll(",","").trim.toFloat // remove commas from string and make float
       val percentage     = (fromFileFloat / expectedFloat) * 100.0f match {
-        case x if x.isNaN => 0.0f // account for division by 0...
-        case x if !x.isNaN => x % 0.01
+        case x if x.isNaN => 0.0f // account for NaN
+        case x if x.isInfinity => fromFileFloat // account for infinity
+        case x if !x.isNaN => x.intValue()
       }
 
       // Log a summary of the file


### PR DESCRIPTION
Fixup bug that in log messages 

`Harvested Infinity% (1,472 / 0) of records from ead_collection_DPLA.xml.fixed.xmll.gz` 

will now be

`Harvested 1472%  (1,472 / 0) of records from ead_collection_DPLA.xml.fixed.xmll.gz`