### PR TITLE
OAI to CSV bug

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/oai/refactor/AllRecordsOaiRelation.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/refactor/AllRecordsOaiRelation.scala
@@ -75,7 +75,7 @@ class AllRecordsOaiRelation(oaiConfiguration: OaiConfiguration, oaiMethods: OaiM
   private[refactor] def eitherToArray(either: Either[OaiError, OaiPage]): Seq[String] =
     either match {
       case Right(OaiPage(string)) =>
-        Seq("page", string.replaceAll("\n", " "), "")
+        Seq("page", string.replaceAll("(\r\n)|\r|\n", " "), "")
       case Left(OaiError(message, None)) =>
         Seq("error", message, "")
       case Left(OaiError(message, Some(url))) =>


### PR DESCRIPTION
Fix bug where hanging CR-LF characters (possibly `0x0A` in SCDL) were not being converted to whitespace and this was causing pattern match failure on line 42.

Ex.  This OAI record has `0x0A`  in `dc:creator` and was not captured by `\n`. I am not 100% sure about the specific character in question because I was not able to inspect the feed directly (OAI output was routed through curl or python script into text and hex editors so there may have been something lost or corrected in translation). 

```
<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd"><responseDate>2021-02-23T02:52:02Z</responseDate><request identifier="oai:scmemory-search.org:oai-dc-statelibrary-sc-gov-10827-27908" metadataPrefix="oai_qdc" verb="GetRecord">https://scmemory-search.org/catalog/oai</request><GetRecord><record><header><identifier>oai:scmemory-search.org:oai-dc-statelibrary-sc-gov-10827-27908</identifier><datestamp>2021-02-19T22:36:38Z</datestamp><setSpec>Provider:17</setSpec></header><metadata><qdc:qualifieddc xmlns:qdc="http://epubs.cclrc.ac.uk/xmlns/qdc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://purl.org/dc/terms/ &#10;        http://dublincore.org/schemas/xmls/qdc/2006/01/06/dcterms.xsd &#10;        http://purl.org/dc/elements/1.1/ &#10;        http://dublincore.org/schemas/xmls/qdc/2006/01/06/dc.xsd"><dc:title>Financial Statements year ended June 30, 2017</dc:title><dc:creator>South Carolina State Auditor</dc:creator><dc:creator>South Carolina Department of
Commerce, Division of Public Railways</dc:creator><dc:identifier>http://hdl.handle.net/10827/27908</dc:identifier><dc:rights>Copyright status undetermined. For more information contact, South Carolina State Library, 1500 Senate Street, Columbia, South Carolina 29201.</dc:rights><dc:subject>Palmetto Railways--Auditing</dc:subject><dc:type>Text</dc:type><dc:publisher>South Carolina State Library</dc:publisher></qdc:qualifieddc></metadata></record></GetRecord></OAI-PMH>
```

```
Harvest failure.
scala.MatchError: WrappedArray( Commerce,  Division of Public Railways</dc:creator><dc:identifier>http://hdl.handle.net/10827/27908</dc:identifier><dc:rights>Copyright status undetermined. For more information contact,  South Carolina State Library) 
	at dpla.ingestion3.harvesters.oai.refactor.AllRecordsOaiRelation.handleCsvRow(AllRecordsOaiRelation.scala:42)
```

Adding addition patterns -- `(\r\n)|\r\n` -- to the regex resolves the harvest error.