### PR TITLE
Trim text on ma identifier mapping

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/MaMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MaMapping.scala
@@ -163,6 +163,7 @@ class MaMapping extends XmlMapping with XmlExtractor with IngestMessageTemplates
       val ids = (getModsRoot(data) \ "identifier")
         .flatMap(node => getByAttribute(node, "type", t))
         .flatMap(extractString(_))
+        .map(_.trim)
 
       if (ids.nonEmpty) {
         Some(s"$label: ${ids.mkString(", ")}")

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MaMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MaMappingTest.scala
@@ -254,6 +254,28 @@ class MaMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.identifier(xml) === expected)
 
   }
+  it should "extract identifiers" in {
+    val xml: Document[NodeSeq] = Document(
+      <record>
+        <metadata>
+          <mods:mods>
+            <mods:identifier type="local-accession">
+              Z2016-20 Sarah (Sallie) Moore Field Collection
+            </mods:identifier>
+            <mods:identifier type="local-other">
+              19030509
+            </mods:identifier>
+          </mods:mods>
+        </metadata>
+      </record>
+    )
+
+    val expected = Seq("Local accession: Z2016-20 Sarah (Sallie) Moore Field Collection",
+    "Local other: 19030509")
+    assert(extractor.identifier(xml) === expected)
+
+  }
+
 
   it should "extract the correct multiple identifiers" in {
     val xml: Document[NodeSeq] = Document(


### PR DESCRIPTION
After inspecting DT-2759 (which was implemented in Dec 2021 but not run because MA has opted out of reingests) add a trim to the text values and one additional test.