### PR TITLE
TX title mapping

### DIFF
--- a/src/test/resources/tx.xml
+++ b/src/test/resources/tx.xml
@@ -10,6 +10,7 @@
     <metadata>
         <untl:metadata xmlns:untl="http://digital2.library.unt.edu/untl/">
             <untl:title qualifier="officialtitle">Texas and the Massachusetts Resolutions</untl:title>
+            <untl:title>Alt title</untl:title>
             <untl:contributor>
                 <untl:info>Contributor, 1807-1886</untl:info>
                 <untl:name>Contributor</untl:name>

--- a/src/test/scala/dpla/ingestion3/mappers/providers/TxMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/TxMappingTest.scala
@@ -108,6 +108,20 @@ class TxMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.title(xml) === expected)
   }
 
+  it should "extract the correct alt title" in {
+    val expected = Seq("Alt title")
+    val xml =
+      <record>
+        <metadata>
+          <untl:metadata xmlns:untl="http://digital2.library.unt.edu/untl/">
+            <untl:title>Alt title</untl:title>
+          </untl:metadata>
+        </metadata>
+      </record>
+
+    assert(extractor.title(Document(xml)) === expected)
+  }
+
   it should "extract the correct types" in {
     val expected = Seq("text") // these will get cleaned up by type enrichment
     assert(extractor.`type`(xml) === expected)


### PR DESCRIPTION
Fixup TX mapping to only map first officaltitle unless no officaltitle exists, then map first title value.