### PR TITLE
Invocation cleanup

### DIFF
--- a/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
@@ -109,10 +109,11 @@ object IngestRemap extends MappingExecutor
       executeEnrichment(sparkConf, mapDataOut, baseDataOut, shortName, logger, conf)
 
     // Json-l
-    executeJsonl(sparkConf, enrichDataOut, baseDataOut, shortName, logger)
+     executeJsonl(sparkConf, enrichDataOut, baseDataOut, shortName, logger)
 
     // Reports
-    executeAllReports(sparkConf, enrichDataOut, baseDataOut, shortName, logger)
+    // Reports commented out by S. Williams for efficiency and because they aren't being used on a regular basis
+    // executeAllReports(sparkConf, mapDataOut, baseDataOut, shortName, logger)
 
     // LDA vectors
     executeTopicModel(sparkConf, enrichDataOut, baseDataOut, shortName, stopWords, cvModel, ldaModel, logger)

--- a/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
@@ -195,9 +195,9 @@ trait Mapper[T, +E] extends IngestMessageTemplates {
     */
   def validateRecommendedProperty[T](values: ZeroToMany[T], field: String, providerId: String, enforce: Boolean)
                                 (implicit collector: MessageCollector[IngestMessage]): ZeroToMany[T] = {
-    if (values.isEmpty & enforce) {
-      collector.add(missingRecommendedFieldMsg(providerId, field))
-    }
+//    if (values.isEmpty & enforce) {
+//      collector.add(missingRecommendedFieldMsg(providerId, field))
+//    }
     values
   }
 

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MaMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MaMappingTest.scala
@@ -221,4 +221,21 @@ class MaMappingTest extends FlatSpec with BeforeAndAfter {
     val expected = Seq(URI("https://ark.digitalcommonwealth.org/ark:/50959/v405tb16x/manifest"))
     assert(extractor.iiifManifest(xml) === expected)
   }
+
+  it should "extract the correct rs.org value from xref" in {
+    val xml: Document[NodeSeq] = Document(
+      <record>
+        <metadata>
+          <mods:mods>
+            <mods:accessCondition displayLabel='rightsstatements.org' xlink:href='http://rightsstatements.org/vocab/NoC-US/1.0/' type='use and reproduction'>
+              No Copyright - United States
+            </mods:accessCondition>
+          </mods:mods>
+        </metadata>
+      </record>
+    )
+
+    val expected = Seq(URI("http://rightsstatements.org/vocab/NoC-US/1.0/"))
+    assert(extractor.edmRights(xml) === expected)
+  }
 }

--- a/src/test/scala/dpla/ingestion3/model/UriTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/UriTest.scala
@@ -30,6 +30,11 @@ class UriTest extends FlatSpec with BeforeAndAfter {
     assert(uri.normalize === "c:\\media\\image.jpg")
   }
 
+  it should "strip a trailing ; from a URI" in {
+    val uri = URI("http://rightsstatements.org/vocab/CNE/1.0;")
+    assert(uri.normalize === "http://rightsstatements.org/vocab/CNE/1.0/")
+  }
+
   "isValidEdmRightsUri" should "return `true` when URI is in list of approved URIs" in {
     val uri = URI("http://rightsstatements.org/vocab/CNE/1.0/")
     assert(uri.isValidEdmRightsUri === true)


### PR DESCRIPTION
* Remove metadata reports from IngestRemap invocation
* Remove logging of `missing recommended field` messages to reduce noise in mapping report
* Add string trailing punctuation normalization to edmRights URI normalization and associated test
* Add edmRights mapping test for MA 
