### PR TITLE
Utility for deleting DPLAs and generating new JSONL

### DIFF
--- a/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
+++ b/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
@@ -127,6 +127,13 @@ class CmdArgs(arguments: Seq[String]) extends ScallopConf(arguments) {
     validate = _.nonEmpty
   )
 
+  val deleteIds: ScallopOption[String] = opt[String](
+    "deleteIds",
+    required = false,
+    noshort = true,
+    validate = _.nonEmpty
+  )
+
   /**
     * Gets the configuration file property from command line arguments
     *
@@ -170,6 +177,8 @@ class CmdArgs(arguments: Seq[String]) extends ScallopConf(arguments) {
   def getCvModel: Option[String] = cvModel.toOption
 
   def getLdaModel: Option[String] = ldaModel.toOption
+
+  def getDeleteIds: Option[String] = deleteIds.toOption
 
   verify()
 }

--- a/src/main/scala/dpla/ingestion3/entries/utils/DeleteEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/utils/DeleteEntry.scala
@@ -1,0 +1,67 @@
+package dpla.ingestion3.entries.utils
+
+import dpla.ingestion3.confs.CmdArgs
+import dpla.ingestion3.dataStorage.InputHelper
+import dpla.ingestion3.executors.DeleteExecutor
+import dpla.ingestion3.utils.Utils
+import org.apache.spark.SparkConf
+
+/**
+  * Driver for reading DplaMapData records (mapped or enriched), deleting specific IDs
+  * and generating JSONL text, which can be bulk loaded into a DPLA Ingestion1 index, in
+  * Elasticsearch 0.90
+  *
+  * Expects three parameters:
+  * 1) a path to the enriched data
+  * 2) a path to output the jsonl data
+  * 3) provider short name (e.g. 'mdl', 'cdl', 'harvard')
+  * 4) spark master (optional parameter that overrides a --master param submitted
+  *    via spark-submit
+  * 5) a comma separated list of DPLA IDs to delete
+  *
+  * Usage
+  * -----
+  * To invoke via sbt:
+  * sbt "run-main dpla.ingestion3.entries.utils.DeleteEntry
+  *       --input=/input/path/to/enriched/
+  *       --output=/output/path/provider/
+  *       --deleteIds=1,2,3,4
+  *       --name=shortName"
+  *       --sparkMaster=local[*]
+  */
+object DeleteEntry extends DeleteExecutor {
+
+  def main(args: Array[String]): Unit = {
+
+    // Read in command line args.
+    val cmdArgs = new CmdArgs(args)
+
+    val dataIn = cmdArgs.getInput
+    val dataOut = cmdArgs.getOutput
+    val shortName = cmdArgs.getProviderName
+    val sparkMaster: Option[String] = cmdArgs.getSparkMaster
+    val deleteIds: String = cmdArgs.getDeleteIds.getOrElse("")
+
+    // If given input path is enrichment, use it as `enrichedData'.
+    // If not, assume that it is a directory containing several enriched sets and
+    // get the most recent enrichment from that directory.
+    val enrichedData = InputHelper.isActivityPath(dataIn) match {
+      case true => dataIn
+      case false => InputHelper.mostRecent(dataIn)
+        .getOrElse(throw new RuntimeException("Unable to load enriched data."))
+    }
+
+    val baseConf =
+      new SparkConf()
+        .setAppName(s"DELETE: $shortName")
+
+    val sparkConf = sparkMaster match {
+      case Some(m) => baseConf.setMaster(m)
+      case None => baseConf
+    }
+
+    val logger = Utils.createLogger("delete")
+
+    executeDelete(sparkConf, enrichedData, dataOut, deleteIds, shortName, logger)
+  }
+}

--- a/src/main/scala/dpla/ingestion3/executors/DeleteExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/DeleteExecutor.scala
@@ -1,0 +1,98 @@
+package dpla.ingestion3.executors
+
+import java.time.LocalDateTime
+
+import com.databricks.spark.avro._
+import dpla.ingestion3.dataStorage.OutputHelper
+import dpla.ingestion3.model.{ModelConverter, jsonlRecord}
+import org.apache.log4j.Logger
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
+import org.apache.spark.storage.StorageLevel
+
+import scala.util.{Failure, Success}
+
+trait DeleteExecutor extends Serializable {
+
+  /**
+
+    * @param sparkConf  Spark configuration
+    * @param dataIn     Data to transform into
+    * @param dataOut    Location to save
+    * @param deleteIds  IDs to delete
+    * @param shortName  Provider shortname
+    * @param logger     Logger object
+    */
+  def executeDelete(sparkConf: SparkConf,
+                    dataIn: String,
+                    dataOut: String,
+                    deleteIds: String,
+                    shortName: String,
+                    logger: Logger): String = {
+
+    // This start time is used for documentation and output file naming.
+    val startDateTime: LocalDateTime = LocalDateTime.now
+
+    // Output for this process in new jsonl sans deleteIds
+    val outputHelper: OutputHelper =
+      new OutputHelper(dataOut, shortName, "jsonl", startDateTime)
+
+    val outputPath: String = outputHelper.activityPath
+
+    logger.info("Starting delete")
+
+    val spark = SparkSession
+      .builder()
+      .config(sparkConf)
+      .getOrCreate()
+
+    import spark.implicits._
+    val sc = spark.sparkContext
+
+    val enrichedRows: DataFrame = spark.read.avro(dataIn)
+
+    // delete items
+    val deleteUris = deleteIds.split(",").map(id => s"http://dp.la/api/items/$id")
+
+    logger.info(s"Sourced enrichment data from $dataIn")
+    logger.info(s"Deleting ${deleteUris.length} IDs from enriched data")
+    logger.info(s"Saving to $outputPath")
+
+    val indexRecords: Dataset[String] = enrichedRows
+      .filter(row => !deleteUris.contains(row.getString(0))) // filter out rows where dplaUri matches
+      .map(row => {
+        val record = ModelConverter.toModel(row)
+        jsonlRecord(record)
+      })
+      .persist(StorageLevel.MEMORY_AND_DISK_SER)
+
+    val indexCount = indexRecords.count
+
+    logger.info(s"Saved $indexCount to JSONL export")
+    // This should always write out as #text() because if we use #json() then the
+    // data will be written out inside a JSON object (e.g. {'value': <doc>}) which is
+    // invalid for our use
+    indexRecords.write.text(outputPath)
+
+    // Create and write manifest.
+
+    val manifestOpts: Map[String, String] = Map(
+      "Activity" -> "JSON-L",
+      "Provider" -> shortName,
+      "Record count" -> indexCount.toString,
+      "Input" -> dataIn
+    )
+
+    outputHelper.writeManifest(manifestOpts) match {
+      case Success(s) => logger.info(s"Manifest written to $s")
+      case Failure(f) => logger.warn(s"Manifest failed to write: $f")
+    }
+
+    sc.stop()
+
+    logger.info("JSON-L export complete")
+
+    // Return output path of jsonl files.
+    outputPath
+  }
+}


### PR DESCRIPTION
Filters list of DPLA IDs from enriched data and generates new JSONL. Used for item take down requests.

Example invocation: 
```
sbt "run-main dpla.ingestion3.entries.utils.DeleteEntry 
--input=s3a://dpla-master-dataset/cdl/enrichment/ 
--output=s3a://dpla-master-dataset/cdl/
--deleteIds=630db811078dc82f0db0856e3da3b95d,93238f5080945c41fe9c3038efb8bc0e 
--name=cdl 
--sparkMaster=local[*]" 
```
