### PR TITLE
ID minting bug and NYPL fixes

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/BhlMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/BhlMapping.scala
@@ -16,7 +16,7 @@ class BhlMapping extends XmlMapping with XmlExtractor {
   // ID minting functions
   override def useProviderName: Boolean = true
 
-  override def getProviderName: String = "bhl"
+  override def getProviderName: Option[String] = Some("bhl")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \\ "header" \ "identifier")

--- a/src/main/scala/dpla/ingestion3/mappers/providers/CdlMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/CdlMapping.scala
@@ -16,7 +16,7 @@ class CdlMapping extends JsonMapping with JsonExtractor {
   override def useProviderName: Boolean = true
 
   // Hard coded to prevent accidental changes to base ID
-  override def getProviderName: String = "cdl"
+  override def getProviderName: Option[String] = Some("cdl")
 
   // OreAggregation fields
   override def dplaUri(data: Document[JValue]): ZeroToOne[URI] = mintDplaItemUri(data)

--- a/src/main/scala/dpla/ingestion3/mappers/providers/CtMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/CtMapping.scala
@@ -19,9 +19,9 @@ class CtMapping extends XmlMapping with XmlExtractor
       FormatTypeValuesBlockList.termList
 
   // ID minting functions
-  override def useProviderName(): Boolean = false
+  override def useProviderName: Boolean = false
 
-  override def getProviderName(): String = "ct"
+  override def getProviderName: Option[String] = Some("ct")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     isShownAtStrings(data).headOption
@@ -59,7 +59,7 @@ class CtMapping extends XmlMapping with XmlExtractor
       .map(n => s"${n \@ "start"}-${n \@ "end"}")
       .map(stringOnlyTimeSpan)
 
-    if(dateIssued.nonEmpty)
+    if (dateIssued.nonEmpty)
       dateIssued
     else
       startEndDates
@@ -113,7 +113,7 @@ class CtMapping extends XmlMapping with XmlExtractor
     (extractStrings(data \ "subject" \ "topic") ++
       extractStrings(data \ "subject" \ "name") ++
       extractStrings(data \ "subject" \ "titleInfo"))
-        .map(nameOnlyConcept)
+      .map(nameOnlyConcept)
 
   // metadata/mods/subject/temporal
   override def temporal(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] =
@@ -140,7 +140,7 @@ class CtMapping extends XmlMapping with XmlExtractor
 
   // OreAggregation
   override def dplaUri(data: Document[NodeSeq]): ZeroToOne[URI] = mintDplaItemUri(data)
-  
+
   // <note type="ownership">
   override def dataProvider(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
     (data \ "note").map(n => getByAttribute(n, "type", "ownership"))
@@ -185,12 +185,12 @@ class CtMapping extends XmlMapping with XmlExtractor
 
   // Help functions
   def constructTitles(nodeSeq: NodeSeq): ZeroToMany[String] = {
-    nodeSeq.map (node => {
-      val nonSort = extractString( node \ "nonSort")
-      val title = extractString( node \ "title")
-      val subTitle = extractString( node \ "subTitle")
-      val partName = extractString( node \ "partName")
-      val partNumber = extractString( node \ "partNumber")
+    nodeSeq.map(node => {
+      val nonSort = extractString(node \ "nonSort")
+      val title = extractString(node \ "title")
+      val subTitle = extractString(node \ "subTitle")
+      val partName = extractString(node \ "partName")
+      val partNumber = extractString(node \ "partNumber")
       List(nonSort, title, subTitle, partName, partNumber).flatten.mkString(" ")
     })
   }

--- a/src/main/scala/dpla/ingestion3/mappers/providers/DcMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/DcMapping.scala
@@ -22,7 +22,7 @@ class DcMapping extends XmlMapping with XmlExtractor {
   // ID minting functions
   override def useProviderName(): Boolean = false // TODO confirm prefix
 
-  override def getProviderName(): String = "dc" // TODO confirm prefix
+  override def getProviderName(): Option[String] = Some("dc") // TODO confirm prefix
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "header" \ "identifier")
@@ -88,7 +88,7 @@ class DcMapping extends XmlMapping with XmlExtractor {
   override def `type`(data: Document[NodeSeq]): Seq[String] =
     (extractStrings(data \ "metadata" \\ "type") ++
       extractStrings(data \ "metadata" \\ "format"))
-    .flatMap(_.splitAtDelimiter(";"))
+      .flatMap(_.splitAtDelimiter(";"))
 
 
   // OreAggregation
@@ -106,7 +106,7 @@ class DcMapping extends XmlMapping with XmlExtractor {
   }
 
   override def isShownAt(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
-      extractStrings(data \ "metadata" \\ "isShownAt").map(stringOnlyWebResource)
+    extractStrings(data \ "metadata" \\ "isShownAt").map(stringOnlyWebResource)
 
   override def originalRecord(data: Document[NodeSeq]): ExactlyOne[String] = Utils.formatXml(data)
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/DlgMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/DlgMapping.scala
@@ -16,7 +16,7 @@ class DlgMapping extends JsonMapping with JsonExtractor {
   override def useProviderName: Boolean = true
 
   // Hard coded to prevent accidental changes to base ID
-  override def getProviderName: String = "dlg"
+  override def getProviderName: Option[String] = Some("dlg")
 
   // OreAggregation fields
   override def dplaUri(data: Document[JValue]): ZeroToOne[URI] = mintDplaItemUri(data)
@@ -33,11 +33,11 @@ class DlgMapping extends JsonMapping with JsonExtractor {
 
   override def edmRights(data: Document[JValue]): ZeroToMany[URI] =
     extractStrings("dc_right_display")(data)
-    .map(URI)
+      .map(URI)
 
-//  override def mediaMaster(data: Document[JValue]): ZeroToMany[EdmWebResource] = {
-//    extractStrings("edm_is_shown_by_display")(data).map(stringOnlyWebResource)
-//  }
+  //  override def mediaMaster(data: Document[JValue]): ZeroToMany[EdmWebResource] = {
+  //    extractStrings("edm_is_shown_by_display")(data).map(stringOnlyWebResource)
+  //  }
 
   override def originalRecord(data: Document[JValue]): ExactlyOne[String] = Utils.formatJson(data)
 
@@ -88,8 +88,8 @@ class DlgMapping extends JsonMapping with JsonExtractor {
     extractStrings("dc_format_display")(data)
       .map(_.applyBlockFilter(
         DigitalSurrogateBlockList.termList ++
-        FormatTypeValuesBlockList.termList ++
-        ExtentIdentificationList.termList))
+          FormatTypeValuesBlockList.termList ++
+          ExtentIdentificationList.termList))
       .filter(_.nonEmpty)
 
   override def identifier(data: Document[JValue]): ZeroToMany[String] =

--- a/src/main/scala/dpla/ingestion3/mappers/providers/EsdnMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/EsdnMapping.scala
@@ -22,7 +22,7 @@ class EsdnMapping extends XmlMapping with XmlExtractor with IngestMessageTemplat
   // ID minting functions
   override def useProviderName(): Boolean = true
 
-  override def getProviderName(): String = "esdn"
+  override def getProviderName(): Option[String] = Some("esdn")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "header" \ "identifier")
@@ -124,8 +124,8 @@ class EsdnMapping extends XmlMapping with XmlExtractor with IngestMessageTemplat
 
   override def subject(data: Document[NodeSeq]): Seq[SkosConcept] =
     (extractStrings(data \\ "subject" \\ "topic") ++
-        extractStrings(data \\ "subject" \\ "name") ++
-        extractStrings(data \\ "subject" \ "titleInfo" \ "title")
+      extractStrings(data \\ "subject" \\ "name") ++
+      extractStrings(data \\ "subject" \ "titleInfo" \ "title")
       ).map(nameOnlyConcept)
 
   override def temporal(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] =

--- a/src/main/scala/dpla/ingestion3/mappers/providers/FlMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/FlMapping.scala
@@ -19,7 +19,7 @@ class FlMapping extends JsonMapping with JsonExtractor with IngestMessageTemplat
   // ID minting functions
   override def useProviderName: Boolean = true
 
-  override def getProviderName: String = "florida"
+  override def getProviderName: Option[String] = Some("florida")
 
   override def originalId(implicit data: Document[JValue]): ZeroToOne[String] =
     extractStrings(unwrap(data) \ "isShownAt").headOption
@@ -62,11 +62,11 @@ class FlMapping extends JsonMapping with JsonExtractor with IngestMessageTemplat
     extractStrings(unwrap(data) \ "sourceResource" \ "alternative")
 
   override def contributor(data: Document[JValue]): ZeroToMany[EdmAgent] =
-    extractStrings(unwrap(data)  \ "sourceResource" \ "contributor" \ "name")
+    extractStrings(unwrap(data) \ "sourceResource" \ "contributor" \ "name")
       .map(nameOnlyAgent)
 
   override def creator(data: Document[JValue]): ZeroToMany[EdmAgent] =
-    extractStrings(unwrap(data)  \ "sourceResource" \ "creator" \ "name")
+    extractStrings(unwrap(data) \ "sourceResource" \ "creator" \ "name")
       .map(nameOnlyAgent)
 
   override def date(data: Document[JValue]): ZeroToMany[EdmTimeSpan] =
@@ -106,7 +106,7 @@ class FlMapping extends JsonMapping with JsonExtractor with IngestMessageTemplat
     extractStrings(unwrap(data) \ "sourceResource" \ "rights" \ "text")
 
   override def subject(data: Document[JValue]): ZeroToMany[SkosConcept] =
-    extractStrings(unwrap(data)  \ "sourceResource" \ "subject" \ "name")
+    extractStrings(unwrap(data) \ "sourceResource" \ "subject" \ "name")
       .map(nameOnlyConcept)
 
   override def title(data: Document[JValue]): AtLeastOne[String] =

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GettyMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GettyMapping.scala
@@ -20,14 +20,14 @@ class GettyMapping extends XmlMapping with XmlExtractor {
   // ID minting functions
   override def useProviderName(): Boolean = true
 
-  override def getProviderName(): String = "getty"
+  override def getProviderName(): Option[String] = Some("getty")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \\ "PrimoNMBib" \ "record" \ "control" \ "recordid")
 
   // SourceResource mapping
   override def collection(data: Document[NodeSeq]): Seq[DcmiTypeCollection] =
-    // display/lds43 AND display/lds34
+  // display/lds43 AND display/lds34
     (extractStrings(data \\ "display" \ "lds43") ++
       extractStrings(data \\ "display" \ "lds34"))
       .map(nameOnlyCollection)
@@ -44,8 +44,8 @@ class GettyMapping extends XmlMapping with XmlExtractor {
       .map(nameOnlyAgent)
 
   override def date(data: Document[NodeSeq]): Seq[EdmTimeSpan] =
-    // display/creationdate
-      extractStrings(data \\ "display" \ "creationdate")
+  // display/creationdate
+    extractStrings(data \\ "display" \ "creationdate")
       .map(stringOnlyTimeSpan)
 
   override def description(data: Document[NodeSeq]): Seq[String] =
@@ -79,7 +79,7 @@ class GettyMapping extends XmlMapping with XmlExtractor {
       .map(nameOnlyAgent)
 
   override def rights(data: Document[NodeSeq]): AtLeastOne[String] =
-    // display/lds27 AND display/rights
+  // display/lds27 AND display/rights
     ((data \\ "display" \ "rights") ++
       (data \\ "display" \ "lds27"))
       .flatMap(extractStrings)
@@ -92,13 +92,13 @@ class GettyMapping extends XmlMapping with XmlExtractor {
       .map(nameOnlyConcept)
 
   override def title(data: Document[NodeSeq]): Seq[String] =
-    // display/title AND display/lds03
+  // display/title AND display/lds03
     (extractStrings(data \\ "display" \ "title") ++
       extractStrings(data \\ "display" \ "lds03"))
       .flatMap(_.splitAtDelimiter(";"))
 
   override def `type`(data: Document[NodeSeq]): Seq[String] =
-    // display/lds26
+  // display/lds26
     extractStrings(data \\ "display" \ "lds26")
 
   // OreAggregation
@@ -109,8 +109,8 @@ class GettyMapping extends XmlMapping with XmlExtractor {
 
   override def isShownAt(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] = {
     val baseIsShownAt = "https://primo.getty.edu/primo-explore/fulldisplay?vid=GRI-OCP&context=L&tab=all_gri&lang=en_US&docid="
-    
-    extractString(data \\"control" \ "sourceid") match {
+
+    extractString(data \\ "control" \ "sourceid") match {
       case Some("GETTY_ROSETTA") =>
         extractStrings(data \\ "display" \ "lds29")
           .map(stringOnlyWebResource)
@@ -125,7 +125,7 @@ class GettyMapping extends XmlMapping with XmlExtractor {
   override def originalRecord(data: Document[NodeSeq]): ExactlyOne[String] = Utils.formatXml(data)
 
   override def preview(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
-    // sear/thumbnail
+  // sear/thumbnail
     extractStrings(data \\ "LINKS" \ "thumbnail")
       .map(stringOnlyWebResource)
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/GpoMapping.scala
@@ -17,7 +17,7 @@ class GpoMapping extends MarcXmlMapping {
   // ID minting functions
   override def useProviderName: Boolean = true
 
-  override def getProviderName: String = "gpo"
+  override def getProviderName: Option[String] = Some("gpo")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "header" \ "identifier")
@@ -25,7 +25,7 @@ class GpoMapping extends MarcXmlMapping {
   // SourceResource mapping
 
   override def contributor(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
-    // <datafield> tag = 700, 710, or 711
+  // <datafield> tag = 700, 710, or 711
     marcFields(data, Seq("700", "710", "711"))
       .filter(filterSubfields(_, Seq("e")) // include if subfield with @code=e exists and...
         .flatMap(extractStrings)
@@ -95,7 +95,7 @@ class GpoMapping extends MarcXmlMapping {
     // Add description frequency if desc310 does not exist, <leader> at index 7 = 's',
     // and a description frequency key is present in <controlfield> 008_18
     val leader7: Option[Char] = leaderAt(data, 7)
-    val controlKey: Option[String] = controlfield(data,Seq("008_18"))
+    val controlKey: Option[String] = controlfield(data, Seq("008_18"))
       .flatMap(extractStrings)
       .headOption
 
@@ -137,7 +137,7 @@ class GpoMapping extends MarcXmlMapping {
   )
 
   override def extent(data: Document[NodeSeq]): ZeroToMany[String] =
-    // <datafield> tag = 300  <subfield> code = a
+  // <datafield> tag = 300  <subfield> code = a
     marcFields(data, Seq("300"), Seq("a"))
       .map(extractStrings)
       .map(_.mkString(" "))
@@ -148,13 +148,17 @@ class GpoMapping extends MarcXmlMapping {
     // <leader> #text character at index 6
     // map character to String value in leaderFormats
     val lFormats: Seq[String] = leaderAt(data, 6)
-      .flatMap(key => Try{ leaderFormats(key) }.toOption)
+      .flatMap(key => Try {
+        leaderFormats(key)
+      }.toOption)
       .toSeq
 
     // <controlfield> code = 007 #text character at index 0
     // map character to String value in controlFormats
     val cFormats: Seq[String] = controlAt(data, "007", 0)
-      .flatMap(key => Try{ controlFormats(key) }.toOption)
+      .flatMap(key => Try {
+        controlFormats(key)
+      }.toOption)
 
     // <datafield> tag = 337, 338, or 340   <subfield> code = a
     val dFormats = marcFields(data, Seq("337", "338", "340"), Seq("a"))
@@ -210,8 +214,8 @@ class GpoMapping extends MarcXmlMapping {
   }
 
   override def place(data: Document[NodeSeq]): ZeroToMany[DplaPlace] =
-    // <datafield> tag = 650  <subfield> code = z
-    // <datafield> tag = 651  <subfield> code = a
+  // <datafield> tag = 650  <subfield> code = z
+  // <datafield> tag = 651  <subfield> code = a
     (marcFields(data, Seq("650"), Seq("z")) ++ marcFields(data, Seq("651"), Seq("a")))
       .flatMap(extractStrings)
       .map(_.stripSuffix("."))
@@ -219,7 +223,7 @@ class GpoMapping extends MarcXmlMapping {
       .distinct
 
   override def publisher(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
-    // <datafield> tag = 260 or 264   <subfield> code = a or b
+  // <datafield> tag = 260 or 264   <subfield> code = a or b
     marcFields(data, Seq("260", "264"), Seq("a", "b"))
       .map(extractStrings)
       .map(_.mkString(" "))
@@ -323,14 +327,14 @@ class GpoMapping extends MarcXmlMapping {
   )
 
   override def subject(data: Document[NodeSeq]): ZeroToMany[SkosConcept] =
-    // <datafield> tag = 600, 610, 611, 630, 650, or 651  <subfield> code is a letter (not a number)
+  // <datafield> tag = 600, 610, 611, 630, 650, or 651  <subfield> code is a letter (not a number)
     datafield(data, Seq("600", "610", "611", "630", "650", "651"))
       .map(extractMarcSubject)
       .map(nameOnlyConcept)
 
   override def temporal(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] =
-    // <datafield> tag = 600, 610, 650, or 651  <subfield> code = y
-    // <datafield> tag = 611                    <subfield> code = d
+  // <datafield> tag = 600, 610, 650, or 651  <subfield> code = y
+  // <datafield> tag = 611                    <subfield> code = d
     (marcFields(data, Seq("600", "610", "650", "651"), Seq("y")) ++ marcFields(data, Seq("611"), Seq("d")))
       .flatMap(extractStrings)
       .map(_.stripSuffix("."))

--- a/src/main/scala/dpla/ingestion3/mappers/providers/HarvardMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/HarvardMapping.scala
@@ -93,14 +93,14 @@ class HarvardMapping extends XmlMapping with XmlExtractor with IngestMessageTemp
 
   override def description(data: Document[NodeSeq]): ZeroToMany[String] =
     extractStrings(data \ "metadata" \ "mods" \ "abstract") ++
-    (data \ "metadata" \ "mods" \ "note")
-      .filterNot(node => filterAttribute(node, "type", "funding"))
-      .filterNot(node => filterAttribute(node, "type", "organization"))
-      .filterNot(node => filterAttribute(node, "type", "reproduction"))
-      .filterNot(node => filterAttribute(node, "type", "system details"))
-      .filterNot(node => filterAttribute(node, "type", "statement of responsibility"))
-      .filterNot(node => filterAttribute(node, "type", "venue"))
-      .flatMap(extractStrings)
+      (data \ "metadata" \ "mods" \ "note")
+        .filterNot(node => filterAttribute(node, "type", "funding"))
+        .filterNot(node => filterAttribute(node, "type", "organization"))
+        .filterNot(node => filterAttribute(node, "type", "reproduction"))
+        .filterNot(node => filterAttribute(node, "type", "system details"))
+        .filterNot(node => filterAttribute(node, "type", "statement of responsibility"))
+        .filterNot(node => filterAttribute(node, "type", "venue"))
+        .flatMap(extractStrings)
 
   override def extent(data: Document[NodeSeq]): ZeroToMany[String] =
     extractStrings(data \ "metadata" \ "mods" \ "physicalDescription" \ "extent")
@@ -192,7 +192,7 @@ class HarvardMapping extends XmlMapping with XmlExtractor with IngestMessageTemp
 
     title ++ collectionTitle
   }
-  
+
   override def `type`(data: Document[NodeSeq]): ZeroToMany[String] =
     extractStrings(data \ "metadata" \ "mods" \ "typeOfResource") ++
       extractStrings(data \ "metadata" \ "mods" \ "extension" \ "librarycloud" \\ "digitalFormat")
@@ -242,7 +242,7 @@ class HarvardMapping extends XmlMapping with XmlExtractor with IngestMessageTemp
 
   override def originalRecord(data: Document[NodeSeq]): ExactlyOne[String] =
     Utils.formatXml(data)
-  
+
   override def isShownAt(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] = {
     val artMuseumLink = (data \ "metadata" \ "mods" \ "location" \ "url")
       .flatMap(node => getByAttribute(node, "displayLabel", "Harvard Art Museums"))
@@ -259,7 +259,7 @@ class HarvardMapping extends XmlMapping with XmlExtractor with IngestMessageTemp
             .flatMap(node => getByAttribute(node, "access", "object in context"))
             .flatMap(extractString(_))
             .map(stringOnlyWebResource)
-      })
+        })
 
     val objectInContext = (data \ "metadata" \ "mods" \ "location" \ "url")
       .flatMap(node => getByAttribute(node, "displayLabel", "Harvard Digital Collections"))
@@ -286,7 +286,7 @@ class HarvardMapping extends XmlMapping with XmlExtractor with IngestMessageTemp
 
   override def useProviderName: Boolean = false
 
-  override def getProviderName: String = "harvard"
+  override def getProviderName: Option[String] = Some("harvard")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \\ "header" \ "identifier").map(_.trim)
@@ -359,7 +359,7 @@ class HarvardMapping extends XmlMapping with XmlExtractor with IngestMessageTemp
       part = namePart.text
     } yield NamePart(part, typeAttr)
 
-    if(nameParts.isEmpty) return ""
+    if (nameParts.isEmpty) return ""
 
     val nameString = nameParts.tail.foldLeft(nameParts.head.part)(
       (a, b) => {

--- a/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
@@ -24,7 +24,7 @@ class HathiMapping extends MarcXmlMapping {
   // ID minting functions
   override def useProviderName: Boolean = true
 
-  override def getProviderName: String = "hathitrust"
+  override def getProviderName: Option[String] = Some("hathitrust")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     // <controlfield> tag = 001

--- a/src/main/scala/dpla/ingestion3/mappers/providers/IaMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/IaMapping.scala
@@ -14,7 +14,7 @@ class IaMapping extends JsonMapping with JsonExtractor with IngestMessageTemplat
   // ID minting functions
   override def useProviderName: Boolean = true
 
-  override def getProviderName: String = "ia"
+  override def getProviderName: Option[String] = Some("ia")
 
   override def originalId(implicit data: Document[JValue]): ZeroToOne[String] =
     extractString(unwrap(data) \ "identifier")
@@ -66,19 +66,19 @@ class IaMapping extends JsonMapping with JsonExtractor with IngestMessageTemplat
 
   // SourceResource
   override def creator(data: Document[JValue]): ZeroToMany[EdmAgent] =
-    extractStrings(unwrap(data)  \\ "creator").map(nameOnlyAgent)
+    extractStrings(unwrap(data) \\ "creator").map(nameOnlyAgent)
 
   override def date(data: Document[JValue]): ZeroToMany[EdmTimeSpan] =
-    extractStrings(unwrap(data)  \\ "date").map(stringOnlyTimeSpan)
+    extractStrings(unwrap(data) \\ "date").map(stringOnlyTimeSpan)
 
   override def description(data: Document[JValue]): ZeroToMany[String] =
     extractStrings(unwrap(data) \\ "description")
 
   override def language(data: Document[JValue]): ZeroToMany[SkosConcept] =
-    extractStrings(unwrap(data) \\ "language" ).map(nameOnlyConcept)
+    extractStrings(unwrap(data) \\ "language").map(nameOnlyConcept)
 
   override def publisher(data: Document[JValue]): ZeroToMany[EdmAgent] =
-    extractStrings(unwrap(data)  \\ "publisher").map(nameOnlyAgent)
+    extractStrings(unwrap(data) \\ "publisher").map(nameOnlyAgent)
 
   override def rights(data: Document[JValue]): AtLeastOne[String] = {
     val defaultRights = Seq("Access to the Internet Archive’s Collections is granted for scholarship " +
@@ -88,16 +88,16 @@ class IaMapping extends JsonMapping with JsonExtractor with IngestMessageTemplat
     val rights = extractStrings(unwrap(data) \\ "rights") ++
       extractStrings(unwrap(data) \\ "possible-copyright-status")
 
-    if(rights.nonEmpty) rights else defaultRights
+    if (rights.nonEmpty) rights else defaultRights
   }
 
   override def subject(data: Document[JValue]): ZeroToMany[SkosConcept] =
-    extractStrings(unwrap(data)  \\ "subject").map(nameOnlyConcept)
+    extractStrings(unwrap(data) \\ "subject").map(nameOnlyConcept)
 
   override def title(data: Document[JValue]): AtLeastOne[String] = {
-    val titles = extractStrings(unwrap(data)  \\ "title")
-    val vols = extractStrings(unwrap(data)  \\ "volume")
-    val issues = extractStrings(unwrap(data)  \\ "issue")
+    val titles = extractStrings(unwrap(data) \\ "title")
+    val vols = extractStrings(unwrap(data) \\ "volume")
+    val issues = extractStrings(unwrap(data) \\ "issue")
 
     val max = List(titles.size, vols.size, issues.size).max
 
@@ -120,7 +120,7 @@ class IaMapping extends JsonMapping with JsonExtractor with IngestMessageTemplat
   }
 
   override def `type`(data: Document[JValue]): ZeroToMany[String] =
-    extractStrings(unwrap(data)  \\ "mediatype")
+    extractStrings(unwrap(data) \\ "mediatype")
 
   def agent = EdmAgent(
     name = Some("Internet Archive"),

--- a/src/main/scala/dpla/ingestion3/mappers/providers/IllinoisMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/IllinoisMapping.scala
@@ -22,7 +22,7 @@ class IllinoisMapping extends XmlMapping with XmlExtractor with IngestMessageTem
   // ID minting functions
   override def useProviderName(): Boolean = true
 
-  override def getProviderName(): String = "il"
+  override def getProviderName(): Option[String] = Some("il")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "header" \ "identifier")
@@ -101,8 +101,8 @@ class IllinoisMapping extends XmlMapping with XmlExtractor with IngestMessageTem
   override def dplaUri(data: Document[NodeSeq]): ZeroToOne[URI] = mintDplaItemUri(data)
 
   override def dataProvider(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
-  extractStrings(data \ "metadata" \\ "provenance")
-    .map(nameOnlyAgent)
+    extractStrings(data \ "metadata" \\ "provenance")
+      .map(nameOnlyAgent)
 
   override def edmRights(data: Document[NodeSeq]): ZeroToMany[URI] =
     (data \ "metadata" \\ "rights").flatMap(r => {

--- a/src/main/scala/dpla/ingestion3/mappers/providers/InMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/InMapping.scala
@@ -18,7 +18,7 @@ class InMapping extends XmlMapping with XmlExtractor
 
   override def useProviderName: Boolean = true
 
-  override def getProviderName: String = "in"
+  override def getProviderName: Option[String] = Some("in")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "header" \ "identifier")
@@ -127,7 +127,7 @@ class InMapping extends XmlMapping with XmlExtractor
 
   override def title(data: Document[NodeSeq]): AtLeastOne[String] =
     extractStrings(data \ "metadata" \ "qualifieddc" \ "title")
-  
+
   override def `type`(data: Document[NodeSeq]): ZeroToMany[String] =
     extractStrings(data \ "metadata" \ "qualifieddc" \ "type")
       .flatMap(_.splitAtDelimiter(";"))

--- a/src/main/scala/dpla/ingestion3/mappers/providers/LcMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/LcMapping.scala
@@ -19,8 +19,7 @@ class LcMapping() extends JsonMapping with JsonExtractor {
   override def useProviderName: Boolean = false
 
   // Hard coded to prevent accidental changes to base ID
-  override def getProviderName: String =
-    "loc"
+  override def getProviderName: Option[String] = Some("loc")
 
   override def originalId(implicit data: Document[JValue]): ZeroToOne[String] =
     extractString(unwrap(data) \ "item" \ "id") // TODO confirm basis field for DPLA ID
@@ -54,7 +53,7 @@ class LcMapping() extends JsonMapping with JsonExtractor {
   )
 
   override def isShownAt(data: Document[JValue]): ZeroToMany[EdmWebResource] =
-    // item['url']
+  // item['url']
     extractStrings(unwrap(data) \ "item" \ "url").map(stringOnlyWebResource)
 
   // SourceResource
@@ -72,7 +71,7 @@ class LcMapping() extends JsonMapping with JsonExtractor {
   }
 
   override def collection(data: Document[JValue]): ZeroToMany[DcmiTypeCollection] =
-    // [partof['title'] for partof in item['partof']
+  // [partof['title'] for partof in item['partof']
     extractStrings(unwrap(data) \\ "partof" \ "title")
       .map(nameOnlyCollection)
 
@@ -93,27 +92,27 @@ class LcMapping() extends JsonMapping with JsonExtractor {
   }
 
   override def description(data: Document[JValue]): ZeroToMany[String] =
-    // item['description'] AND item['created_published']
+  // item['description'] AND item['created_published']
     extractStrings(unwrap(data) \ "item" \ "description") ++
-      extractStrings(unwrap(data) \ "item" \ "created_published" )
+      extractStrings(unwrap(data) \ "item" \ "created_published")
 
   override def extent(data: Document[JValue]): ZeroToMany[String] =
-    // item['medium']
+  // item['medium']
     extractStrings(unwrap(data) \ "item" \ "medium")
 
   override def format(data: Document[JValue]): ZeroToMany[String] = {
     // (item['type'] AND item['genre']) OR type in item['format']],
     val format =
       extractStrings(unwrap(data) \ "item" \ "type") ++
-      extractStrings(unwrap(data) \ "item" \ "genre") ++
-      extractStrings(unwrap(data) \ "item" \ "format" \ "type")
+        extractStrings(unwrap(data) \ "item" \ "genre") ++
+        extractStrings(unwrap(data) \ "item" \ "format" \ "type")
 
     format.map(_.applyBlockFilter(formatBlockList))
       .filter(_.nonEmpty)
   }
 
   override def identifier(data: Document[JValue]): ZeroToMany[String] =
-    // item['id']
+  // item['id']
     extractStrings(unwrap(data) \ "item" \ "id")
 
   override def language(data: Document[JValue]): ZeroToMany[SkosConcept] = {
@@ -122,29 +121,29 @@ class LcMapping() extends JsonMapping with JsonExtractor {
   }
 
   override def place(data: Document[JValue]): ZeroToMany[DplaPlace] =
-    // item['location']].keys
-    // loc.gov/item: item['coordinates']   << lat // TODO How should this integrate?
+  // item['location']].keys
+  // loc.gov/item: item['coordinates']   << lat // TODO How should this integrate?
     extractKeys(unwrap(data) \ "item" \ "location")
       .map(_.capitalizeFirstChar) // capitalize first char since we are using json keys
       .map(nameOnlyPlace)
 
   override def rights(data: Document[JValue]): AtLeastOne[String] =
-    // "For rights relating to this resource, visit " + same mapping for isShownAt
-  isShownAt(data).flatMap(edmWr => Seq(s"For rights relating to this resource, visit ${edmWr.uri.value}"))
+  // "For rights relating to this resource, visit " + same mapping for isShownAt
+    isShownAt(data).flatMap(edmWr => Seq(s"For rights relating to this resource, visit ${edmWr.uri.value}"))
 
   override def subject(data: Document[JValue]): ZeroToMany[SkosConcept] =
-    // item['subject_headings']
+  // item['subject_headings']
     extractStrings(unwrap(data) \ "item" \ "subject_headings").map(nameOnlyConcept)
 
   override def title(data: Document[JValue]): AtLeastOne[String] =
-    // item['title']
+  // item['title']
     extractStrings(unwrap(data) \ "item" \ "title")
 
   override def `type`(data: Document[JValue]): ZeroToMany[String] = {
     // item['type'] OR item['original_format']].keys
     extractStrings(unwrap(data) \ "item" \ "type") ++
-    extractKeys(unwrap(data) \ "item" \ "original_format") ++
-    format(data)
+      extractKeys(unwrap(data) \ "item" \ "original_format") ++
+      format(data)
   }
 }
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MarylandMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MarylandMapping.scala
@@ -15,7 +15,7 @@ class MarylandMapping extends XmlMapping with XmlExtractor {
   // ID minting functions
   override def useProviderName: Boolean = true
 
-  override def getProviderName: String = "maryland"
+  override def getProviderName: Option[String] = Some("maryland")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "header" \ "identifier")

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MdlMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MdlMapping.scala
@@ -11,7 +11,7 @@ import org.json4s
 import org.json4s.JsonDSL._
 import org.json4s._
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{Success, Try}
 
 class MdlMapping extends JsonMapping with JsonExtractor with IngestMessageTemplates {
 
@@ -22,7 +22,7 @@ class MdlMapping extends JsonMapping with JsonExtractor with IngestMessageTempla
   // ID minting functions
   override def useProviderName: Boolean = true
 
-  override def getProviderName: String = "minnesota"
+  override def getProviderName: Option[String] = Some("minnesota")
 
   override def originalId(implicit data: Document[JValue]): ZeroToOne[String] =
     extractString(unwrap(data) \ "attributes" \ "metadata" \ "isShownAt")
@@ -36,10 +36,12 @@ class MdlMapping extends JsonMapping with JsonExtractor with IngestMessageTempla
   override def edmRights(data: Document[json4s.JValue]): ZeroToMany[URI] =
     extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "rights")
       .filter(r =>
-        Try { new java.net.URI(r).getHost } match {
+        Try {
+          new java.net.URI(r).getHost
+        } match {
           case Success(host: String) => host.equalsIgnoreCase("rightsstatements.org") || host.equalsIgnoreCase("creativecommons.org")
           case _ => false
-      })
+        })
       .map(URI)
 
   override def intermediateProvider(data: Document[JValue]): ZeroToOne[EdmAgent] =
@@ -101,24 +103,26 @@ class MdlMapping extends JsonMapping with JsonExtractor with IngestMessageTempla
     place(unwrap(data) \ "attributes" \ "metadata" \ "sourceResource" \ "spatial")
 
   override def publisher(data: Document[JValue]): ZeroToMany[EdmAgent] =
-    extractStrings(unwrap(data)  \ "attributes" \ "metadata" \ "sourceResource" \ "publisher").map(nameOnlyAgent)
+    extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "sourceResource" \ "publisher").map(nameOnlyAgent)
 
   override def rights(data: Document[JValue]): AtLeastOne[String] =
     extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "rights")
       .filterNot(r =>
-        Try { new java.net.URI(r).getHost } match {
+        Try {
+          new java.net.URI(r).getHost
+        } match {
           case Success(host: String) => host.equalsIgnoreCase("rightsstatements.org") || host.equalsIgnoreCase("creativecommons.org")
           case _ => false
         })
 
   override def subject(data: Document[JValue]): ZeroToMany[SkosConcept] =
-    extractStrings(unwrap(data)  \ "attributes" \ "metadata" \ "sourceResource" \ "subject" \ "name").map(nameOnlyConcept)
+    extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "sourceResource" \ "subject" \ "name").map(nameOnlyConcept)
 
   override def title(data: Document[JValue]): AtLeastOne[String] =
-    extractStrings(unwrap(data)  \ "attributes" \ "metadata" \ "sourceResource" \ "title")
+    extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "sourceResource" \ "title")
 
   override def `type`(data: Document[JValue]): ZeroToMany[String] =
-    extractStrings(unwrap(data)  \ "attributes" \ "metadata" \ "sourceResource" \ "type")
+    extractStrings(unwrap(data) \ "attributes" \ "metadata" \ "sourceResource" \ "type")
 
   // Helper functions
   def extractCollection(collection: JValue): ZeroToMany[DcmiTypeCollection] = {
@@ -126,7 +130,8 @@ class MdlMapping extends JsonMapping with JsonExtractor with IngestMessageTempla
       DcmiTypeCollection(
         title = extractString(c \\ "title"),
         description = extractString(c \\ "description")
-      )})
+      )
+    })
   }
 
   def extractDate(date: JValue): ZeroToMany[EdmTimeSpan] = {

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MeMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MeMapping.scala
@@ -16,7 +16,7 @@ class MeMapping extends XmlMapping with XmlExtractor
   // IdMinter methods
   override def useProviderName: Boolean = true
 
-  override def getProviderName: String = "maine"
+  override def getProviderName: Option[String] = Some("maine")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "header" \ "identifier").map(_.trim)
@@ -90,7 +90,7 @@ class MeMapping extends XmlMapping with XmlExtractor
   )
 
   override def sidecar(data: Document[NodeSeq]): JValue =
-    ("prehashId" -> buildProviderBaseId()(data)) ~ ("dplaId" -> mintDplaId(data) )
+    ("prehashId" -> buildProviderBaseId()(data)) ~ ("dplaId" -> mintDplaId(data))
 
   def metadataRoot(data: Document[NodeSeq]): NodeSeq = data \ "metadata" \ "qualifieddc"
 }

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MichiganMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MichiganMapping.scala
@@ -21,7 +21,7 @@ class MichiganMapping extends XmlMapping with XmlExtractor with IngestMessageTem
   // ID minting functions
   override def useProviderName(): Boolean = true
 
-  override def getProviderName(): String = "mi"
+  override def getProviderName(): Option[String] = Some("mi")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "header" \ "identifier")
@@ -48,7 +48,7 @@ class MichiganMapping extends XmlMapping with XmlExtractor with IngestMessageTem
       .filter(node => {
         val role = (node \ "role" \ "roleTerm").text
         role.isEmpty || role.equalsIgnoreCase("creator")
-      } )
+      })
       .flatMap(n => extractStrings(n \ "namePart"))
       .map(nameOnlyAgent)
 
@@ -73,15 +73,15 @@ class MichiganMapping extends XmlMapping with XmlExtractor with IngestMessageTem
       .flatMap(node => getByAttribute(node.asInstanceOf[Elem], "point", "end"))
       .flatMap(node => extractStrings(node))
 
-    val constructedDateIssued = if(dateIssuedEarly.length == dateIssuedLate.length) {
-        dateIssuedEarly.zip(dateIssuedLate).map {
-          case (begin: String, end: String) =>
-            EdmTimeSpan(
-              originalSourceDate = Some(s"$begin-$end"),
-              begin = Some(begin),
-              end = Some(end)
-            )
-        }
+    val constructedDateIssued = if (dateIssuedEarly.length == dateIssuedLate.length) {
+      dateIssuedEarly.zip(dateIssuedLate).map {
+        case (begin: String, end: String) =>
+          EdmTimeSpan(
+            originalSourceDate = Some(s"$begin-$end"),
+            begin = Some(begin),
+            end = Some(end)
+          )
+      }
     } else {
       Seq()
     }
@@ -93,7 +93,7 @@ class MichiganMapping extends XmlMapping with XmlExtractor with IngestMessageTem
       case _ => Seq()
     }
   }
-  
+
   override def description(data: Document[NodeSeq]): Seq[String] = {
     // <mods:note> and <mods:abstract>
     extractStrings(data \\ "mods" \ "abstract") ++

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MissouriMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MissouriMapping.scala
@@ -18,7 +18,7 @@ class MissouriMapping extends JsonMapping with JsonExtractor with IngestMessageT
   // ID minting functions
   override def useProviderName: Boolean = false // Missouri provides ids with the provider name already prepended
 
-  override def getProviderName: String = "missouri"
+  override def getProviderName: Option[String] = Some("missouri")
 
   override def originalId(implicit data: Document[JValue]): ZeroToOne[String] =
     extractString(unwrap(data) \ "@id")
@@ -56,7 +56,7 @@ class MissouriMapping extends JsonMapping with JsonExtractor with IngestMessageT
   // SourceResource
 
   override def creator(data: Document[JValue]): ZeroToMany[EdmAgent] =
-    extractStrings(unwrap(data)  \ "sourceResource" \ "creator").map(nameOnlyAgent)
+    extractStrings(unwrap(data) \ "sourceResource" \ "creator").map(nameOnlyAgent)
 
   override def description(data: Document[JValue]): ZeroToMany[String] =
     extractStrings(unwrap(data) \ "sourceResource" \ "description")
@@ -81,10 +81,10 @@ class MissouriMapping extends JsonMapping with JsonExtractor with IngestMessageT
     extractStrings(unwrap(data) \ "sourceResource" \ "rights")
 
   override def subject(data: Document[JValue]): ZeroToMany[SkosConcept] =
-    extractStrings(unwrap(data)  \ "sourceResource" \ "subject" \ "name").map(nameOnlyConcept)
+    extractStrings(unwrap(data) \ "sourceResource" \ "subject" \ "name").map(nameOnlyConcept)
 
   override def date(data: Document[JValue]): ZeroToMany[EdmTimeSpan] =
-     extractDate(unwrap(data) \ "sourceResource" \ "temporal")
+    extractDate(unwrap(data) \ "sourceResource" \ "temporal")
 
   override def title(data: Document[JValue]): AtLeastOne[String] =
     extractStrings(unwrap(data) \ "sourceResource" \ "title")

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MtMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MtMapping.scala
@@ -36,24 +36,24 @@ class MtMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
   // ID minting functions
   override def useProviderName(): Boolean = true
 
-  override def getProviderName(): String = "mt"
+  override def getProviderName(): Option[String] = Some("mt")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \\ "header" \ "identifier")
 
   // SourceResource mapping
   override def collection(data: Document[NodeSeq]): ZeroToMany[DcmiTypeCollection] =
-    // first instance of <mods:relatedItem><mods:titleInfo><mods:title>
+  // first instance of <mods:relatedItem><mods:titleInfo><mods:title>
     extractStrings(data \\ "relatedItem" \ "titleInfo" \ "title")
       .map(nameOnlyCollection)
       .take(1)
 
   override def creator(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
-    // <mods:name><mods:namePart> when <mods:role><mods:roleTerm> equals Creator
-  (data \\ "name")
-    .map(node => node.filter(n => (n \\ "roleTerm").text.equalsIgnoreCase("creator")))
-    .flatMap(n => extractStrings(n \ "namePart"))
-    .map(nameOnlyAgent)
+  // <mods:name><mods:namePart> when <mods:role><mods:roleTerm> equals Creator
+    (data \\ "name")
+      .map(node => node.filter(n => (n \\ "roleTerm").text.equalsIgnoreCase("creator")))
+      .flatMap(n => extractStrings(n \ "namePart"))
+      .map(nameOnlyAgent)
 
   override def date(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] =
   // <mods:originInfo><mods:dateCreated>
@@ -88,7 +88,7 @@ class MtMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
       .map(nameOnlyAgent)
 
   override def rights(data: Document[NodeSeq]): AtLeastOne[String] =
-    // <mods:accessCondition> @type=local rights statements
+  // <mods:accessCondition> @type=local rights statements
     (data \\ "mods" \ "accessCondition")
       .filter({ n => filterAttribute(n, "type", "local rights statements") })
       .flatMap(extractStrings)
@@ -111,10 +111,10 @@ class MtMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
 
   override def dataProvider(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
   // <mods:note> @type=ownership
-  (data \\ "metadata" \ "mods" \ "note")
-    .flatMap(node => getByAttribute(node.asInstanceOf[Elem], "type", "ownership"))
-    .flatMap(extractStrings)
-    .map(nameOnlyAgent)
+    (data \\ "metadata" \ "mods" \ "note")
+      .flatMap(node => getByAttribute(node.asInstanceOf[Elem], "type", "ownership"))
+      .flatMap(extractStrings)
+      .map(nameOnlyAgent)
 
   override def edmRights(data: Document[NodeSeq]): ZeroToMany[URI] = {
     // <mods:accessCondition>@type=use and reproduction @xlink:href =[this is the value to be mapped]
@@ -126,7 +126,7 @@ class MtMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
   }
 
   override def isShownAt(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
-    // <mods:location><mods:url> @access=object in context @usage=primary display
+  // <mods:location><mods:url> @access=object in context @usage=primary display
     (data \\ "location" \ "url")
       .flatMap(node => getByAttribute(node.asInstanceOf[Elem], "usage", "primary display"))
       .flatMap(node => getByAttribute(node.asInstanceOf[Elem], "access", "object in context"))
@@ -136,7 +136,7 @@ class MtMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
   override def originalRecord(data: Document[NodeSeq]): ExactlyOne[String] = Utils.formatXml(data)
 
   override def preview(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
-    // <mods:location><mods:url> @access=preview
+  // <mods:location><mods:url> @access=preview
     previewHelper(data).map(stringOnlyWebResource)
 
   override def provider(data: Document[NodeSeq]): ExactlyOne[EdmAgent] = agent

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MwdlMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MwdlMapping.scala
@@ -26,7 +26,7 @@ class MwdlMapping extends XmlMapping with XmlExtractor {
   // ID minting functions
   override def useProviderName(): Boolean = true
 
-  override def getProviderName(): String = "mwdl"
+  override def getProviderName(): Option[String] = Some("mwdl")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \\ "PrimoNMBib" \ "record" \ "control" \ "recordid")
@@ -47,15 +47,15 @@ class MwdlMapping extends XmlMapping with XmlExtractor {
       .map(nameOnlyAgent)
 
   override def date(data: Document[NodeSeq]): Seq[EdmTimeSpan] =
-    // search/creationdate AND PrimoNMBib/record/display/creationdate
-      extractStrings(data \\ "display" \ "creationdate")
-        .flatMap(_.splitAtDelimiter(";"))
-        .map(stringOnlyTimeSpan)
+  // search/creationdate AND PrimoNMBib/record/display/creationdate
+    extractStrings(data \\ "display" \ "creationdate")
+      .flatMap(_.splitAtDelimiter(";"))
+      .map(stringOnlyTimeSpan)
 
   override def description(data: Document[NodeSeq]): Seq[String] =
   // search/description (contains dc:description, dcterms:abstract, and dcterms:tableOfContents)
     extractStrings(data \\ "search" \ "description")
-    .map(_.limitCharacters(1000))
+      .map(_.limitCharacters(1000))
 
   override def extent(data: Document[NodeSeq]): ZeroToMany[String] =
     extractStrings(data \\ "display" \ "lds05")

--- a/src/main/scala/dpla/ingestion3/mappers/providers/NJDEMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/NJDEMapping.scala
@@ -21,7 +21,7 @@ class NJDEMapping extends XmlMapping with XmlExtractor with IngestMessageTemplat
   // ID minting functions
   override def useProviderName(): Boolean = true
 
-  override def getProviderName(): String = "njde"
+  override def getProviderName(): Option[String] = Some("njde")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "header" \ "identifier").map(_.trim)
@@ -43,7 +43,7 @@ class NJDEMapping extends XmlMapping with XmlExtractor with IngestMessageTemplat
   override def date(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] =
     extractStrings(metadata(data) \\ "date")
       .map(stringOnlyTimeSpan)
-  
+
   override def description(data: Document[NodeSeq]): Seq[String] =
     extractStrings(metadata(data) \\ "description")
 
@@ -65,7 +65,7 @@ class NJDEMapping extends XmlMapping with XmlExtractor with IngestMessageTemplat
       .map(nameOnlyPlace)
 
   override def subject(data: Document[NodeSeq]): Seq[SkosConcept] =
-     extractStrings(metadata(data) \\ "subject")
+    extractStrings(metadata(data) \\ "subject")
       .map(nameOnlyConcept)
 
   override def title(data: Document[NodeSeq]): Seq[String] =

--- a/src/main/scala/dpla/ingestion3/mappers/providers/NYPLMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/NYPLMapping.scala
@@ -15,6 +15,7 @@ import scala.util.{Failure, Success, Try}
 import scala.xml.{Elem, NodeSeq, XML}
 
 class NyplJsonExtractor extends JsonExtractor
+
 class NyplXmlExtractor extends XmlExtractor
 
 class NyplMapping(doc: Document[JValue] = null) extends JsonMapping with IngestMessageTemplates {
@@ -34,6 +35,7 @@ class NyplMapping(doc: Document[JValue] = null) extends JsonMapping with IngestM
   }
 
   private def modsRoot(data: JValue): JValue = data \ "solr_doc_hash" \ "mods_st"
+
   private def solrRoot(data: JValue): JValue = data \ "solr_doc_hash"
 
   /**
@@ -43,6 +45,8 @@ class NyplMapping(doc: Document[JValue] = null) extends JsonMapping with IngestM
     * @return Boolean
     */
   override def useProviderName: Boolean = true
+
+  override def getProviderName: Option[String] = Some("nypl")
 
   /**
     * Extract the record's "persistent" identifier. Implementations should raise
@@ -59,45 +63,45 @@ class NyplMapping(doc: Document[JValue] = null) extends JsonMapping with IngestM
 
   val latLongRegex = "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
 
-  val creatorRoles = Seq("architect", "art copyist", "artist", "attributed name", "author","binder","binding designer",
-    "book jacket designer","bookplate designer","calligrapher","cartographer","choreographer","composer","correspondent",
-    "costume designer","cover designer","creator","dedicator","designer","director","dissertant","dubious author",
-    "engraver","etcher","facsimilist","film director","forger","illustrator","interviewee","interviewer","inventor",
-    "landscape architect","librettist","lighting designer","lithographer","lyricist","papermaker","performer",
-    "photographer","sculptor","set designer","singer","sound designer","wood engraver","woodcutter")
+  val creatorRoles = Seq("architect", "art copyist", "artist", "attributed name", "author", "binder", "binding designer",
+    "book jacket designer", "bookplate designer", "calligrapher", "cartographer", "choreographer", "composer", "correspondent",
+    "costume designer", "cover designer", "creator", "dedicator", "designer", "director", "dissertant", "dubious author",
+    "engraver", "etcher", "facsimilist", "film director", "forger", "illustrator", "interviewee", "interviewer", "inventor",
+    "landscape architect", "librettist", "lighting designer", "lithographer", "lyricist", "papermaker", "performer",
+    "photographer", "sculptor", "set designer", "singer", "sound designer", "wood engraver", "woodcutter")
 
-  val contributorRoles = Seq("actor", "adapter","addressee","analyst","animator","annotator","applicant","arranger",
-    "art director","artistic director", "assignee","associated name","auctioneer","author in quotations or text extracts",
-    "author of afterword, colophon, etc.", "author of dialog","author of introduction, etc.","bibliographic antecedent",
-    "blurbwriter","book designer", "book producer", "bookseller","censor","cinematographer","client","collector",
-    "collotyper","colorist","commentator","commentator for written text","compiler","complainant","complainant-appellant",
-    "complainant-appellee","compositor","conceptor","conductor", "conservator","consultant","consultant to a project",
-    "contestant","contestant-appellant","contestant-appellee","contestee", "contestee-appellant","contestee-appellee",
-    "contractor","contributor","copyright claimant","copyright holder","corrector",
-    "curator","curator of an exhibition","dancer","data contributor","data manager","dedicatee","defendant","defendant-appellant",
-    "defendant-appellee","degree granting institution","degree grantor","delineator","depositor","distributor","donor",
-    "draftsman","editor","editor of compilation","editor of moving image work","electrician","electrotyper","engineer","expert",
-    "field director","film distributor","film editor","film producer","first party","former owner","funder",
-    "geographic information specialist","honoree","host","illuminator","inscriber","instrumentalist","issuing body","judge","laboratory",
-    "laboratory director","lead","lender","libelant","libelant-appellant","libelant-appellee","libelee","libelee-appellant",
-    "libelee-appellee","licensee","licensor","manufacturer","marbler","markup editor","metadata contact","metal-engraver",
-    "moderator","monitor","music copyist","musical director","musician","narrator","opponent","organizer","originator",
-    "other","owner","panelist","patent applicant","patent holder","patron","permitting agency","plaintiff","plaintiff-appellant",
-    "plaintiff-appellee","platemaker","presenter","printer","printer of plates","printmaker","process contact","producer",
-    "production company","production manager","production personnel","programmer","project director","proofreader",
-    "publisher","publishing director","puppeteer","radio producer","recording engineer","redaktor","fenderer","feporter",
-    "research team head","research team member","researcher","respondent","respondent-appellant","respondent-appellee",
-    "responsible party","restager","reviewer","rubricator","scenarist","scientific advisor","screenwriter","scribe",
-    "second party","secretary","signer","speaker","sponsor","stage director","stage manager","standards body","stereotyper",
-    "storyteller","supporting host","surveyor","teacher","technical director","television director","television producer",
-    "thesis advisor","transcriber","translator","type designer","typographer","videographer","voice actor","witness",
+  val contributorRoles = Seq("actor", "adapter", "addressee", "analyst", "animator", "annotator", "applicant", "arranger",
+    "art director", "artistic director", "assignee", "associated name", "auctioneer", "author in quotations or text extracts",
+    "author of afterword, colophon, etc.", "author of dialog", "author of introduction, etc.", "bibliographic antecedent",
+    "blurbwriter", "book designer", "book producer", "bookseller", "censor", "cinematographer", "client", "collector",
+    "collotyper", "colorist", "commentator", "commentator for written text", "compiler", "complainant", "complainant-appellant",
+    "complainant-appellee", "compositor", "conceptor", "conductor", "conservator", "consultant", "consultant to a project",
+    "contestant", "contestant-appellant", "contestant-appellee", "contestee", "contestee-appellant", "contestee-appellee",
+    "contractor", "contributor", "copyright claimant", "copyright holder", "corrector",
+    "curator", "curator of an exhibition", "dancer", "data contributor", "data manager", "dedicatee", "defendant", "defendant-appellant",
+    "defendant-appellee", "degree granting institution", "degree grantor", "delineator", "depositor", "distributor", "donor",
+    "draftsman", "editor", "editor of compilation", "editor of moving image work", "electrician", "electrotyper", "engineer", "expert",
+    "field director", "film distributor", "film editor", "film producer", "first party", "former owner", "funder",
+    "geographic information specialist", "honoree", "host", "illuminator", "inscriber", "instrumentalist", "issuing body", "judge", "laboratory",
+    "laboratory director", "lead", "lender", "libelant", "libelant-appellant", "libelant-appellee", "libelee", "libelee-appellant",
+    "libelee-appellee", "licensee", "licensor", "manufacturer", "marbler", "markup editor", "metadata contact", "metal-engraver",
+    "moderator", "monitor", "music copyist", "musical director", "musician", "narrator", "opponent", "organizer", "originator",
+    "other", "owner", "panelist", "patent applicant", "patent holder", "patron", "permitting agency", "plaintiff", "plaintiff-appellant",
+    "plaintiff-appellee", "platemaker", "presenter", "printer", "printer of plates", "printmaker", "process contact", "producer",
+    "production company", "production manager", "production personnel", "programmer", "project director", "proofreader",
+    "publisher", "publishing director", "puppeteer", "radio producer", "recording engineer", "redaktor", "fenderer", "feporter",
+    "research team head", "research team member", "researcher", "respondent", "respondent-appellant", "respondent-appellee",
+    "responsible party", "restager", "reviewer", "rubricator", "scenarist", "scientific advisor", "screenwriter", "scribe",
+    "second party", "secretary", "signer", "speaker", "sponsor", "stage director", "stage manager", "standards body", "stereotyper",
+    "storyteller", "supporting host", "surveyor", "teacher", "technical director", "television director", "television producer",
+    "thesis advisor", "transcriber", "translator", "type designer", "typographer", "videographer", "voice actor", "witness",
     "writer of accompanying material")
 
   override def title(data: Document[json4s.JValue]): AtLeastOne[String] =
   // titleInfo \ "title" @usage='primary'
     (modsXml \ "titleInfo")
       .flatMap(node => xml.getByAttribute(node, "usage", "primary"))
-      .flatMap(node => xml.extractStrings (node \ "title"))
+      .flatMap(node => xml.extractStrings(node \ "title"))
 
   override def alternateTitle(data: Document[json4s.JValue]): ZeroToMany[String] =
   // all other title values
@@ -169,6 +173,7 @@ class NyplMapping(doc: Document[JValue] = null) extends JsonMapping with IngestM
     json.extractStrings("keyDate_st")(solrRoot(data)).map(stringOnlyTimeSpan) // TODO confirm
 
   override def publisher(data: Document[json4s.JValue]): ZeroToMany[EdmAgent] = Seq(emptyEdmAgent)
+
   // TODO this is complicated
 
   override def edmRights(data: Document[json4s.JValue]): ZeroToMany[URI] =
@@ -209,7 +214,7 @@ class NyplMapping(doc: Document[JValue] = null) extends JsonMapping with IngestM
 
   // Helper method
   def agent = EdmAgent(
-    name = Some("New York Public Library"),
+    name = Some("The New York Public Library"),
     uri = Some(URI("http://dp.la/api/contributor/nypl"))
   )
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/NaraMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/NaraMapping.scala
@@ -20,9 +20,9 @@ class NaraMapping extends XmlMapping with XmlExtractor {
   override val enforceEdmRights: Boolean = true // edmRights is now a required property for NARA
 
   // ID minting functions
-  override def useProviderName(): Boolean = true
+  override def useProviderName: Boolean = true
 
-  override def getProviderName(): String = "nara"
+  override def getProviderName: Option[String] = Some("nara")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString("naId")(data)
@@ -91,35 +91,36 @@ class NaraMapping extends XmlMapping with XmlExtractor {
 
     val edmRights = List(useRestriction)
       .zipAll(specificRestrictions, None, None) // merge useRestriction and specificRestriction into set,
-      .map{ case (ur: Option[String], sr: Option[String]) => (ur, sr) match {
-        case (Some("Restricted - Fully"), Some("Copyright")) => Some(rightsUri("InC"))
-        case (Some("Restricted - Fully"), Some("Donor Restrictions")) => Some(rightsUri("InC"))
-        case (Some("Restricted - Fully"), Some("Public Law 101-246")) => Some(rightsUri("InC"))
-        case (Some("Restricted - Fully"), Some("Service Mark")) => Some(rightsUri("NoC-OKLR"))
-        case (Some("Restricted - Fully"), Some("Trademark")) => Some(rightsUri("NoC-OKLR"))
-        case (Some("Restricted - Fully"), Some("Other")) => Some(rightsUri("NoC-OKLR"))
-        case (Some("Restricted - Partly"), Some("Copyright")) => Some(rightsUri("InC"))
-        case (Some("Restricted - Partly"), Some("Donor Restrictions")) => Some(rightsUri("InC"))
-        case (Some("Restricted - Partly"), Some("Public Law 101-246")) => Some(rightsUri("InC"))
-        case (Some("Restricted - Partly"), Some("Service Mark")) => Some(rightsUri("NoC-OKLR"))
-        case (Some("Restricted - Partly"), Some("Trademark")) => Some(rightsUri("NoC-OKLR"))
-        case (Some("Restricted - Partly"), Some("Other")) => Some(rightsUri("NoC-OKLR"))
-        case (Some("Restricted - Possibly"), Some("Copyright")) => Some(rightsUri("UND"))
-        case (Some("Restricted - Possibly"), Some("Donor Restrictions")) => Some(rightsUri("UND"))
-        case (Some("Restricted - Possibly"), Some("Public Law 101-246")) => Some(rightsUri("NKC"))
-        case (Some("Restricted - Possibly"), Some("Service Mark")) => Some(rightsUri("NoC-OKLR"))
-        case (Some("Restricted - Possibly"), Some("Trademark")) => Some(rightsUri("NoC-OKLR"))
-        case (Some("Restricted - Possibly"), Some("Other")) => Some(rightsUri("NoC-OKLR"))
-        case (Some("Restricted - Possibly"), _) => Some(rightsUri("UND"))
-        case (Some("Undetermined"), _) => Some(rightsUri("CNE"))
-        case (Some("Unrestricted"), _) => Some(rightsUri("NoC-US"))
-        case (_, _) => None
-      }}
+      .map { case (ur: Option[String], sr: Option[String]) => (ur, sr) match {
+      case (Some("Restricted - Fully"), Some("Copyright")) => Some(rightsUri("InC"))
+      case (Some("Restricted - Fully"), Some("Donor Restrictions")) => Some(rightsUri("InC"))
+      case (Some("Restricted - Fully"), Some("Public Law 101-246")) => Some(rightsUri("InC"))
+      case (Some("Restricted - Fully"), Some("Service Mark")) => Some(rightsUri("NoC-OKLR"))
+      case (Some("Restricted - Fully"), Some("Trademark")) => Some(rightsUri("NoC-OKLR"))
+      case (Some("Restricted - Fully"), Some("Other")) => Some(rightsUri("NoC-OKLR"))
+      case (Some("Restricted - Partly"), Some("Copyright")) => Some(rightsUri("InC"))
+      case (Some("Restricted - Partly"), Some("Donor Restrictions")) => Some(rightsUri("InC"))
+      case (Some("Restricted - Partly"), Some("Public Law 101-246")) => Some(rightsUri("InC"))
+      case (Some("Restricted - Partly"), Some("Service Mark")) => Some(rightsUri("NoC-OKLR"))
+      case (Some("Restricted - Partly"), Some("Trademark")) => Some(rightsUri("NoC-OKLR"))
+      case (Some("Restricted - Partly"), Some("Other")) => Some(rightsUri("NoC-OKLR"))
+      case (Some("Restricted - Possibly"), Some("Copyright")) => Some(rightsUri("UND"))
+      case (Some("Restricted - Possibly"), Some("Donor Restrictions")) => Some(rightsUri("UND"))
+      case (Some("Restricted - Possibly"), Some("Public Law 101-246")) => Some(rightsUri("NKC"))
+      case (Some("Restricted - Possibly"), Some("Service Mark")) => Some(rightsUri("NoC-OKLR"))
+      case (Some("Restricted - Possibly"), Some("Trademark")) => Some(rightsUri("NoC-OKLR"))
+      case (Some("Restricted - Possibly"), Some("Other")) => Some(rightsUri("NoC-OKLR"))
+      case (Some("Restricted - Possibly"), _) => Some(rightsUri("UND"))
+      case (Some("Undetermined"), _) => Some(rightsUri("CNE"))
+      case (Some("Unrestricted"), _) => Some(rightsUri("NoC-US"))
+      case (_, _) => None
+    }
+    }
 
     // The most restrictive statements
     val mostRestrictive = Seq(
       Some(rightsUri("InC")), // in copyright
-      Some(rightsUri("UND"))  // copyright undetermined
+      Some(rightsUri("UND")) // copyright undetermined
     )
 
     // If more than one rights statement is mapped then select either of the most restrictive statements
@@ -230,7 +231,6 @@ class NaraMapping extends XmlMapping with XmlExtractor {
 
   override def `type`(data: Document[NodeSeq]): ZeroToMany[String] =
     extractTypes(data)
-
 
 
   // Helper methods
@@ -349,6 +349,7 @@ class NaraMapping extends XmlMapping with XmlExtractor {
 
   /**
     * removes the time portion of an ISO-8601 datetime
+    *
     * @param string
     * @return string without the time, if there was one
     */
@@ -471,11 +472,11 @@ class NaraMapping extends XmlMapping with XmlExtractor {
 
 
   private def extractTypes(data: NodeSeq): Seq[String] = for {
-      stringType <- extractStrings(data \\ "generalRecordsTypeArray" \ "generalRecordsType" \ "termName")
-      mappedType <- NaraTypeVocabEnforcer.mapNaraType(stringType)
-    } yield {
-      mappedType
-    }
+    stringType <- extractStrings(data \\ "generalRecordsTypeArray" \ "generalRecordsType" \ "termName")
+    mappedType <- NaraTypeVocabEnforcer.mapNaraType(stringType)
+  } yield {
+    mappedType
+  }
 }
 
 object NaraTypeVocabEnforcer {

--- a/src/main/scala/dpla/ingestion3/mappers/providers/NcMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/NcMapping.scala
@@ -22,7 +22,7 @@ class NcMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
   // ID minting functions
   override def useProviderName(): Boolean = true
 
-  override def getProviderName(): String = "digitalnc"
+  override def getProviderName(): Option[String] = Some("digitalnc")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "header" \ "identifier")
@@ -37,14 +37,14 @@ class NcMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
 
   // SourceResource mapping
   override def contributor(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
-    // when <role><roleTerm> DOES equal "contributor>
+  // when <role><roleTerm> DOES equal "contributor>
     (data \\ "mods" \ "name")
       .filter(node => (node \ "role" \ "roleTerm").text.equalsIgnoreCase("contributor"))
       .flatMap(n => extractStrings(n \ "namePart"))
       .map(nameOnlyAgent)
 
   override def creator(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
-    // <mods:name><mods:namePart> when <role><roleTerm> is 'creator'
+  // <mods:name><mods:namePart> when <role><roleTerm> is 'creator'
     (data \\ "mods" \ "name")
       .filter(node => (node \ "role" \ "roleTerm").text.equalsIgnoreCase("creator"))
       .flatMap(n => extractStrings(n \ "namePart"))
@@ -56,7 +56,7 @@ class NcMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
       .flatMap(extractStrings)
       .map(stringOnlyTimeSpan)
   }
-  
+
   override def description(data: Document[NodeSeq]): Seq[String] =
   // <mods:note type='content'>
     (data \\ "mods" \ "note")
@@ -99,7 +99,7 @@ class NcMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
       .flatMap(extractStrings)
 
   override def subject(data: Document[NodeSeq]): Seq[SkosConcept] =
-    // <mods:subject><mods:topic>
+  // <mods:subject><mods:topic>
     extractStrings(data \\ "mods" \ "subject" \ "topic")
       .map(nameOnlyConcept)
 
@@ -115,7 +115,7 @@ class NcMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
   override def dplaUri(data: Document[NodeSeq]): ZeroToOne[URI] = mintDplaItemUri(data)
 
   override def dataProvider(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
-    // first <note type="ownership">
+  // first <note type="ownership">
     (data \\ "mods" \ "note")
       .filter(node => filterAttribute(node, "type", "ownership"))
       .flatMap(extractStrings)
@@ -130,7 +130,7 @@ class NcMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
       .map(URI)
 
   override def intermediateProvider(data: Document[NodeSeq]): ZeroToOne[EdmAgent] =
-    // second <note type=ownership> if it exists
+  // second <note type=ownership> if it exists
     (data \\ "mods" \ "note")
       .filter(node => filterAttribute(node, "type", "ownership"))
       .flatMap(extractStrings)

--- a/src/main/scala/dpla/ingestion3/mappers/providers/NorthwestHeritageMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/NorthwestHeritageMapping.scala
@@ -23,7 +23,7 @@ class NorthwestHeritageMapping extends XmlMapping with XmlExtractor with IngestM
   // ID minting functions
   override def useProviderName(): Boolean = true
 
-  override def getProviderName(): String = "nwdh"
+  override def getProviderName(): Option[String] = Some("nwdh")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "identifier")
@@ -52,7 +52,7 @@ class NorthwestHeritageMapping extends XmlMapping with XmlExtractor with IngestM
       .map(nameOnlyAgent)
 
   override def date(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] =
-    // <mods:originInfo><mods:dateCreated>
+  // <mods:originInfo><mods:dateCreated>
     extractStrings(data \ "originInfo" \ "dateCreated")
       .map(stringOnlyTimeSpan)
 
@@ -94,7 +94,7 @@ class NorthwestHeritageMapping extends XmlMapping with XmlExtractor with IngestM
       .map(nameOnlyAgent)
 
   override def subject(data: Document[NodeSeq]): Seq[SkosConcept] =
-    // <mods:subject><mods:topic>
+  // <mods:subject><mods:topic>
     extractStrings(data \ "subject" \ "topic").map(nameOnlyConcept)
 
   override def title(data: Document[NodeSeq]): Seq[String] =

--- a/src/main/scala/dpla/ingestion3/mappers/providers/OhioMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/OhioMapping.scala
@@ -19,7 +19,7 @@ class OhioMapping extends XmlMapping with XmlExtractor
   // ID minting functions
   override def useProviderName(): Boolean = false
 
-  override def getProviderName(): String = "ohio"
+  override def getProviderName(): Option[String] = Some("ohio")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "header" \ "identifier")
@@ -59,9 +59,9 @@ class OhioMapping extends XmlMapping with XmlExtractor
     extractStrings(data \ "metadata" \\ "format")
       .flatMap(_.splitAtDelimiter(";"))
       .map(_.applyBlockFilter(
-         DigitalSurrogateBlockList.termList ++
-         FormatTypeValuesBlockList.termList ++
-        ExtentIdentificationList.termList))
+        DigitalSurrogateBlockList.termList ++
+          FormatTypeValuesBlockList.termList ++
+          ExtentIdentificationList.termList))
       .filter(_.nonEmpty)
 
   override def identifier(data: Document[NodeSeq]): Seq[String] =
@@ -153,12 +153,13 @@ class OhioMapping extends XmlMapping with XmlExtractor
   /**
     * Extracts values from format field and returns values that appear to be
     * extent statements
+    *
     * @param data
     * @return
     */
   def extentFromFormat(data: Document[NodeSeq]): ZeroToMany[String] =
-     extractStrings(data \ "metadata" \\ "format")
-       .flatMap(_.splitAtDelimiter(";"))
-       .map(_.extractExtents)
-       .filter(_.nonEmpty)
+    extractStrings(data \ "metadata" \\ "format")
+      .flatMap(_.splitAtDelimiter(";"))
+      .map(_.extractExtents)
+      .filter(_.nonEmpty)
 }

--- a/src/main/scala/dpla/ingestion3/mappers/providers/OklahomaMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/OklahomaMapping.scala
@@ -21,7 +21,7 @@ class OklahomaMapping extends XmlMapping with XmlExtractor with IngestMessageTem
   // ID minting functions
   override def useProviderName(): Boolean = true
 
-  override def getProviderName(): String = "oklahoma"
+  override def getProviderName(): Option[String] = Some("oklahoma")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "header" \ "identifier")
@@ -132,7 +132,7 @@ class OklahomaMapping extends XmlMapping with XmlExtractor with IngestMessageTem
     (data \\ "mods" \ "titleInfo")
       .filterNot({ n => filterAttribute(n, "type", "alternative") })
       .flatMap(titleInfo => extractStrings(titleInfo \ "title")) ++ // FIXME see above
-    alternateTitle(data)
+      alternateTitle(data)
 
   override def `type`(data: Document[NodeSeq]): Seq[String] =
   // <mods:typeofresource>

--- a/src/main/scala/dpla/ingestion3/mappers/providers/OrbisCascadeMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/OrbisCascadeMapping.scala
@@ -14,10 +14,10 @@ class OrbisCascadeMapping extends XmlMapping with XmlExtractor with IngestMessag
   // ID minting functions
   override def useProviderName(): Boolean = true
 
-  override def getProviderName(): String = "orbis-cascade"
+  override def getProviderName(): Option[String] = Some("orbis-cascade")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] = {
-    val xml: Elem  = data.get.asInstanceOf[Elem]
+    val xml: Elem = data.get.asInstanceOf[Elem]
     xml.attribute(xml.getNamespace("rdf"), "about")
       .getOrElse(throw new Exception("Missing required record ID"))
       .flatMap(extractStrings(_))
@@ -25,9 +25,9 @@ class OrbisCascadeMapping extends XmlMapping with XmlExtractor with IngestMessag
   }
 
   // SourceResource mapping
-    override def contributor(data: Document[NodeSeq]): Seq[EdmAgent] =
-      extractStrings(data \\ "SourceResource" \ "contributor")
-        .map(nameOnlyAgent)
+  override def contributor(data: Document[NodeSeq]): Seq[EdmAgent] =
+    extractStrings(data \\ "SourceResource" \ "contributor")
+      .map(nameOnlyAgent)
 
   override def creator(data: Document[NodeSeq]): Seq[EdmAgent] =
     extractStrings(data \\ "SourceResource" \ "contributor")
@@ -37,7 +37,7 @@ class OrbisCascadeMapping extends XmlMapping with XmlExtractor with IngestMessag
     val dateEarly = extractStrings(data \\ "SourceResource" \ "date" \ "TimeSpan" \ "begin")
     val dateLate = extractStrings(data \\ "SourceResource" \ "date" \ "TimeSpan" \ "end")
 
-    if(dateEarly.length == dateLate.length) {
+    if (dateEarly.length == dateLate.length) {
       dateEarly.zip(dateLate).map {
         case (begin: String, end: String) =>
           EdmTimeSpan(
@@ -93,23 +93,23 @@ class OrbisCascadeMapping extends XmlMapping with XmlExtractor with IngestMessag
 
       // Canonical list of mappings
       // https://docs.google.com/spreadsheets/d/17YZEQRtxdgttRCW6NsCWQ2d9qI9L4IrqzXcPEr6mg18/edit#gid=0
-      
-      "http://archiveswest.orbiscascade.org/contact#idu"->"University of Idaho Library, Special Collections and Archives",
-      "http://harvester.orbiscascade.org/agency/ormcl"->"Linfield College",
-      "http://archiveswest.orbiscascade.org/contact#orkt"->"Oregon Institute of Technology Libraries, Shaw Historical Library",
-      "http://archiveswest.orbiscascade.org/contact#orpl"->"Lewis & Clark College, Special Collections and Archives",
-      "http://archiveswest.orbiscascade.org/contact#waps"->"Washington State University Libraries, Manuscripts, Archives, and Special Collections",
-      "http://archiveswest.orbiscascade.org/contact#watu"->"University of Puget Sound, Archives & Special Collections",
-      "http://archiveswest.orbiscascade.org/contact#orngf"->"George Fox University Archives",
-      "http://archiveswest.orbiscascade.org/contact#wachene"->"Eastern Washington University",
-      "http://archiveswest.orbiscascade.org/contact#orsaw"->"Willamette University Archives and Special Collections",
-      "http://harvester.orbiscascade.org/agency/orpr"->"Reed College",
-      "http://archiveswest.orbiscascade.org/contact#ormonw"->"Western Oregon University Archives",
-      "http://archiveswest.orbiscascade.org/contact#orcs"->"Oregon State University Libraries, Special Collections and Archives Research Center",
-      "http://archiveswest.orbiscascade.org/contact#waspc"->"Seattle Pacific University",
-      "http://harvester.orbiscascade.org/agency/orashs"->"Southern Oregon University, Hannon Library",
-      "http://harvester.orbiscascade.org/agency/orpu"->"University of Portland",
-      "http://archiveswest.orbiscascade.org/contact#oru"->"University of Oregon Libraries, Special Collections and University Archives"
+
+      "http://archiveswest.orbiscascade.org/contact#idu" -> "University of Idaho Library, Special Collections and Archives",
+      "http://harvester.orbiscascade.org/agency/ormcl" -> "Linfield College",
+      "http://archiveswest.orbiscascade.org/contact#orkt" -> "Oregon Institute of Technology Libraries, Shaw Historical Library",
+      "http://archiveswest.orbiscascade.org/contact#orpl" -> "Lewis & Clark College, Special Collections and Archives",
+      "http://archiveswest.orbiscascade.org/contact#waps" -> "Washington State University Libraries, Manuscripts, Archives, and Special Collections",
+      "http://archiveswest.orbiscascade.org/contact#watu" -> "University of Puget Sound, Archives & Special Collections",
+      "http://archiveswest.orbiscascade.org/contact#orngf" -> "George Fox University Archives",
+      "http://archiveswest.orbiscascade.org/contact#wachene" -> "Eastern Washington University",
+      "http://archiveswest.orbiscascade.org/contact#orsaw" -> "Willamette University Archives and Special Collections",
+      "http://harvester.orbiscascade.org/agency/orpr" -> "Reed College",
+      "http://archiveswest.orbiscascade.org/contact#ormonw" -> "Western Oregon University Archives",
+      "http://archiveswest.orbiscascade.org/contact#orcs" -> "Oregon State University Libraries, Special Collections and Archives Research Center",
+      "http://archiveswest.orbiscascade.org/contact#waspc" -> "Seattle Pacific University",
+      "http://harvester.orbiscascade.org/agency/orashs" -> "Southern Oregon University, Hannon Library",
+      "http://harvester.orbiscascade.org/agency/orpu" -> "University of Portland",
+      "http://archiveswest.orbiscascade.org/contact#oru" -> "University of Oregon Libraries, Special Collections and University Archives"
     )
 
 
@@ -121,7 +121,7 @@ class OrbisCascadeMapping extends XmlMapping with XmlExtractor with IngestMessag
       .flatMap(uri => lookup.get(uri))
       .map(nameOnlyAgent)
   }
-  
+
   override def edmRights(data: Document[NodeSeq]): ZeroToMany[URI] = {
     val xml: Elem = (data \ "rights").headOption.getOrElse(Node).asInstanceOf[Elem]
     val rights = xml.attribute(xml.getNamespace("rdf"), "resource").getOrElse(Seq())
@@ -144,7 +144,7 @@ class OrbisCascadeMapping extends XmlMapping with XmlExtractor with IngestMessag
           .flatMap(extractStrings(_))
       case None => Seq()
     }
-    
+
     srAbout.map(stringOnlyWebResource)
   }
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/P2PMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/P2PMapping.scala
@@ -18,7 +18,7 @@ class P2PMapping extends XmlMapping with XmlExtractor with IngestMessageTemplate
   override def useProviderName: Boolean = true
 
   // Hard coded to prevent accidental changes to base ID
-  override def getProviderName: String = "p2p"
+  override def getProviderName: Option[String] = Some("p2p")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \\ "header" \ "identifier").map(_.trim)

--- a/src/main/scala/dpla/ingestion3/mappers/providers/ScMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/ScMapping.scala
@@ -21,7 +21,7 @@ class ScMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
   // ID minting functions
   override def useProviderName(): Boolean = true
 
-  override def getProviderName(): String = "scdl"
+  override def getProviderName(): Option[String] = Some("scdl")
 
   // FYI This ID minting will change all SCDL IDs [again]
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
@@ -44,7 +44,7 @@ class ScMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
   override def date(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] =
     extractStrings(metadata(data) \ "date")
       .map(stringOnlyTimeSpan)
-  
+
   override def description(data: Document[NodeSeq]): Seq[String] =
     extractStrings(metadata(data) \ "description")
 
@@ -74,7 +74,7 @@ class ScMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
       extractStrings(metadata(data) \ "accessRights")
 
   override def subject(data: Document[NodeSeq]): Seq[SkosConcept] =
-     extractStrings(metadata(data) \ "subject")
+    extractStrings(metadata(data) \ "subject")
       .map(nameOnlyConcept)
 
   override def temporal(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] =

--- a/src/main/scala/dpla/ingestion3/mappers/providers/SdMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/SdMapping.scala
@@ -1,12 +1,11 @@
 package dpla.ingestion3.mappers.providers
 
 import dpla.ingestion3.mappers.utils._
-import org.json4s._
 
 class SdMapping extends MdlMapping with JsonMapping with JsonExtractor {
 
   // ID minting functions
   override def useProviderName: Boolean = true
 
-  override def getProviderName: String = "sd"
+  override def getProviderName: Option[String] = Some("sd")
 }

--- a/src/main/scala/dpla/ingestion3/mappers/providers/SiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/SiMapping.scala
@@ -18,7 +18,7 @@ class SiMapping extends XmlMapping with XmlExtractor {
   // ID minting functions
   override def useProviderName: Boolean = true
 
-  override def getProviderName: String = "smithsonian"
+  override def getProviderName: Option[String] = Some("smithsonian")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] = {
     // Hard code URL query for item as basis for DPLA identifier to maintain SI ids between ingestion1 and ingestion3
@@ -71,25 +71,25 @@ class SiMapping extends XmlMapping with XmlExtractor {
       .map(nameOnlyAgent)
 
   override def creator(data: Document[NodeSeq]): Seq[EdmAgent] = {
-//    val creatorAttr = Seq("Architect", "Artist", "Artists/Makers", "Attributed to", "Author", "Cabinet Maker",
-//      "Ceramist", "Circle of", "Co-Designer", "Creator", "Decorator", "Designer", "Draftsman", "Editor", "Embroiderer",
-//      "Engraver", "Etcher", "Executor", "Follower of", "Graphic Designer", "Instrumentiste", "Inventor",
-//      "Landscape Architect", "Landscape Designer", "Maker", "Model Maker/maker", "Modeler", "Painter", "Photographer",
-//      "Possible attribution", "Possibly", "Possibly by", "Print Maker", "Printmaker", "Probably", "School of", "Sculptor",
-//      "Studio of", "Workshop of", "Weaver", "Writer", "animator", "architect", "artist", "artist.", "artist?",
-//      "artist attribution", "author", "author.", "author?", "authors?", "caricaturist", "cinematographer", "composer",
-//      "composer, lyricist", "composer; lyrcist", "composer; lyricist", "composer; performer", "composer; recording artist",
-//      "composer?", "creator", "creators", "designer", "developer", "director", "editor", "engraver", "ethnographer", "fabricator",
-//      "filmmaker", "filmmaker, anthropologist", "garden designer", "graphic artist", "illustrator", "inventor",
-//      "landscape Architect", "landscape architect", "landscape architect, photographer", "landscape designer",
-//      "lantern slide maker", "lithographer", "lyicist", "lyicrist", "lyricist", "lyricist; composer", "maker", "maker (possibly)",
-//      "maker or owner", "maker; inventor", "original artist", "performer", "performer; composer; lyricist",
-//      "performer; recording artist", "performers", "performing artist; recipient", "performing artist; user", "photgrapher",
-//      "photograher", "photographer", "photographer and copyright claimant", "photographer and/or colorist", "photographer or collector",
-//      "photographer?", "photographerl", "photographerphotographer", "photographers", "photographers?", "photographer}",
-//      "photographic firm", "photogrpaher", "playwright", "poet", "possible maker", "printer", "printmaker", "producer",
-//      "recordig artist", "recording artist", "recording artist; composer", "recordist", "recordng artist", "sculptor",
-//      "shipbuilder", "shipbuilders", "shipping firm", "weaver", "weaver or owner")
+    //    val creatorAttr = Seq("Architect", "Artist", "Artists/Makers", "Attributed to", "Author", "Cabinet Maker",
+    //      "Ceramist", "Circle of", "Co-Designer", "Creator", "Decorator", "Designer", "Draftsman", "Editor", "Embroiderer",
+    //      "Engraver", "Etcher", "Executor", "Follower of", "Graphic Designer", "Instrumentiste", "Inventor",
+    //      "Landscape Architect", "Landscape Designer", "Maker", "Model Maker/maker", "Modeler", "Painter", "Photographer",
+    //      "Possible attribution", "Possibly", "Possibly by", "Print Maker", "Printmaker", "Probably", "School of", "Sculptor",
+    //      "Studio of", "Workshop of", "Weaver", "Writer", "animator", "architect", "artist", "artist.", "artist?",
+    //      "artist attribution", "author", "author.", "author?", "authors?", "caricaturist", "cinematographer", "composer",
+    //      "composer, lyricist", "composer; lyrcist", "composer; lyricist", "composer; performer", "composer; recording artist",
+    //      "composer?", "creator", "creators", "designer", "developer", "director", "editor", "engraver", "ethnographer", "fabricator",
+    //      "filmmaker", "filmmaker, anthropologist", "garden designer", "graphic artist", "illustrator", "inventor",
+    //      "landscape Architect", "landscape architect", "landscape architect, photographer", "landscape designer",
+    //      "lantern slide maker", "lithographer", "lyicist", "lyicrist", "lyricist", "lyricist; composer", "maker", "maker (possibly)",
+    //      "maker or owner", "maker; inventor", "original artist", "performer", "performer; composer; lyricist",
+    //      "performer; recording artist", "performers", "performing artist; recipient", "performing artist; user", "photgrapher",
+    //      "photograher", "photographer", "photographer and copyright claimant", "photographer and/or colorist", "photographer or collector",
+    //      "photographer?", "photographerl", "photographerphotographer", "photographers", "photographers?", "photographer}",
+    //      "photographic firm", "photogrpaher", "playwright", "poet", "possible maker", "printer", "printmaker", "producer",
+    //      "recordig artist", "recording artist", "recording artist; composer", "recordist", "recordng artist", "sculptor",
+    //      "shipbuilder", "shipbuilders", "shipping firm", "weaver", "weaver or owner")
     (data \ "freetext" \ "name")
       .filterNot(node => filterAttribute(node, "label", "contributor"))
       .flatMap(extractStrings)
@@ -157,7 +157,7 @@ class SiMapping extends XmlMapping with XmlExtractor {
       case "" => None
       case _ => Some(str)
     }
-    
+
     val preciseGeoLocation = (data \ "indexedStructured" \ "geoLocation").map(node => {
 
       val country = (node \ "L2")
@@ -202,7 +202,7 @@ class SiMapping extends XmlMapping with XmlExtractor {
     })
 
     // return structured DPLA Place if non-empty, otherwise use freetext spatial information
-    if(preciseGeoLocation.nonEmpty)
+    if (preciseGeoLocation.nonEmpty)
       preciseGeoLocation
     else
       (data \ "freetext" \ "place")
@@ -223,11 +223,11 @@ class SiMapping extends XmlMapping with XmlExtractor {
 
     if (mediaRights.isEmpty)
       (data \ "freetext" \ "creditLine")
-         .filter(node => filterAttribute(node, "label", "credit line"))
+        .filter(node => filterAttribute(node, "label", "credit line"))
         .flatMap(extractStrings(_)) ++
-      (data \ "freetext" \ "objectRights")
-        .filter(node => filterAttribute(node, "label", "rights"))
-        .flatMap(extractStrings(_))
+        (data \ "freetext" \ "objectRights")
+          .filter(node => filterAttribute(node, "label", "rights"))
+          .flatMap(extractStrings(_))
     else
       mediaRights
   } // done
@@ -244,9 +244,9 @@ class SiMapping extends XmlMapping with XmlExtractor {
           .flatMap(node => getByAttribute(node, "label", topic))
           .flatMap(extractStrings(_))
       })
-    ).flatMap(_.splitAtDelimiter("\\\\"))
-     .flatMap(_.splitAtDelimiter(":"))
-     .map(nameOnlyConcept)
+      ).flatMap(_.splitAtDelimiter("\\\\"))
+      .flatMap(_.splitAtDelimiter(":"))
+      .map(nameOnlyConcept)
   } // done
 
   override def temporal(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] =
@@ -256,8 +256,8 @@ class SiMapping extends XmlMapping with XmlExtractor {
     (data \ "descriptiveNonRepeating" \ "title")
       .filter(node =>
         filterAttribute(node, "label", "title") ||
-        filterAttribute(node, "label", "object name") ||
-        filterAttribute(node, "label", "title (spanish)"))
+          filterAttribute(node, "label", "object name") ||
+          filterAttribute(node, "label", "title (spanish)"))
       .flatMap(node => extractStrings(node)) // done
 
   override def `type`(data: Document[NodeSeq]): ZeroToMany[String] =

--- a/src/main/scala/dpla/ingestion3/mappers/providers/TxMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/TxMapping.scala
@@ -24,7 +24,7 @@ class TxMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
   // Do not fail records that appear in more than one set
   // override val enforceDuplicateIds: Boolean = false
 
-  override def getProviderName: String = "texas"
+  override def getProviderName: Option[String] = Some("texas")
 
   override def dplaUri(data: Document[NodeSeq]): ZeroToOne[URI] = mintDplaItemUri(data)
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/TxdlMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/TxdlMapping.scala
@@ -16,7 +16,7 @@ class TxdlMapping extends XmlMapping with XmlExtractor
   // IdMinter methods
   override def useProviderName: Boolean = true
 
-  override def getProviderName: String = "txdl"
+  override def getProviderName: Option[String] = Some("txdl")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "header" \ "identifier").map(_.trim)

--- a/src/main/scala/dpla/ingestion3/mappers/providers/VirginiasMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/VirginiasMapping.scala
@@ -21,13 +21,11 @@ class VirginiasMapping extends XmlMapping with XmlExtractor with IngestMessageTe
   // ID minting functions
   override def useProviderName(): Boolean = false
 
-  // TODO: Provider name ok?
-  override def getProviderName(): String = "virginias"
+  override def getProviderName(): Option[String] = Some("virginias")
 
-  // TODO: What field in virginias records should we use for persistent ID?
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "identifier")
-  
+
   override def collection(data: Document[NodeSeq]): Seq[DcmiTypeCollection] =
     extractStrings(data \ "isPartOf")
       .map(nameOnlyCollection)

--- a/src/main/scala/dpla/ingestion3/mappers/providers/VtMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/VtMapping.scala
@@ -21,7 +21,7 @@ class VtMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
 
   override def useProviderName: Boolean = false
 
-  override def getProviderName(): String = "vt"
+  override def getProviderName: Option[String] = Some("vt")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractStrings(data \ "identifier").headOption

--- a/src/main/scala/dpla/ingestion3/mappers/providers/WiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/WiMapping.scala
@@ -23,7 +23,7 @@ class WiMapping extends XmlMapping with XmlExtractor
   // ID minting functions
   override def useProviderName: Boolean = true
 
-  override def getProviderName: String = "wisconsin"
+  override def getProviderName: Option[String] = Some("wisconsin")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "header" \ "identifier")
@@ -84,12 +84,12 @@ class WiMapping extends XmlMapping with XmlExtractor
   override def rights(data: Document[NodeSeq]): Seq[String] =
     ((data \ "metadata" \\ "rights") ++
       (data \ "metadata" \\ "accessRights")).flatMap(rights => {
-        rights.prefix match {
-          case "dc" => Some(rights.text.trim) // dc:rights
-          case "dct" => Some(rights.text.trim) // dct:accessRights
-          case _ => None
-        }
-      })
+      rights.prefix match {
+        case "dc" => Some(rights.text.trim) // dc:rights
+        case "dct" => Some(rights.text.trim) // dct:accessRights
+        case _ => None
+      }
+    })
 
   override def rightsHolder(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
     extractStrings(data \ "metadata" \\ "rightsHolder").map(nameOnlyAgent)

--- a/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
@@ -111,7 +111,7 @@ trait Mapping[T] {
     * @see buildProviderBaseId
     * @return String Provider shortname
     */
-  def getProviderName: String = ""
+  def getProviderName: Option[String] = None
 
   /**
     * Builds the ID to be hashed by either concatenating the provider's
@@ -129,11 +129,11 @@ trait Mapping[T] {
     */
   protected def buildProviderBaseId()(implicit data: Document[T]): Option[String] = {
 
-    originalId match {
-      case Some(id) =>
-        if (useProviderName) Some(s"$getProviderName--$id")
-        else Some(id)
-      case None => None
+    (originalId, useProviderName, getProviderName) match {
+      case (Some(id), true, Some(providerName)) => Some(s"$providerName--$id")
+      case (Some(id), false, _) => Some(id)
+      case (_, true, None) => None
+      case (_, _, _) => None
     }
   }
 

--- a/src/test/scala/dpla/ingestion3/mappers/providers/CtMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/CtMappingTest.scala
@@ -16,7 +16,7 @@ class CtMappingTest extends FlatSpec with BeforeAndAfter {
   val extractor = new CtMapping
 
   it should "not use the provider shortname in minting IDs " in
-    assert(!extractor.useProviderName())
+    assert(!extractor.useProviderName)
 
   it should "extract the correct original ID" in {
     val expected = Some("http://hdl.handle.net/11134/20002:1323")

--- a/src/test/scala/dpla/ingestion3/mappers/providers/FlMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/FlMappingTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec}
 
 class FlMappingTest extends FlatSpec with BeforeAndAfter {
 
-  val shortName = "florida"
+  val shortName = Some("florida")
   val jsonString: String = new FlatFileIO().readFileAsString("/fl.json")
   val json: Document[JValue] = Document(parse(jsonString))
   val extractor = new FlMapping
@@ -21,7 +21,7 @@ class FlMappingTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "return the correct provider name" in {
-    assert(extractor.getProviderName === "florida")
+    assert(extractor.getProviderName === shortName)
   }
 
   it should "extract the correct original ID" in {

--- a/src/test/scala/dpla/ingestion3/mappers/providers/HarvardMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/HarvardMappingTest.scala
@@ -14,7 +14,7 @@ class HarvardMappingTest extends FlatSpec with BeforeAndAfter {
   val mapping = new HarvardMapping
 
   "A Harvard mapping" should "have the correct provider name" in {
-    assert(mapping.getProviderName === "harvard")
+    assert(mapping.getProviderName === Some("harvard"))
   }
 
   it should "extract the correct alternative title from MARC-derived records" in {

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MdlMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MdlMappingTest.scala
@@ -10,18 +10,16 @@ import org.scalatest.{BeforeAndAfter, FlatSpec}
 
 class MdlMappingTest extends FlatSpec with BeforeAndAfter {
 
-  val shortName = "mdl"
   val jsonString: String = new FlatFileIO().readFileAsString("/mdl.json")
   val json: Document[JValue] = Document(parse(jsonString))
   val extractor = new MdlMapping
-
 
   it should "use the provider short name when minting DPLA ids" in {
     assert(extractor.useProviderName === true)
   }
 
   it should "return the correct provider name" in {
-    assert(extractor.getProviderName === "minnesota")
+    assert(extractor.getProviderName === Some("minnesota"))
   }
 
   it should "extract the correct original ID" in {
@@ -126,7 +124,8 @@ class MdlMappingTest extends FlatSpec with BeforeAndAfter {
   }
   // rights
   it should "extract the correct rights" in {
-    val jsonString = """
+    val jsonString =
+      """
       {
         "attributes": {
           "metadata": {
@@ -142,7 +141,8 @@ class MdlMappingTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "not map non-rs or non-cc host domains to edmRights" in {
-    val jsonString = """
+    val jsonString =
+      """
       {
         "attributes": {
           "metadata": {
@@ -159,7 +159,8 @@ class MdlMappingTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "not map non-URIs to edmRights" in {
-    val jsonString = """
+    val jsonString =
+      """
       {
         "attributes": {
           "metadata": {
@@ -175,7 +176,8 @@ class MdlMappingTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "work when rights is empty string" in {
-    val jsonString = """
+    val jsonString =
+      """
       {
         "attributes": {
           "metadata": {
@@ -191,7 +193,8 @@ class MdlMappingTest extends FlatSpec with BeforeAndAfter {
   }
 
   it should "work when rights not provided" in {
-    val jsonString = """
+    val jsonString =
+      """
       {
         "attributes": {
           "metadata": {
@@ -207,7 +210,8 @@ class MdlMappingTest extends FlatSpec with BeforeAndAfter {
 
   // rights
   it should "map to dcRights but not edmRights when rights value contains both text and uri" in {
-    val jsonString = """
+    val jsonString =
+      """
       {
         "attributes": {
           "metadata": {

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MissouriMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MissouriMappingTest.scala
@@ -10,18 +10,17 @@ import org.scalatest.{BeforeAndAfter, FlatSpec}
 
 class MissouriMappingTest extends FlatSpec with BeforeAndAfter {
 
-  val shortName = "missouri"
+  val shortName = Some("missouri")
   val jsonString: String = new FlatFileIO().readFileAsString("/mo.json")
   val json: Document[JValue] = Document(parse(jsonString))
   val extractor = new MissouriMapping
-
 
   it should "use the provider short name when minting DPLA ids" in {
     assert(extractor.useProviderName === false)
   }
 
   it should "return the correct provider name" in {
-    assert(extractor.getProviderName === "missouri")
+    assert(extractor.getProviderName === shortName)
   }
 
   it should "extract the correct original ID" in {

--- a/src/test/scala/dpla/ingestion3/mappers/providers/NYPLMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/NYPLMappingTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec}
 class NYPLMappingTest extends FlatSpec with BeforeAndAfter {
 
   implicit val msgCollector: MessageCollector[IngestMessage] = new MessageCollector[IngestMessage]
-  val shortName = "nypl"
+  val shortName = Some("nypl")
   val jsonString: String = new FlatFileIO().readFileAsString("/nypl.json")
   val json: Document[JValue] = Document(parse(jsonString))
   val extractor = new NyplMapping(json)
@@ -19,6 +19,18 @@ class NYPLMappingTest extends FlatSpec with BeforeAndAfter {
   it should "extract the correct original ID " in {
     val expected = Some("93cd9a10-c552-012f-20e8-58d385a7bc34")
     assert(extractor.originalId(json) === expected)
+  }
+
+  it should "mint the correct DPLA URI" in {
+    assert(extractor.dplaUri(json) === Some(URI("http://dp.la/api/items/9412682033a0b7a5926b584e7756019c")))
+  }
+
+  it should "use provider prefix" in {
+    assert(extractor.useProviderName === true)
+  }
+
+  it should "use the correct provider prefix" in {
+    assert(extractor.getProviderName === shortName)
   }
 
   it should "extract the correct title " in {

--- a/src/test/scala/dpla/ingestion3/mappers/providers/NaraMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/NaraMappingTest.scala
@@ -12,17 +12,17 @@ import scala.xml.{NodeSeq, XML}
 class NaraMappingTest extends FlatSpec with BeforeAndAfter {
 
   implicit val msgCollector: MessageCollector[IngestMessage] = new MessageCollector[IngestMessage]
-  val shortName = "nara"
+  val shortName = Some("nara")
   val xmlString: String = new FlatFileIO().readFileAsString("/nara.xml")
   val xml: Document[NodeSeq] = Document(XML.loadString(xmlString))
   val itemUri = new URI("http://catalog.archives.gov/id/2132862")
   val extractor = new NaraMapping
 
   it should "use the provider shortname in minting IDs" in
-    assert(extractor.useProviderName())
+    assert(extractor.useProviderName)
 
   it should "pass through the short name to ID minting" in
-    assert(extractor.getProviderName() === shortName)
+    assert(extractor.getProviderName === shortName)
 
   it should "extract original ID" in {
     assert(extractor.originalId(xml) === Some("2132862"))

--- a/src/test/scala/dpla/ingestion3/mappers/providers/P2PMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/P2PMappingTest.scala
@@ -14,7 +14,7 @@ class P2PMappingTest extends FlatSpec with BeforeAndAfter {
   val mapping = new P2PMapping
 
   "A P2PMapping" should "have the correct provider name" in {
-    assert(mapping.getProviderName === "p2p")
+    assert(mapping.getProviderName === Some("p2p"))
   }
 
   it should "get the correct original ID" in {


### PR DESCRIPTION
Fixup NYPL provider name (New York Public Library -> The New York Public Library)
Fixup NYPL ID minting (empty provider name bug)

Fix bug that allows for empty string provider name to be used when minting DPLA ID
Refactor mappings and mapping tests
Linting