### PR TITLE
Change Wikimedia eligibility criteria for mediaMaster

### DIFF
--- a/src/main/scala/dpla/ingestion3/wiki/WikiMapper.scala
+++ b/src/main/scala/dpla/ingestion3/wiki/WikiMapper.scala
@@ -67,7 +67,7 @@ trait WikiMapper {
     *         False otherwise
     */
   def isAssetEligible(iiif: Option[URI], mediaMasters: Seq[EdmWebResource]): Boolean =
-    (iiif, mediaMasters.size.equals(1) && mediaMasters.head.uri.value.toLowerCase.contains(".jp")) match {
+    (iiif, mediaMasters.nonEmpty) match {
       case(None, false) => false // Neither IIIF manifest nor media masters exist
       case(_, _) => true // either IIIF manifest or exactly one media exist
     }


### PR DESCRIPTION
Eligibility criteria for mediaMaster -- there is at least one asset. 
