### PR TITLE
NWDH mediaMaster and IIIF mappings and tests

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/NorthwestHeritageMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/NorthwestHeritageMapping.scala
@@ -29,6 +29,20 @@ class NorthwestHeritageMapping extends XmlMapping with XmlExtractor with IngestM
     extractString(data \ "identifier")
       .map(_.trim)
 
+  override def iiifManifest(data: Document[NodeSeq]): ZeroToMany[URI] =
+    // <mods:location><mods:url note="iiifManifest">
+    (data \ "location" \ "url")
+      .flatMap(node => getByAttribute(node, "note", "iiifManifest"))
+      .flatMap(extractStrings)
+      .map(URI)
+
+  override def mediaMaster(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
+    // <mods:location><mods:url note="iiifManifest">
+    (data \ "location" \ "url")
+      .flatMap(node => getByAttribute(node, "note", "mediaMaster"))
+      .flatMap(extractStrings)
+      .map(stringOnlyWebResource)
+
   // SourceResource mapping
   override def collection(data: Document[NodeSeq]): ZeroToMany[DcmiTypeCollection] =
   // <mods:relatedItem type=host><mods:titleInfo><mods:title>

--- a/src/test/resources/northwest-heritage.xml
+++ b/src/test/resources/northwest-heritage.xml
@@ -26,6 +26,12 @@
         <mods:url usage="primary" access="object in context">http://ddr.densho.org/ddr-densho-101-1/</mods:url>
     </mods:location>
     <mods:location>
+        <mods:url note="iiifManifest">http://iiif.manifest/</mods:url>
+    </mods:location>
+    <mods:location>
+        <mods:url note="mediaMaster">http://media.master/</mods:url>
+    </mods:location>
+    <mods:location>
         <mods:url access="preview">https://ddr.densho.org/media/ddr-densho-101/ddr-densho-101-1-mezzanine-96054e814c-a.jpg</mods:url>
     </mods:location>
     <mods:location>

--- a/src/test/scala/dpla/ingestion3/mappers/providers/NorthwestHeritageMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/NorthwestHeritageMappingTest.scala
@@ -112,5 +112,15 @@ class NorthwestHeritageMappingTest extends FlatSpec with BeforeAndAfter {
     val expected = Seq("Watkins, Carleton E., 1829-1916").map(nameOnlyAgent)
     assert(extractor.publisher(xml) === expected)
   }
+
+  it should "extract the correct iiifManifest" in {
+    val expected = Seq("http://iiif.manifest/").map(URI)
+    assert(extractor.iiifManifest(xml) === expected)
+  }
+
+  it should "extract the correct media master" in {
+    val expected = Seq("http://media.master/").map(stringOnlyWebResource)
+    assert(extractor.mediaMaster(xml) === expected)
+  }
 }
 


### PR DESCRIPTION
From a repository that supports IIIF
```
<mods:location>
   <mods:url note="iiifManifest">http://cdm16977.contentdm.oclc.org/iiif/info/p16977coll5/4/manifest.json</mods:url>
</mods:location>
```

From  a repository with mediaMaster
```
<mods:location>
   <mods:url note="mediaMaster">https://ddr.densho.org/media/ddr-densho-336/ddr-densho-336-1-mezzanine-49979d16fd-a.jpg</mods:url>
</mods:location>
```