### PR TITLE
Fix/mdl rights mapping

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/MdlMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MdlMapping.scala
@@ -31,6 +31,7 @@ class MdlMapping extends JsonMapping with JsonExtractor with IngestMessageTempla
 
   override def edmRights(data: Document[json4s.JValue]): ZeroToMany[URI] =
     extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "rights").map(URI)
+      .filter(_.validate)
 
   override def intermediateProvider(data: Document[JValue]): ZeroToOne[EdmAgent] =
     extractString(unwrap(data) \ "attributes" \ "metadata" \ "intermediateProvider").map(nameOnlyAgent)
@@ -94,7 +95,8 @@ class MdlMapping extends JsonMapping with JsonExtractor with IngestMessageTempla
     extractStrings(unwrap(data)  \ "attributes" \ "metadata" \ "sourceResource" \ "publisher").map(nameOnlyAgent)
 
   override def rights(data: Document[JValue]): AtLeastOne[String] =
-    extractStrings(unwrap(data)  \ "attributes" \ "metadata" \ "sourceResource" \ "rights")
+    extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "rights")
+      .filterNot(t => t.contains("rightsstatements.org") | t.contains("creativecommons.org") )
 
   override def subject(data: Document[JValue]): ZeroToMany[SkosConcept] =
     extractStrings(unwrap(data)  \ "attributes" \ "metadata" \ "sourceResource" \ "subject" \ "name").map(nameOnlyConcept)

--- a/src/main/scala/dpla/ingestion3/model/DplaMapData.scala
+++ b/src/main/scala/dpla/ingestion3/model/DplaMapData.scala
@@ -152,7 +152,7 @@ case class URI(value: String) {
       case Success(uri) =>
         val path = uri.getPath.replaceFirst("/page/", "/vocab/")
         new java.net.URI(s"http://${uri.getHost}$path/").normalize.toString // normalize to http and drop parameters
-      case Failure(_) => ""
+      case Failure(_) => value
     }
   }
 

--- a/src/test/resources/mdl.json
+++ b/src/test/resources/mdl.json
@@ -16,7 +16,7 @@
   },
   "attributes": {
     "metadata": {
-      "rights": "www.fake.rights.url.org/public-domain",
+      "rights": "http://rightsstatements.org/public-domain",
       "intermediateProvider": "one intermediate provider",
       "object": "http://image.prview.org/thumb.jpg",
       "title": "Hmong vendors learn the law on legal drug sales",
@@ -123,9 +123,6 @@
         ],
         "description": "description",
         "type": "image",
-        "rights": [
-          "free text rights statement"
-        ],
         "publisher": [
           "pub1"
         ],

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MdlMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MdlMappingTest.scala
@@ -33,9 +33,10 @@ class MdlMappingTest extends FlatSpec with BeforeAndAfter {
 
   // dplaUri
   it should "extract correct edmRights" in {
-    val expected = Seq(URI("www.fake.rights.url.org/public-domain"))
+    val expected = Seq(URI("http://rightsstatements.org/public-domain"))
     assert(extractor.edmRights(json) === expected)
   }
+
   // intermediateProvider
   it should "extract the correct intermediateProvider" in {
     val expected = Some(nameOnlyAgent("one intermediate provider"))
@@ -125,7 +126,24 @@ class MdlMappingTest extends FlatSpec with BeforeAndAfter {
   }
   // rights
   it should "extract the correct rights" in {
+    val jsonString = """
+      {
+        "attributes": {
+          "metadata": {
+            "rights": "free text rights statement"
+          }
+        }
+      }
+    """"
+    val json: Document[JValue] = Document(parse(jsonString))
+
     val expected = List("free text rights statement")
+    assert(extractor.rights(json) === expected)
+  }
+
+  // rights
+  it should "not map rs.org value to dc rights" in {
+    val expected = List()
     assert(extractor.rights(json) === expected)
   }
 

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MdlMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MdlMappingTest.scala
@@ -141,6 +141,89 @@ class MdlMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.rights(json) === expected)
   }
 
+  it should "not map non-rs or non-cc host domains to edmRights" in {
+    val jsonString = """
+      {
+        "attributes": {
+          "metadata": {
+            "rights": "http://mhs.org/copyright"
+          }
+        }
+      }
+    """".stripMargin
+    val json: Document[JValue] = Document(parse(jsonString))
+
+
+    val expected = Seq()
+    assert(extractor.edmRights(json) === expected)
+  }
+
+  it should "not map non-URIs to edmRights" in {
+    val jsonString = """
+      {
+        "attributes": {
+          "metadata": {
+            "rights": "free text! free text! free text!"
+          }
+        }
+      }
+    """".stripMargin
+    val json: Document[JValue] = Document(parse(jsonString))
+
+    val expected = Seq()
+    assert(extractor.edmRights(json) === expected)
+  }
+
+  it should "work when rights is empty string" in {
+    val jsonString = """
+      {
+        "attributes": {
+          "metadata": {
+            "rights": ""
+          }
+        }
+      }
+    """".stripMargin
+    val json: Document[JValue] = Document(parse(jsonString))
+
+    val expected = Seq()
+    assert(extractor.edmRights(json) === expected)
+  }
+
+  it should "work when rights not provided" in {
+    val jsonString = """
+      {
+        "attributes": {
+          "metadata": {
+          }
+        }
+      }
+    """".stripMargin
+    val json: Document[JValue] = Document(parse(jsonString))
+
+    val expected = Seq()
+    assert(extractor.edmRights(json) === expected)
+  }
+
+  // rights
+  it should "map to dcRights but not edmRights when rights value contains both text and uri" in {
+    val jsonString = """
+      {
+        "attributes": {
+          "metadata": {
+            "rights": "text of cc statement; http://creativecommons.org/"
+          }
+        }
+      }
+    """".stripMargin
+    val json: Document[JValue] = Document(parse(jsonString))
+
+    val expectedEmpty = List()
+    val expectedRights = List("text of cc statement; http://creativecommons.org/")
+    assert(extractor.edmRights(json) === expectedEmpty)
+    assert(extractor.rights(json) === expectedRights)
+  }
+
   // rights
   it should "not map rs.org value to dc rights" in {
     val expected = List()

--- a/src/test/scala/dpla/ingestion3/model/UriTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/UriTest.scala
@@ -25,9 +25,9 @@ class UriTest extends FlatSpec with BeforeAndAfter {
     assert(uri.normalize === "http://rightsstatements.org/vocab/CNE/1.0/")
   }
 
-  it should "return empty string if not given a URI" in {
+  it should "return the original value if not given a URI" in {
     val uri = URI("c:\\media\\image.jpg")
-    assert(uri.normalize === "")
+    assert(uri.normalize === "c:\\media\\image.jpg")
   }
 
   "isValidEdmRightsUri" should "return `true` when URI is in list of approved URIs" in {


### PR DESCRIPTION
Refactor of MDL rights mapping. URIs where the hostname is either `rightsstatements.org` or `creativecommons.org` will be mapped to edmRights and normalized/validated. All other values go to dcRights.
