### PR TITLE
Using provider name requires defining provider name

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/RumseyMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/RumseyMapping.scala
@@ -18,6 +18,8 @@ class RumseyMapping extends XmlMapping with XmlExtractor
   // IdMinter methods
   override def useProviderName: Boolean = true
 
+  override def getProviderName: Option[String] = Some("david_rumsey")
+
   // FYI - David Rumsey IDs will/have changed in i3. Ingestion1 used first absolute URI in dc:identifier property
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "header" \ "identifier").map(_.trim)


### PR DESCRIPTION
Disarming the footgun by pulling the trigger until empty