### PR TITLE
Fix MWDL mapping of isShownAt

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/MwdlMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MwdlMapping.scala
@@ -121,7 +121,7 @@ class MwdlMapping extends XmlMapping with XmlExtractor {
   // baseIsShownAt + control\recordid
     (data \\ "control" \ "recordid")
       .flatMap(extractStrings)
-      .map(baseIsShownAt + _ + suffixIsShownAt)
+      .map(baseIsShownAt + _.trim + suffixIsShownAt)
       .map(stringOnlyWebResource)
 
   override def originalRecord(data: Document[NodeSeq]): ExactlyOne[String] = Utils.formatXml(data)

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MwdlMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MwdlMappingTest.scala
@@ -70,8 +70,17 @@ class MwdlMappingTest extends FlatSpec with BeforeAndAfter {
     assert(extractor.edmRights(xml) === expected)
   }
   it should "extract the correct isShownAt" in {
+    val xml: NodeSeq = <PrimoNMBib xmlns="http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib">
+        <record>
+            <control>
+                <recordid>
+                  digcoll_slc_27works_598
+                </recordid>
+              </control>
+          </record>
+      </PrimoNMBib>
     val expected = Seq(uriOnlyWebResource(URI("https://utah-primoprod.hosted.exlibrisgroup.com/primo-explore/fulldisplay?docid=digcoll_slc_27works_598&context=L&vid=MWDL")))
-    assert(extractor.isShownAt(xml) === expected)
+    assert(extractor.isShownAt(Document(xml)) === expected)
   }
   it should "extract the correct preview" in {
     val expected = Seq("https://libarchive.slcc.edu/islandora/object/works_598/datastream/TN/",


### PR DESCRIPTION
There are some cases where the `recordid` is surrounded by white space and those need to be stripped before constructing isShownAt URL