### PR TITLE
Updates for changes rights

### DIFF
--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -250,17 +250,6 @@ package object model {
         | }}""".stripMargin
   }
 
-  def getWikiOtherFieldsRights(edmRights: Option[URI]): String =
-    edmRights match {
-      case Some(uri) =>
-        if(uri.toString.startsWith("http://rightsstatements.org"))
-          s"{{ InFi | Standardized rights statement | {{ rights statement | ${escapeWikiChars(uri.toString)} }} }}"
-        else
-          ""
-      case None => ""
-    }
-
-
   def getWikiPermissionTemplate(edmRights: Option[URI]): String = {
     edmRights match {
       case Some(uri) => uri.toString match {

--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -247,7 +247,6 @@ package object model {
         |       | local_id = ${record.sourceResource.identifier.map(escapeWikiChars).mkString("; ")}
         |   }}
         |   | Institution = {{ Institution | wikidata = $dataProviderWikiUri }}
-        |   | Other fields = ${getWikiOtherFieldsRights(record.edmRights)}
         | }}""".stripMargin
   }
 
@@ -265,7 +264,8 @@ package object model {
   def getWikiPermissionTemplate(edmRights: Option[URI]): String = {
     edmRights match {
       case Some(uri) => uri.toString match {
-        case t if t.startsWith("http://rightsstatements.org/vocab/NoC-US/") => "PD-US"
+        case t if t.startsWith("http://rightsstatements.org/vocab/NKC/") => "NKC | $dataProviderWikiUri"
+        case t if t.startsWith("http://rightsstatements.org/vocab/NoC-US/") => "NoC-US | $dataProviderWikiUri"
         case t if t.startsWith("http://creativecommons.org/publicdomain/mark/") => "PD-US"
         case t if t.startsWith("http://creativecommons.org/publicdomain/zero/") => "cc-zero"
         case t if t.startsWith("http://creativecommons.org/licenses/by/") => licenseToMarkupCode(t)

--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -231,6 +231,11 @@ package object model {
   def buildWikiMarkup(record: OreAggregation): String = {
     val dataProviderWikiUri = getDataProviderWikiId(record)
     val dplaId = getDplaId(record)
+    val permissionsTemplate = getWikiPermissionTemplate(record.edmRights)
+    val permissions = record.edmRights.toString match {
+      case pt if pt.contains("http://rightsstatements.org") => s"$permissionsTemplate | ${dataProviderWikiUri}"
+      case _ => permissionsTemplate
+    }
 
     s"""|== {{int:filedesc}} ==
         | {{ Artwork
@@ -238,7 +243,7 @@ package object model {
         |   | title = ${record.sourceResource.title.map(escapeWikiChars).mkString("; ")}
         |   | description = ${record.sourceResource.description.map(escapeWikiChars).mkString("; ")}
         |   | date = ${record.sourceResource.date.flatMap { _.prefLabel }.map(escapeWikiChars).mkString("; ")}
-        |   | permission = {{${getWikiPermissionTemplate(record.edmRights)}}}
+        |   | permission = {{${permissions}}}
         |   | source = {{ DPLA
         |       | ${escapeWikiChars(dataProviderWikiUri)}
         |       | hub = ${escapeWikiChars(record.provider.name.getOrElse(""))}
@@ -253,8 +258,8 @@ package object model {
   def getWikiPermissionTemplate(edmRights: Option[URI]): String = {
     edmRights match {
       case Some(uri) => uri.toString match {
-        case t if t.startsWith("http://rightsstatements.org/vocab/NKC/") => "NKC | $dataProviderWikiUri"
-        case t if t.startsWith("http://rightsstatements.org/vocab/NoC-US/") => "NoC-US | $dataProviderWikiUri"
+        case t if t.startsWith("http://rightsstatements.org/vocab/NKC/") => "NKC"
+        case t if t.startsWith("http://rightsstatements.org/vocab/NoC-US/") => "NoC-US"
         case t if t.startsWith("http://creativecommons.org/publicdomain/mark/") => "PD-US"
         case t if t.startsWith("http://creativecommons.org/publicdomain/zero/") => "cc-zero"
         case t if t.startsWith("http://creativecommons.org/licenses/by/") => licenseToMarkupCode(t)

--- a/src/test/scala/dpla/ingestion3/model/WikiMarkupStringTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/WikiMarkupStringTest.scala
@@ -46,7 +46,6 @@ class WikiMarkupStringTest extends FlatSpec {
                            |       | local_id = us-history-13243; j-doe-archives-2343
                            |   }}
                            |   | Institution = {{ Institution | wikidata = Q83878447 }}
-                           |   | Other fields =$whitespace
                            | }}""".stripMargin
     assert(expectedMarkup === markup)
   }

--- a/src/test/scala/dpla/ingestion3/model/WikiMarkupStringTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/WikiMarkupStringTest.scala
@@ -13,7 +13,7 @@ class WikiMarkupStringTest extends FlatSpec {
                         |   | title = The Title
                         |   | description = The description
                         |   | date = 2012-05-07
-                        |   | permission = {{PD-US}}
+                        |   | permission = {{NoC-US|Q83878447}}
                         |   | source = {{ DPLA
                         |       | Q83878447
                         |       | hub = The Provider
@@ -22,7 +22,6 @@ class WikiMarkupStringTest extends FlatSpec {
                         |       | local_id = us-history-13243; j-doe-archives-2343
                         |   }}
                         |   | Institution = {{ Institution | wikidata = Q83878447 }}
-                        |   | Other fields = {{ InFi | Standardized rights statement | {{ rights statement | http://rightsstatements.org/vocab/NoC-US/ }} }}
                         | }}""".stripMargin
     assert(expectedMarkup === markup)
   }

--- a/src/test/scala/dpla/ingestion3/model/WikiMarkupStringTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/WikiMarkupStringTest.scala
@@ -13,7 +13,7 @@ class WikiMarkupStringTest extends FlatSpec {
                         |   | title = The Title
                         |   | description = The description
                         |   | date = 2012-05-07
-                        |   | permission = {{NoC-US|Q83878447}}
+                        |   | permission = {{NoC-US | Q83878447}}
                         |   | source = {{ DPLA
                         |       | Q83878447
                         |       | hub = The Provider


### PR DESCRIPTION
This patch should make the following 3 changes:

1. In the case of a NoC-US item, the `permission` template parameter now uses `NoC-US | $dataProviderWikiUri` instead of `PD-US`.
2. New case of a `.../NKC/` item is now allowed, for which the `permission` template parameter uses `NKC | $dataProviderWikiUri`.
3. Combining the rights statement with the permission field means we can simplify the output by removing the `Other fields` portion of the template, and the code required to check `getWikiOtherFieldsRights` code required to produce it.

I have updated the test case so it reflects a valid current output based on above changes.