### PR TITLE
Fix/non printable characters

### DIFF
--- a/src/main/scala/dpla/ingestion3/enrichments/normalizations/StringNormalizationUtils.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/normalizations/StringNormalizationUtils.scala
@@ -238,7 +238,7 @@ object StringNormalizationUtils {
       */
     lazy val stripEndingPeriod: SingleStringEnrichment = {
       if (value.matches(""".*?[^\.]\.[\n\r\s]*$"""))
-        value.replaceAll("""\.[\n\r\s]*$""", "")
+        value.replaceAll("""\.[\n\r\s\h\v]*$""", "")
       else
         value
     }

--- a/src/main/scala/dpla/ingestion3/enrichments/normalizations/StringNormalizationUtils.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/normalizations/StringNormalizationUtils.scala
@@ -164,8 +164,12 @@ object StringNormalizationUtils {
     /**
       * Reduce multiple whitespace values to a single and removes
       * leading and trailing white space
+      *
+      * https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
+      *   \h 	A horizontal whitespace character: [ \t\xA0\u1680\u180e\u2000-\u200a\u202f\u205f\u3000]
+      *   \v 	A vertical whitespace character: [\n\x0B\f\r\x85\u2028\u2029]
       */
-    lazy val reduceWhitespace: SingleStringEnrichment = value.replaceAll(" +", " ").trim
+    lazy val reduceWhitespace: SingleStringEnrichment = value.replaceAll("[\\h\\v]+", " ").trim
 
     lazy val cleanupGeocoordinates: SingleStringEnrichment =
       value.splitAtDelimiter(",") match {

--- a/src/test/scala/dpla/ingestion3/enrichments/StringNormalizationUtilsTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/StringNormalizationUtilsTest.scala
@@ -240,6 +240,13 @@ class StringNormalizationUtilsTest extends FlatSpec with BeforeAndAfter {
     assert(enrichedValue === "foo bar choo")
   }
 
+  it should "reduce leading and trailing non printable horizontal and vertical whitespace characters" in {
+    val originalValue = "\u2028foo choo\u00a0\u2028 "
+    val enrichedValue = originalValue.reduceWhitespace
+    assert(enrichedValue === "foo choo")
+  }
+
+
 
 
   "capitalizeFirstChar" should "not capitalize the b in '3 blind mice'" in {

--- a/src/test/scala/dpla/ingestion3/enrichments/StringNormalizationUtilsTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/StringNormalizationUtilsTest.scala
@@ -156,6 +156,15 @@ class StringNormalizationUtilsTest extends FlatSpec with BeforeAndAfter {
     val expectedValue = ".. It's OK.."
     assert(enrichedValue === expectedValue)
   }
+
+  it should "remove whitespace and \n " in {
+    val originalValue = "\n    President George W. Bush and Mrs. Laura Bush Stand with President Nicolas Sarkozy of France on the North Portico of the White House After His Arrival for Dinner \n  "
+    val enrichedValue = originalValue.cleanupEndingPunctuation
+    val expectedValue = "\n    President George W. Bush and Mrs. Laura Bush Stand with President Nicolas Sarkozy of France on the North Portico of the White House After His Arrival for Dinner"
+    assert(enrichedValue === expectedValue)
+  }
+
+
   it should "not remove .) from Synagogues -- Washington (D.C.)" in {
     val originalValue = "Synagogues -- Washington (D.C.)"
     val enrichedValue = originalValue.cleanupEndingPunctuation
@@ -218,6 +227,20 @@ class StringNormalizationUtilsTest extends FlatSpec with BeforeAndAfter {
     val enrichedValue = originalValue.reduceWhitespace
     assert(enrichedValue === "foo bar choo")
   }
+
+  it should "reduce non printable characters" in {
+    val originalValue = "   foo bar\u00a0 choo "
+    val enrichedValue = originalValue.reduceWhitespace
+    assert(enrichedValue === "foo bar choo")
+  }
+
+  it should "reduce non printable vertical whitespace characters" in {
+    val originalValue = " \u2028foo \u2028  bar\u00a0\u2028 choo "
+    val enrichedValue = originalValue.reduceWhitespace
+    assert(enrichedValue === "foo bar choo")
+  }
+
+
 
   "capitalizeFirstChar" should "not capitalize the b in '3 blind mice'" in {
     val originalValue = "3 blind mice"
@@ -374,4 +397,5 @@ class StringNormalizationUtilsTest extends FlatSpec with BeforeAndAfter {
     val originalValue = """ "Hello John" """
     assert(originalValue.stripDblQuotes == " Hello John ")
   }
+
 }

--- a/src/test/scala/dpla/ingestion3/enrichments/StringNormalizationsTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/StringNormalizationsTest.scala
@@ -42,4 +42,21 @@ class StringNormalizationsTest extends FlatSpec with BeforeAndAfter {
 
     assert(enrichedRecord === expectedRecord)
   }
+
+  it should " remove trailing whitespace from edmAgent.name" in {
+    val agent = Seq("Indiana Harbor Belt Railroad Company ").map(nameOnlyAgent)
+    val expectedAgent = Seq("Indiana Harbor Belt Railroad Company").map(nameOnlyAgent)
+
+    val mappedRecord = MappedRecordsFixture.mappedRecord.copy(
+      sourceResource = DplaSourceResource(creator = agent)
+    )
+
+    val expectedRecord= MappedRecordsFixture.mappedRecord.copy(
+      sourceResource = DplaSourceResource(creator = expectedAgent)
+    )
+
+    val enrichedRecord = stringEnrichments.enrich(mappedRecord)
+
+    assert(enrichedRecord === expectedRecord)
+  }
 }


### PR DESCRIPTION
Strips horizontal and vertical whitespace (non-printing) characters

```
https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
  \h 	A horizontal whitespace character: [ \t\xA0\u1680\u180e\u2000-\u200a\u202f\u205f\u3000]
  \v 	A vertical whitespace character: [\n\x0B\f\r\x85\u2028\u2029]
```