### PR TITLE
dataProvider to object w/URIs and provider.exactMatch 

### DIFF
--- a/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
@@ -49,7 +49,7 @@ class EnrichmentDriver(conf: i3Conf) extends Serializable {
   }
 
   def enrichDataProvider(record: OreAggregation): EdmAgent = {
-    val enrichedWithWikiEntity = wikiEntityEnrichment.enrichEntity(record.dataProvider, Option(record.provider))
+    val enrichedWithWikiEntity: EdmAgent = wikiEntityEnrichment.enrichEntity(record.dataProvider, Option(record.provider))
     val uri = createDataProviderUri(record.dataProvider.name)
     enrichedWithWikiEntity.copy(uri = uri)
   }
@@ -74,6 +74,7 @@ class EnrichmentDriver(conf: i3Conf) extends Serializable {
       provider = wikiEntityEnrichment.enrichEntity(enriched.provider),
 
       dataProvider = enrichDataProvider(enriched),
+
       sourceResource = enriched.sourceResource.copy(
         date = enriched.sourceResource.date.map(date => dateEnrichment.generateBeginEnd(date.originalSourceDate)).distinct,
         language = enriched.sourceResource.language.map(languageEnrichment.enrichLanguage).distinct,

--- a/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
@@ -4,6 +4,7 @@ import dpla.ingestion3.confs.i3Conf
 import dpla.ingestion3.enrichments.date.DateBuilder
 import dpla.ingestion3.model._
 import dpla.ingestion3.enrichments.normalizations.StandardNormalizations._
+import dpla.ingestion3.model.DplaMapData.ZeroToOne
 
 import scala.util.Try
 
@@ -26,6 +27,33 @@ class EnrichmentDriver(conf: i3Conf) extends Serializable {
   val typeEnrichment= new TypeEnrichment
   val wikiEntityEnrichment = new WikiEntityEnrichment
 
+  lazy private val dplaContributorUri = "http://dp.la/api/contributor/"
+
+  /**
+    * Create a DPLA URI for each dataProvider
+    *
+    * Lowercase label, strip excessive whitespace, remove non-alphanumeric characters
+    *
+    * @param name Label of dataProvider
+    * @return
+    */
+  def createDataProviderUri(name: ZeroToOne[String]): ZeroToOne[URI] = name match {
+    case Some(dataProvider) =>
+      val providerLabel = dataProvider
+        .toLowerCase // lowercase
+        .trim // remove leading and trailing whitespace
+        .replaceAll("( )+", "-") // replace 1-n whitespace with single -
+        .replaceAll("[^a-z0-9s-]", "") // remove non-alphanumeric chars
+      Some(URI(s"$dplaContributorUri$providerLabel"))
+    case None => throw new RuntimeException("Missing required field Data Provider name when minting URI")
+  }
+
+  def enrichDataProvider(record: OreAggregation): EdmAgent = {
+    val enrichedWithWikiEntity = wikiEntityEnrichment.enrichEntity(record.dataProvider, Option(record.provider))
+    val uri = createDataProviderUri(record.dataProvider.name)
+    enrichedWithWikiEntity.copy(uri = uri)
+  }
+
   /**
     * Applies a set of common enrichments that need to be run for all providers
     *   * Spatial
@@ -44,7 +72,8 @@ class EnrichmentDriver(conf: i3Conf) extends Serializable {
 
     enriched.copy(
       provider = wikiEntityEnrichment.enrichEntity(enriched.provider),
-      dataProvider = wikiEntityEnrichment.enrichEntity(enriched.dataProvider, Option(enriched.provider)),
+
+      dataProvider = enrichDataProvider(enriched),
       sourceResource = enriched.sourceResource.copy(
         date = enriched.sourceResource.date.map(date => dateEnrichment.generateBeginEnd(date.originalSourceDate)).distinct,
         language = enriched.sourceResource.language.map(languageEnrichment.enrichLanguage).distinct,

--- a/src/main/scala/dpla/ingestion3/enrichments/WikiEntityEnrichment.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/WikiEntityEnrichment.scala
@@ -12,7 +12,7 @@ import scala.io.Source
   */
 class WikiEntityEnrichment extends FileLoader with VocabEnrichment[EdmAgent] with JsonExtractor  {
 
-  protected val wikiUriBase = "https://wikidata.org/wiki/"
+  protected val wikiUriBase = "http://www.wikidata.org/entity/"
 
   // Files to source vocabulary from
   private val fileList = Seq(

--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -128,7 +128,10 @@ package object model {
         ("@context" -> "http://dp.la/api/items/context") ~
         ("@id" -> record.dplaUri.toString) ~
         ("aggregatedCHO" -> "#sourceResource") ~
-        ("dataProvider" -> record.dataProvider.name) ~
+        ("dataProvider" ->
+          ("@id" -> record.dataProvider.uri.getOrElse(throw new RuntimeException("Invalid dataProvider URI")).toString) ~
+          ("name" -> record.dataProvider.name) ~
+          ("exactMatch" -> record.dataProvider.exactMatch.map(_.toString))) ~
         ("iiifManifest" -> record.iiifManifest.map(i => i.toString)) ~ // IIIF Manifest URI
         ("ingestDate" -> ingestDate) ~
         ("ingestType" -> "item") ~

--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -145,11 +145,9 @@ package object model {
                                                         // expects JSON and all ORs in ingest1 were converted to JSON
                                                         // TODO We need to prettify this so the OR is readable in CQA
         ("provider" ->
-          ("@id" -> record.provider.uri
-                      .getOrElse(
-                        throw new RuntimeException("Invalid Provider URI")
-                      ).toString) ~
+          ("@id" -> record.provider.uri.getOrElse(throw new RuntimeException("Invalid Provider URI")).toString) ~
           ("name" -> record.provider.name)) ~
+          ("exactMatch" -> record.provider.exactMatch.map(_.toString))) ~
         ("sourceResource" ->
           ("@id" ->
             (record.dplaUri.toString + "#SourceResource")) ~

--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -146,7 +146,7 @@ package object model {
                                                         // TODO We need to prettify this so the OR is readable in CQA
         ("provider" ->
           ("@id" -> record.provider.uri.getOrElse(throw new RuntimeException("Invalid Provider URI")).toString) ~
-          ("name" -> record.provider.name)) ~
+          ("name" -> record.provider.name) ~
           ("exactMatch" -> record.provider.exactMatch.map(_.toString))) ~
         ("sourceResource" ->
           ("@id" ->

--- a/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
+++ b/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
@@ -55,6 +55,7 @@ object EnrichedRecordFixture {
     OreAggregation(
       dataProvider = EdmAgent(
         name = Some("The Data Provider"),
+        uri = Some(URI("http://dp.la/api/contributor/the-data-provider")),
         exactMatch = Seq(URI("Q83878447"))
       ),
       dplaUri = new URI("https://dp.la/item/123"),
@@ -145,7 +146,8 @@ object EnrichedRecordFixture {
         `type` = Seq("image", "text")
       ),
       dataProvider = EdmAgent(
-        name = Some("The Data Provider")
+        name = Some("The Data Provider"),
+        uri = Some(URI("http://dp.la/api/contributor/the-data-provider"))
       ),
       dplaUri = new URI("https://dp.la/item/123"),
       isShownAt = EdmWebResource(uri = new URI("https://example.org/record/123")),

--- a/src/test/scala/dpla/ingestion3/enrichments/WikiEntityEnrichmentTest.scala
+++ b/src/test/scala/dpla/ingestion3/enrichments/WikiEntityEnrichmentTest.scala
@@ -13,7 +13,7 @@ class WikiEntityEnrichmentTest extends FlatSpec with BeforeAndAfter {
     val qualifierValue = Option(nameOnlyAgent("PA Digital"))
     val expectedValue = EdmAgent(
       name = Some("University of Pennsylvania"),
-      exactMatch = Seq(URI("https://wikidata.org/wiki/Q49117"))
+      exactMatch = Seq(URI("http://www.wikidata.org/entity/Q49117"))
     )
      assert(wikiEnrichment.enrichEntity(originalValue, qualifierValue) === expectedValue)
   }
@@ -23,7 +23,7 @@ class WikiEntityEnrichmentTest extends FlatSpec with BeforeAndAfter {
     val qualifierValue = nameOnlyAgent("PA Digital")
     val expectedValue = EdmAgent(
       name = Some("university of Pennsylvania"),
-      exactMatch = Seq(URI("https://wikidata.org/wiki/Q49117"))
+      exactMatch = Seq(URI("http://www.wikidata.org/entity/Q49117"))
     )
      assert(wikiEnrichment.enrichEntity(originalValue, Option(qualifierValue)) === expectedValue)
   }
@@ -35,7 +35,7 @@ class WikiEntityEnrichmentTest extends FlatSpec with BeforeAndAfter {
     )
     val expectedValue = EdmAgent(
       name = Some("PA Digital"),
-      exactMatch = Seq(URI("https://wikidata.org/wiki/Q83878501")),
+      exactMatch = Seq(URI("http://www.wikidata.org/entity/Q83878501")),
       uri = Some(URI("http://dp.la/api/contributor/pa"))
     )
     assert(wikiEnrichment.enrichEntity(originalValue) === expectedValue)
@@ -45,7 +45,7 @@ class WikiEntityEnrichmentTest extends FlatSpec with BeforeAndAfter {
     val originalValue = nameOnlyAgent("pa digital")
     val expectedValue = EdmAgent(
       name = Some("pa digital"),
-      exactMatch = Seq(URI("https://wikidata.org/wiki/Q83878501"))
+      exactMatch = Seq(URI("http://www.wikidata.org/entity/Q83878501"))
     )
     assert(wikiEnrichment.enrichEntity(originalValue) === expectedValue)
   }


### PR DESCRIPTION
Creates a DPLA contributor URI for dataProvider
Enriches dataProvider with Wikidata URIs [mapped to EdmAgent.exactMatch]

dataProvider is now an object and not a string in JSONL/ES index 
* name
* @id 
* exactMatch

provider now includes exactMatch property 

Associated tests with those changes. 