### PR TITLE
URI normalization with encoded characters

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
@@ -2,7 +2,7 @@ package dpla.ingestion3.mappers
 
 import dpla.ingestion3.enrichments.normalizations.StringNormalizationUtils._
 import dpla.ingestion3.mappers.utils._
-import dpla.ingestion3.messages.{IngestLogLevel, IngestMessage, IngestMessageTemplates, MessageCollector}
+import dpla.ingestion3.messages.{IngestMessage, IngestMessageTemplates, MessageCollector}
 import dpla.ingestion3.model.DplaMapData.{ExactlyOne, ZeroToMany, ZeroToOne}
 import dpla.ingestion3.model._
 import dpla.ingestion3.utils.Utils._
@@ -73,17 +73,10 @@ trait Mapper[T, +E] extends IngestMessageTemplates {
 
           // normalize() drops duplicates //
           Try { new java.net.URI(uriString).normalize.toString} match {
-            case Success(s) => s
+            case Success(normalizedUri) => normalizedUri
             case Failure(f) =>
               // log warning message about failed normalization
-              collector.add(
-                IngestMessage(
-                  message = s"Error normalizing URI".trim,
-                  level = IngestLogLevel.warn,
-                  id = providerId,
-                  field = "edmRights",
-                  value = s"$f -- original value == ${value.toString} -- normalized to == $uriString"
-                ))
+              collector.add(invalidEdmRightsMsg(providerId, "edmRights", s"${value.toString}: $f" , msg = None, enforce = false))
               // return original value
               value.toString
           }

--- a/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
@@ -41,7 +41,7 @@ trait Mapper[T, +E] extends IngestMessageTemplates {
                         (implicit collector: MessageCollector[IngestMessage]): ZeroToMany[URI] = {
     values.map (value => {
       val normalized = Try { new java.net.URI(value.toString.trim) } match {
-        case Success(uri) =>
+        case Success(uri) => {
           // does scheme (http/https) require normalization
           if (uri.toString.startsWith("https")) {
             collector.add(normalizedEdmRightsHttpsMsg(providerId, "edmRights", value.toString, msg = None, enforce = false))
@@ -61,19 +61,18 @@ trait Mapper[T, +E] extends IngestMessageTemplates {
           if (uri.getQuery != null) {
             collector.add(normalizedEdmRightsRsPageMsg(providerId, "edmRights", value.toString, msg = None, enforce = false))
           }
-
           // trailing `/` on path
-          if(!uri.getPath.endsWith("/")) {
+          if (!uri.getPath.endsWith("/")) {
             collector.add(normalizedEdmRightsTrailingSlashMsg(providerId, "edmRights", value.toString, msg = None, enforce = false))
           }
-
           // trailing punctuation
-          if(!uri.getPath.equalsIgnoreCase(uri.getPath.cleanupEndingPunctuation)) {
+          if (!uri.getPath.equalsIgnoreCase(uri.getPath.cleanupEndingPunctuation)) {
             collector.add(normalizedEdmRightsTrailingPunctuationMsg(providerId, "edmRights", value.toString, msg = None, enforce = false))
           }
 
           val uriString = s"http://${uri.getHost}${path.cleanupEndingPunctuation}/" // force http, drop parameters and trailing punctuation
           new java.net.URI(uriString).normalize.toString // normalize() drops duplicates //
+        }
         case Failure(_) => value.toString
       }
 

--- a/src/test/scala/dpla/ingestion3/mappers/MapperTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/MapperTest.scala
@@ -88,6 +88,16 @@ class MapperTest extends FlatSpec with BeforeAndAfter with IngestMessageTemplate
     assert(msgCollector.getAll().contains(message))
   }
 
+  it should "not normailze an invalid uri" in {
+    msgCollector.deleteAll()
+    val rightsString = "http://rightsstatements.org/vocab /UND/1.0/"
+    val rightsUris = Seq(rightsString).map(URI)
+    val normalizedRights = mapTest.normalizeEdmRights(rightsUris, id)
+    println(normalizedRights)
+    println(rightsUris)
+    assert(normalizedRights === rightsUris)
+  }
+
   it should "log a missingRights ERROR when dcRights is empty, edmRights is invalid and " +
     "enforce missing rights = TRUE for validateRights and enforce for validateEdmRights = FALSE" in {
     msgCollector.deleteAll()

--- a/src/test/scala/dpla/ingestion3/mappers/MapperTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/MapperTest.scala
@@ -90,7 +90,7 @@ class MapperTest extends FlatSpec with BeforeAndAfter with IngestMessageTemplate
 
   it should "not normailze an invalid uri" in {
     msgCollector.deleteAll()
-    val rightsString = "http://rightsstatements.org/vocab /UND/1.0/"
+    val rightsString = "http://rightsstatements.org/vocab%20/UND/1.0/"
     val rightsUris = Seq(rightsString).map(URI)
     val normalizedRights = mapTest.normalizeEdmRights(rightsUris, id)
     println(normalizedRights)

--- a/src/test/scala/dpla/ingestion3/mappers/MapperTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/MapperTest.scala
@@ -88,13 +88,12 @@ class MapperTest extends FlatSpec with BeforeAndAfter with IngestMessageTemplate
     assert(msgCollector.getAll().contains(message))
   }
 
-  it should "not normailze an invalid uri" in {
+  it should "not normalize a uri that is invalid because it contains a whitespace in the path and " +
+    "return the original value" in {
     msgCollector.deleteAll()
     val rightsString = "http://rightsstatements.org/vocab%20/UND/1.0/"
     val rightsUris = Seq(rightsString).map(URI)
     val normalizedRights = mapTest.normalizeEdmRights(rightsUris, id)
-    println(normalizedRights)
-    println(rightsUris)
     assert(normalizedRights === rightsUris)
   }
 


### PR DESCRIPTION
Fixes bug where encoded whitespace in URL was decoded during URI normalization and not successfully encoded back. This does not attempt to encode characters but traps and reports the error. These URI will not pass validation. 