### PR TITLE
Fix CT edmRights 

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/CtMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/CtMapping.scala
@@ -150,6 +150,7 @@ class CtMapping extends XmlMapping with XmlExtractor
   override def edmRights(data: Document[NodeSeq]): ZeroToMany[URI] =
   // href in accessCondition prop where @type='use and reproduction'
     (data \ "accessCondition")
+      .filterNot(node => node.attribute("displayLabel").isDefined)
       .flatMap(node => getByAttribute(node, "type", "use and reproduction"))
       .flatMap(node => node.attribute(node.getNamespace("xlink"), "href"))
       .flatMap(n => extractString(n.head))

--- a/src/test/resources/ct.xml
+++ b/src/test/resources/ct.xml
@@ -44,7 +44,7 @@
     </subject>
     <identifier type="local">MSS19940065:282:7223</identifier>
     <accessCondition type="restrictions on access">The collection is open and available for research.</accessCondition>
-    <accessCondition type="use and reproduction" displayLabel="Intellectual Rights Statement" xlink:href="rs.org">This work is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License, CC BY-NC.</accessCondition>
+    <accessCondition type="use and reproduction" xlink:href="rs.org">This work is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License, CC BY-NC.</accessCondition>
     <recordInfo>
         <recordCreationDate encoding="w3cdtf">2011-12-16T15:09-0500</recordCreationDate>
         <recordOrigin>This finding aid was produced using the Archivists' Toolkit</recordOrigin>

--- a/src/test/scala/dpla/ingestion3/mappers/providers/CtMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/CtMappingTest.scala
@@ -15,7 +15,7 @@ class CtMappingTest extends FlatSpec with BeforeAndAfter {
   val xml: Document[NodeSeq] = Document(XML.loadString(xmlString))
   val extractor = new CtMapping
 
-  it should "not use the provider shortname in minting IDs "in
+  it should "not use the provider shortname in minting IDs " in
     assert(!extractor.useProviderName())
 
   it should "extract the correct original ID" in {
@@ -103,6 +103,18 @@ class CtMappingTest extends FlatSpec with BeforeAndAfter {
 
   it should "extract the correct edmRights value" in {
     val expected = Seq(URI("rs.org"))
+    assert(extractor.edmRights(xml) === expected)
+  }
+
+  it should "not extract xlink:href to edmRights when displayLabel attribute present" in {
+    val xml: Document[NodeSeq] = Document(
+      <mods>
+        <accessCondition type="use and reproduction" displayLabel="public" xlink:href="uconn.edu/rights">
+          This work is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License, CC BY-NC
+          .</accessCondition>
+      </mods>
+    )
+    val expected = Seq()
     assert(extractor.edmRights(xml) === expected)
   }
 }


### PR DESCRIPTION
CT edmRights mapping should not map `accessCondition` properties where there is a `@displayLabel` attribute