### PR TITLE
DplaMapData serialization changes

### DIFF
--- a/src/main/scala/dpla/ingestion3/enrichments/normalizations/StringNormalizations.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/normalizations/StringNormalizations.scala
@@ -1,7 +1,6 @@
 package dpla.ingestion3.enrichments.normalizations
 
 import dpla.ingestion3.enrichments.normalizations.StringNormalizationUtils._
-import dpla.ingestion3.model.DplaMapData.LiteralOrUri
 import dpla.ingestion3.model._
 
 /**
@@ -138,8 +137,8 @@ class StringNormalizations {
     )
 
   def enrichRelation(relation: LiteralOrUri): LiteralOrUri = {
-    if (relation.isInstanceOf[String])
-      relation.toString.stripHTML.reduceWhitespace.asInstanceOf[LiteralOrUri]
+    if (!relation.isUri)
+      LiteralOrUri(relation.value.stripHTML.reduceWhitespace, isUri = false)
     else
       relation
   }

--- a/src/main/scala/dpla/ingestion3/entries/reports/PreMappingReporterMain.scala
+++ b/src/main/scala/dpla/ingestion3/entries/reports/PreMappingReporterMain.scala
@@ -1,6 +1,6 @@
 package dpla.ingestion3.entries.reports
 
-import dpla.ingestion3.premappingreports._
+import dpla.ingestion3.preMappingReports.PreMappingReporter
 import org.apache.log4j.{LogManager, Logger}
 
 import scala.util.Failure

--- a/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
@@ -428,7 +428,7 @@ class XmlMapper extends Mapper[NodeSeq, XmlMapping] {
         originalRecord = formatXml(document.get),
         preview = validatedPreview, // thumbnail
         provider = mapping.provider(document),
-        sidecar = mapping.sidecar(document),
+        sidecar = toJsonString(mapping.sidecar(document)),
         tags = mapping.tags(document),
         iiifManifest = validatedIIIFManifest,
         mediaMaster = mapping.mediaMaster(document),
@@ -522,7 +522,7 @@ class JsonMapper extends Mapper[JValue, JsonMapping] {
         originalRecord = formatJson(document.get),
         preview = validatedPreview, // thumbnail
         provider = mapping.provider(document),
-        sidecar = mapping.sidecar(document),
+        sidecar = toJsonString(mapping.sidecar(document)),
         tags = mapping.tags(document),
         iiifManifest = validatedIIIFManifest,
         mediaMaster = mapping.mediaMaster(document),

--- a/src/main/scala/dpla/ingestion3/mappers/providers/HarvardMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/HarvardMapping.scala
@@ -148,7 +148,7 @@ class HarvardMapping extends XmlMapping with XmlExtractor with IngestMessageTemp
       if relatedItem \@ "type" == "series"
       relation <- relatedItem \ "titleInfo"
       title <- processTitleInfo(relation)
-    } yield Left(title)
+    } yield LiteralOrUri(title, isUri = false)
 
 
   override def rights(data: Document[NodeSeq]): AtLeastOne[String] =

--- a/src/main/scala/dpla/ingestion3/mappers/providers/NaraMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/NaraMapping.scala
@@ -218,7 +218,7 @@ class NaraMapping extends XmlMapping with XmlExtractor {
     extractPublisher(data).map(nameOnlyAgent)
 
   override def relation(data: Document[NodeSeq]): ZeroToMany[LiteralOrUri] =
-    extractRelation(data).map(Left(_))
+    extractRelation(data).map(LiteralOrUri(_, isUri = false))
 
   override def rights(data: Document[NodeSeq]): AtLeastOne[String] =
     extractRights(data)

--- a/src/main/scala/dpla/ingestion3/mappers/providers/OhioMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/OhioMapping.scala
@@ -4,7 +4,7 @@ import dpla.ingestion3.enrichments.normalizations.StringNormalizationUtils._
 import dpla.ingestion3.enrichments.normalizations.filters.{DigitalSurrogateBlockList, ExtentIdentificationList, FormatTypeValuesBlockList}
 import dpla.ingestion3.mappers.utils.{Document, XmlMapping, XmlExtractor}
 import dpla.ingestion3.messages.IngestMessageTemplates
-import dpla.ingestion3.model.DplaMapData.{ExactlyOne, LiteralOrUri, ZeroToMany, ZeroToOne}
+import dpla.ingestion3.model.DplaMapData.{ExactlyOne, ZeroToMany, ZeroToOne}
 import dpla.ingestion3.model._
 import dpla.ingestion3.utils.Utils
 import org.json4s.JValue

--- a/src/main/scala/dpla/ingestion3/mappers/providers/P2PMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/P2PMapping.scala
@@ -167,7 +167,7 @@ class P2PMapping extends XmlMapping with XmlExtractor with IngestMessageTemplate
       relatedItem <- data \ "metadata" \ "mods" \ "relatedItem"
       if relatedItem \@ "type" == "series"
       relation <- relatedItem \ "titleInfo" \ "title"
-    } yield Left(relation.text.trim)
+    } yield LiteralOrUri(relation.text.trim, isUri = false)
 
   override def collection(data: Document[NodeSeq]): ZeroToMany[DcmiTypeCollection] =
     for {

--- a/src/main/scala/dpla/ingestion3/mappers/providers/PaMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/PaMapping.scala
@@ -2,7 +2,7 @@ package dpla.ingestion3.mappers.providers
 
 import dpla.ingestion3.mappers.utils.{Document, XmlExtractor, XmlMapping}
 import dpla.ingestion3.messages.IngestMessageTemplates
-import dpla.ingestion3.model.DplaMapData.{ExactlyOne, LiteralOrUri, ZeroToMany, ZeroToOne}
+import dpla.ingestion3.model.DplaMapData.{ExactlyOne, ZeroToMany, ZeroToOne}
 import dpla.ingestion3.model._
 import dpla.ingestion3.utils.Utils
 import org.json4s.JValue

--- a/src/main/scala/dpla/ingestion3/mappers/providers/RumseyMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/RumseyMapping.scala
@@ -3,7 +3,7 @@ package dpla.ingestion3.mappers.providers
 import dpla.ingestion3.enrichments.normalizations.StringNormalizationUtils._
 import dpla.ingestion3.mappers.utils.{Document, XmlExtractor, XmlMapping}
 import dpla.ingestion3.messages.IngestMessageTemplates
-import dpla.ingestion3.model.DplaMapData.{ExactlyOne, LiteralOrUri, ZeroToMany, ZeroToOne}
+import dpla.ingestion3.model.DplaMapData.{ExactlyOne, ZeroToMany, ZeroToOne}
 import dpla.ingestion3.model._
 import dpla.ingestion3.utils.Utils
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/TxMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/TxMapping.scala
@@ -215,7 +215,7 @@ class TxMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
       .flatMap(node => {
         val name = extractStrings(node \ "name")
         val propertyValue = node.child match {
-          case _: ArrayBuffer[String] => Seq(node.text)
+          case _: ArrayBuffer[_] => Seq(node.text)
           case _ => Seq()
         }
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/WiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/WiMapping.scala
@@ -4,7 +4,7 @@ import dpla.ingestion3.enrichments.normalizations.StringNormalizationUtils._
 import dpla.ingestion3.enrichments.normalizations.filters.{DigitalSurrogateBlockList, ExtentIdentificationList}
 import dpla.ingestion3.mappers.utils.{Document, XmlMapping, XmlExtractor}
 import dpla.ingestion3.messages.IngestMessageTemplates
-import dpla.ingestion3.model.DplaMapData.{ExactlyOne, LiteralOrUri, ZeroToMany, ZeroToOne}
+import dpla.ingestion3.model.DplaMapData.{ExactlyOne, ZeroToMany, ZeroToOne}
 import dpla.ingestion3.model._
 import dpla.ingestion3.utils.Utils
 import org.json4s.JValue

--- a/src/main/scala/dpla/ingestion3/model/DplaMapData.scala
+++ b/src/main/scala/dpla/ingestion3/model/DplaMapData.scala
@@ -17,7 +17,11 @@ object DplaMapData {
   type AtLeastOne[T] = Seq[T]
   type ZeroToOne[T] = Option[T]
   type ExactlyOne[T] = T
-  type LiteralOrUri = Either[String, URI]
+}
+
+case class LiteralOrUri(value: String, isUri: Boolean) {
+  def asUri: Option[URI] =
+    if (isUri) Some(URI(value)) else None
 }
 
 //Core Classes
@@ -39,7 +43,7 @@ case class OreAggregation(
                            preview: ZeroToOne[EdmWebResource] = None, // thumbnail
                            provider: ExactlyOne[EdmAgent],
                            edmRights: ZeroToOne[URI] = None,
-                           sidecar: JValue = JNothing,
+                           sidecar: String = "",
                            messages: ZeroToMany[IngestMessage] = Seq[IngestMessage](),
                            originalId: ExactlyOne[String],
                            tags: ZeroToMany[URI] = Seq[URI](),

--- a/src/main/scala/dpla/ingestion3/model/ModelConverter.scala
+++ b/src/main/scala/dpla/ingestion3/model/ModelConverter.scala
@@ -1,7 +1,6 @@
 package dpla.ingestion3.model
 
 import dpla.ingestion3.messages.IngestMessage
-import dpla.ingestion3.model.DplaMapData.LiteralOrUri
 import org.apache.spark.sql.Row
 import org.json4s.JsonAST.{JNothing, JValue}
 import org.json4s.jackson.JsonMethods.parse
@@ -31,7 +30,7 @@ object ModelConverter {
     preview = toOptionEdmWebResource(row.getStruct(8)),
     provider = toEdmAgent(row.getStruct(9)),
     edmRights = optionalUri(row, 10),
-    sidecar = optionalJValue(row, 11),
+    sidecar = row.getString(11),
     messages = toMulti(row, 12, toIngestMessage),
     originalId = potentiallyMissingStringField(row, 13).getOrElse("MISSING"),
     tags = potentiallyMissingArrayOfUrisField(row, 14), // FIXME with potentiallyMissing[T]
@@ -110,8 +109,8 @@ object ModelConverter {
   )
 
   private[model] def toLiteralOrUri(row: Row): LiteralOrUri =
-    if (row.getBoolean(1)) Right(URI(row.getString(0)))
-    else Left(row.getString(0))
+    if (row.getBoolean(1)) LiteralOrUri(row.getString(0), isUri = true)
+    else LiteralOrUri(row.getString(0), isUri = false)
 
   private[model] def toEdmAgent(row: Row): EdmAgent = EdmAgent(
     uri = optionalUri(row, 0),

--- a/src/main/scala/dpla/ingestion3/model/RowConverter.scala
+++ b/src/main/scala/dpla/ingestion3/model/RowConverter.scala
@@ -1,7 +1,6 @@
 package dpla.ingestion3.model
 
 import dpla.ingestion3.messages.IngestMessage
-import dpla.ingestion3.model.DplaMapData.LiteralOrUri
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.types.StructType
@@ -33,7 +32,7 @@ object RowConverter {
         oreAggregation.preview.map(fromEdmWebResource).orNull, //8
         fromEdmAgent(oreAggregation.provider), //9
         oreAggregation.edmRights.map(_.toString).orNull, //10
-        compact(render(oreAggregation.sidecar)), //11
+        oreAggregation.sidecar, //11
         oreAggregation.messages.map(fromIngestMessage), //12
         oreAggregation.originalId, //13
         oreAggregation.tags.map(_.toString), //14
@@ -97,8 +96,8 @@ object RowConverter {
   )
 
   private[model] def fromLiteralOrUri(literalOrUri: LiteralOrUri): Row = Row(
-    literalOrUri.merge.toString, //both types turn into strings with toString
-    literalOrUri.isRight //right is URI, isRight is true when it's a uri
+    literalOrUri.value, //both types turn into strings with toString
+    literalOrUri.isUri //right is URI, isRight is true when it's a uri
   )
 
   private[model] def fromDplaPlace(dplaPlace: DplaPlace): Row = Row(

--- a/src/main/scala/dpla/ingestion3/preMappingReports/JsonShredder.scala
+++ b/src/main/scala/dpla/ingestion3/preMappingReports/JsonShredder.scala
@@ -1,4 +1,4 @@
-package dpla.ingestion3.premappingreports
+package dpla.ingestion3.preMappingReports
 
 import scala.annotation.tailrec
 import org.json4s.JValue

--- a/src/main/scala/dpla/ingestion3/preMappingReports/PreMappingReport.scala
+++ b/src/main/scala/dpla/ingestion3/preMappingReports/PreMappingReport.scala
@@ -1,4 +1,4 @@
-package dpla.ingestion3.premappingreports
+package dpla.ingestion3.preMappingReports
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.functions._

--- a/src/main/scala/dpla/ingestion3/preMappingReports/PreMappingReporter.scala
+++ b/src/main/scala/dpla/ingestion3/preMappingReports/PreMappingReporter.scala
@@ -1,4 +1,4 @@
-package dpla.ingestion3.premappingreports
+package dpla.ingestion3.preMappingReports
 
 import java.io.File
 

--- a/src/main/scala/dpla/ingestion3/preMappingReports/Shred.scala
+++ b/src/main/scala/dpla/ingestion3/preMappingReports/Shred.scala
@@ -1,4 +1,4 @@
-package dpla.ingestion3.premappingreports
+package dpla.ingestion3.preMappingReports
 
 import org.json4s._
 

--- a/src/main/scala/dpla/ingestion3/preMappingReports/Shredder.scala
+++ b/src/main/scala/dpla/ingestion3/preMappingReports/Shredder.scala
@@ -1,4 +1,4 @@
-package dpla.ingestion3.premappingreports
+package dpla.ingestion3.preMappingReports
 
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions._

--- a/src/main/scala/dpla/ingestion3/preMappingReports/XmlShredder.scala
+++ b/src/main/scala/dpla/ingestion3/preMappingReports/XmlShredder.scala
@@ -1,7 +1,7 @@
-package dpla.ingestion3.premappingreports
+package dpla.ingestion3.preMappingReports
 
 import scala.annotation.tailrec
-import scala.util.{Try, Failure, Success}
+import scala.util.{Failure, Success, Try}
 import scala.xml._
 
 /**

--- a/src/main/scala/dpla/ingestion3/reports/Report.scala
+++ b/src/main/scala/dpla/ingestion3/reports/Report.scala
@@ -1,6 +1,5 @@
 package dpla.ingestion3.reports
 
-import dpla.ingestion3.model.DplaMapData.LiteralOrUri
 import dpla.ingestion3.model._
 import org.apache.spark.sql._
 
@@ -100,11 +99,7 @@ trait Report {
           t.map(_.asInstanceOf[EdmTimeSpan].originalSourceDate.getOrElse("__MISSING EdmTimeSpan.originalSourceDate__"))
         case _: SkosConcept =>
           t.map(_.asInstanceOf[SkosConcept].providedLabel.getOrElse("__MISSING SkosConcept.providedLabel__"))
-        case _: Either[_,_] =>
-          t.map(_.asInstanceOf[LiteralOrUri] match {
-            case Left(string) => string
-            case Right(uri) => uri.toString
-          })
+        case LiteralOrUri(_, _) => t.map(_.asInstanceOf[LiteralOrUri].value)
         case _ => t.map(_.toString)
       }
     }

--- a/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
+++ b/src/test/scala/dpla/ingestion3/data/EnrichedRecordFixture.scala
@@ -30,7 +30,7 @@ object EnrichedRecordFixture {
       isShownAt = EdmWebResource(
         uri = URI("https://example.org/record/123")
       ),
-      sidecar = ("prehashId" -> "oai:somestate:id123") ~ ("dplaId" -> "4b1bd605bd1d75ee23baadb0e1f24457"),
+      sidecar = toJsonString(("prehashId" -> "oai:somestate:id123") ~ ("dplaId" -> "4b1bd605bd1d75ee23baadb0e1f24457")),
       originalId = "The original ID",
       sourceResource = DplaSourceResource(
         creator = Seq(EdmAgent(
@@ -57,27 +57,27 @@ object EnrichedRecordFixture {
         name = Some("The Data Provider"),
         exactMatch = Seq(URI("Q83878447"))
       ),
-      dplaUri = new URI("https://dp.la/item/123"),
+      dplaUri = URI("https://dp.la/item/123"),
       originalRecord = "The Original Record",
       provider = EdmAgent(
-        uri = Some(new URI("http://dp.la/api/contributor/thedataprovider")),
+        uri = Some(URI("http://dp.la/api/contributor/thedataprovider")),
         name = Some("The Provider")
       ),
-      hasView = Seq(EdmWebResource(uri = new URI("https://example.org/"))),
+      hasView = Seq(EdmWebResource(uri = URI("https://example.org/"))),
       intermediateProvider = Some(
         EdmAgent(name = Some("The Intermediate Provider"))
       ),
       `object` = Some(
-        EdmWebResource(uri = new URI("https://example.org/record/123.html"))
+        EdmWebResource(uri = URI("https://example.org/record/123.html"))
       ),
       preview = Some(
-        EdmWebResource(uri = new URI("https://example.org/thumbnail/123.jpg"))
+        EdmWebResource(uri = URI("https://example.org/thumbnail/123.jpg"))
       ),
-      edmRights = Some(new URI("https://example.org/rights/public_domain.html")),
+      edmRights = Some(URI("https://example.org/rights/public_domain.html")),
       isShownAt = EdmWebResource(
         uri = new URI("https://example.org/record/123")
       ),
-      sidecar = ("prehashId" -> "oai:somestate:id123") ~ ("dplaId" -> "4b1bd605bd1d75ee23baadb0e1f24457"),
+      sidecar = toJsonString(("prehashId" -> "oai:somestate:id123") ~ ("dplaId" -> "4b1bd605bd1d75ee23baadb0e1f24457")),
       originalId = "The original ID",
       sourceResource = DplaSourceResource(
         collection = Seq(DcmiTypeCollection(
@@ -138,7 +138,7 @@ object EnrichedRecordFixture {
 
   val minimalEnrichedRecord =
     OreAggregation(
-      sidecar = ("prehashId" -> "oai:somestate:id123") ~ ("dplaId" -> "123"),
+      sidecar = toJsonString(("prehashId" -> "oai:somestate:id123") ~ ("dplaId" -> "123")),
       sourceResource = DplaSourceResource(
         rights = Seq("Public Domain"),
         title = Seq("The Title"),
@@ -147,24 +147,24 @@ object EnrichedRecordFixture {
       dataProvider = EdmAgent(
         name = Some("The Data Provider")
       ),
-      dplaUri = new URI("https://dp.la/item/123"),
-      isShownAt = EdmWebResource(uri = new URI("https://example.org/record/123")),
+      dplaUri = URI("https://dp.la/item/123"),
+      isShownAt = EdmWebResource(uri = URI("https://example.org/record/123")),
       originalRecord = "The Original Record",
       provider = EdmAgent(
         name = Some("The Provider"),
-        uri = Some(new URI("http://dp.la/api/contributor/thedataprovider"))
+        uri = Some(URI("http://dp.la/api/contributor/thedataprovider"))
       ),
-      hasView = Seq(EdmWebResource(uri = new URI("https://example.org/"))),
+      hasView = Seq(EdmWebResource(uri = URI("https://example.org/"))),
       intermediateProvider = Some(
         EdmAgent(name = Some("The Intermediate Provider"))
       ),
       `object` = Some(
-        EdmWebResource(uri = new URI("https://example.org/record/123.html"))
+        EdmWebResource(uri = URI("https://example.org/record/123.html"))
       ),
       preview = Some(
-        EdmWebResource(uri = new URI("https://example.org/thumbnail/123.jpg"))
+        EdmWebResource(uri = URI("https://example.org/thumbnail/123.jpg"))
       ),
-      edmRights = Some(new URI("https://example.org/rights/public_domain.html")),
+      edmRights = Some(URI("https://example.org/rights/public_domain.html")),
       originalId = "The original ID"
     )
 }

--- a/src/test/scala/dpla/ingestion3/mappers/providers/HarvardMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/HarvardMappingTest.scala
@@ -559,8 +559,8 @@ class HarvardMappingTest extends FlatSpec with BeforeAndAfter {
         </mods:mods>
       )
     )
-    assert(result.contains(Left("Latin American pamphlet digital project at Harvard University")))
-    assert(result.contains(Left("Latin American pamphlet digital project at Harvard University. 4245 Preservation microfilm collection")))
+    assert(result.contains(LiteralOrUri("Latin American pamphlet digital project at Harvard University", isUri = false)))
+    assert(result.contains(LiteralOrUri("Latin American pamphlet digital project at Harvard University. 4245 Preservation microfilm collection", isUri = false)))
   }
 
   //todo

--- a/src/test/scala/dpla/ingestion3/mappers/providers/NaraMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/NaraMappingTest.scala
@@ -101,7 +101,7 @@ class NaraMappingTest extends FlatSpec with BeforeAndAfter {
 
   it should "extract relations" in {
     val relations = extractor.relation(xml)
-    assert(relations === Seq(Left("Records of the Forest Service ; Historic Photographs")))
+    assert(relations === Seq(LiteralOrUri("Records of the Forest Service ; Historic Photographs", isUri = false)))
   }
 
   it should "extract rights" in {

--- a/src/test/scala/dpla/ingestion3/mappers/providers/P2PMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/P2PMappingTest.scala
@@ -338,7 +338,7 @@ class P2PMappingTest extends FlatSpec with BeforeAndAfter {
         </mods:mods>
       )
     ).headOption.getOrElse(Left(""))
-    assert(result === Left("Game of Thrones"))
+    assert(result === LiteralOrUri("Game of Thrones", isUri = false))
   }
 
   it should "extract collection" in {

--- a/src/test/scala/dpla/ingestion3/model/ModelConverterTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/ModelConverterTest.scala
@@ -171,12 +171,12 @@ class ModelConverterTest extends FlatSpec with BeforeAndAfter {
 
   it should "handle LiteralOrUri" in {
     val literalOrUri1 = ModelConverter.toLiteralOrUri(literal)
-    assert(literalOrUri1.isLeft)
-    assert(literalOrUri1.left.getOrElse("") === "I'm very literal")
+    assert(!literalOrUri1.isUri)
+    assert(literalOrUri1.value === "I'm very literal")
 
     val literalOrUri2 = ModelConverter.toLiteralOrUri(uri)
-    assert(literalOrUri2.isRight)
-    assert(literalOrUri2.right.getOrElse(new URI("http://example.com")) === new URI(urlString1))
+    assert(literalOrUri2.isUri)
+    assert(literalOrUri2.asUri === Some(URI(urlString1)))
   }
 
   it should "handle optional EdmWebResources" in {

--- a/src/test/scala/dpla/ingestion3/model/RowConverterTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/RowConverterTest.scala
@@ -49,8 +49,8 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
   )
   val emtpySkosConcept = SkosConcept()
 
-  val stringLiteralOrUri = Left("String")
-  val uriLiteralOrUri = Right(uri1)
+  val stringLiteralOrUri = LiteralOrUri("String", isUri = false)
+  val uriLiteralOrUri = LiteralOrUri(uri1.toString, isUri = true)
 
   val edmAgent = EdmAgent(
     uri = Some(uri1),
@@ -262,7 +262,7 @@ class RowConverterTest extends FlatSpec with BeforeAndAfter {
       language = Seq(skosConcept, skosConcept, skosConcept),
       place = Seq(dplaPlace, dplaPlace, dplaPlace),
       publisher = Seq(edmAgent, edmAgent, edmAgent),
-      relation = Seq(Right(uri1), Left("foobar"), Right(uri2), Left("snozzbuzz")),
+      relation = Seq(LiteralOrUri(uri1.toString, isUri = true), LiteralOrUri("foobar", isUri = false), LiteralOrUri(uri2.toString, isUri = true), LiteralOrUri("snozzbuzz", isUri = false)),
       replacedBy = Seq("someone's", "taken", "my", "place"),
       replaces = Seq("we're", "the", "replacmements"),
       rights = Seq("some", "rights"),


### PR DESCRIPTION
- preMappingReports package name cleanup
- Changed LiteralOrUri to a case class
- Made sidecar a string

These changes needed to make it possible to use OreAggegation in a Dataset 
and write it out to parquet without encoder messiness or managing it manually
ala ModelConverter / RowConverter.