### PR TITLE
Update mapping for preview to use generated URLs for all values

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/DlgMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/DlgMapping.scala
@@ -6,6 +6,7 @@ import dpla.ingestion3.mappers.utils.{Document, JsonExtractor, JsonMapping}
 import dpla.ingestion3.model.DplaMapData._
 import dpla.ingestion3.model.{EdmAgent, _}
 import dpla.ingestion3.utils.Utils
+import org.json4s
 import org.json4s.JValue
 import org.json4s.JsonDSL._
 
@@ -34,21 +35,21 @@ class DlgMapping extends JsonMapping with JsonExtractor {
     extractStrings("dc_right_display")(data)
     .map(URI)
 
-  override def mediaMaster(data: Document[JValue]): ZeroToMany[EdmWebResource] = {
-    extractStrings("edm_is_shown_by_display")(data).map(stringOnlyWebResource)
-  }
+//  override def mediaMaster(data: Document[JValue]): ZeroToMany[EdmWebResource] = {
+//    extractStrings("edm_is_shown_by_display")(data).map(stringOnlyWebResource)
+//  }
 
   override def originalRecord(data: Document[JValue]): ExactlyOne[String] = Utils.formatJson(data)
 
-  override def preview(data: Document[JValue]): ZeroToMany[EdmWebResource] = {
-    val isShownBy = extractStrings("edm_is_shown_by_display")(data)
-    val preview =
-      if(isShownBy.nonEmpty)
-        isShownBy
-      else
-        originalId(data).map(id => s"https://dlg.galileo.usg.edu/do-th:$id").toSeq
+  override def preview(data: Document[JValue]): ZeroToMany[EdmWebResource] =
+    originalId(data)
+      .map(id => s"https://dlg.galileo.usg.edu/do-th:$id")
+      .map(stringOnlyWebResource)
+      .toSeq
 
-    preview.map(stringOnlyWebResource)
+  override def iiifManifest(data: Document[json4s.JValue]): ZeroToMany[URI] = {
+    extractStrings("iiif_manifest_url_ss")(data)
+      .map(URI)
   }
 
   override def provider(data: Document[JValue]): ExactlyOne[EdmAgent] = EdmAgent(

--- a/src/test/resources/dlg.json
+++ b/src/test/resources/dlg.json
@@ -52,7 +52,6 @@
   "dcterms_rights_holder_display": [
     "This image is the property of the Auburn University Libraries and is intended for non-commercial use. Users of the image are asked to acknowledge the Auburn University Libraries."
   ],
-  "edm_is_shown_by_display": ["edm_is_shown_by_display"],
   "dc_relation_display": [
     "Deeply Rooted",
     "USAIN State and Local Literature Preservation Project"

--- a/src/test/scala/dpla/ingestion3/mappers/providers/DlgMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/DlgMappingTest.scala
@@ -112,18 +112,6 @@ class DlgMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.place(json) === expected)
   }
 
-  // preview
-  it should "create the correct previews" in {
-    val expected = Seq("edm_is_shown_by_display").map(stringOnlyWebResource)
-    assert(extractor.preview(json) === expected)
-  }
-
-  // mediaMaster
-  it should "create the correct media master" in {
-    val expected = Seq("edm_is_shown_by_display").map(stringOnlyWebResource)
-    assert(extractor.mediaMaster(json) === expected)
-  }
-
   it should "create the correct preview when `edm_is_shown_by_display` is missing" in {
     val jsonString: String = new FlatFileIO().readFileAsString("/dlg_missing_preview.json")
     val json: Document[JValue] = Document(parse(jsonString))


### PR DESCRIPTION
Remove mediaMaster mapping because it relies upon the unsteady 'edm_is_shown_at_display' value (what was replaced by in preview)

Update tests