### PR TITLE
Remove /rdf from edmRights path 

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
@@ -52,12 +52,16 @@ trait Mapper[T, +E] extends IngestMessageTemplates {
               collector.add(normalizedEdmRightsWWWMsg(providerId, "edmRights", value.toString, msg = None, enforce = false))
             }
             // change /page/ to /vocab/
-            val path = if (uri.getPath.contains("/page/")) {
+            // remove /rdf
+            val path = if (uri.getPath.contains("/page/") | uri.getPath.contains("/rdf")) {
               collector.add(normalizedEdmRightsRsPageMsg(providerId, "edmRights", value.toString, msg = None, enforce = false))
-              uri.getPath.replaceFirst("/page/", "/vocab/")
-            } else {
+              uri.getPath.replaceFirst("/page/", "/vocab/").replace("/rdf","")
+            }
+            else {
               uri.getPath
             }
+
+
             // Strip `?` and all following
             if (uri.getQuery != null) {
               collector.add(normalizedEdmRightsRsPageMsg(providerId, "edmRights", value.toString, msg = None, enforce = false))

--- a/src/test/scala/dpla/ingestion3/mappers/MapperTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/MapperTest.scala
@@ -55,6 +55,16 @@ class MapperTest extends FlatSpec with BeforeAndAfter with IngestMessageTemplate
     assert(validatedEdmRights === normalizedRightsUri)
   }
 
+  it should "normalized a rights URI by removing /rdf from path" in {
+
+    val rightsUris = Seq("http://creativecommons.org/licenses/by/4.0/rdf").map(URI)
+    val normalizedRightsUri = Seq(URI("http://creativecommons.org/licenses/by/4.0/"))
+
+    val validatedEdmRights = mapTest.normalizeEdmRights(rightsUris, id)
+
+    assert(validatedEdmRights === normalizedRightsUri)
+  }
+
   it should "log a warning when an invalid rs.org value is provided and enforce is FALSE" in {
     msgCollector.deleteAll()
     val rightsString = "http://rightsstatements.org/"


### PR DESCRIPTION
Removes /rdf from URI path to normalize to valid URI