### PR TITLE
WI gov't document tags

### DIFF
--- a/src/main/scala/dpla/ingestion3/enrichments/TaggingUtils.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/TaggingUtils.scala
@@ -6,6 +6,26 @@ object TaggingUtils {
 
   implicit class Tags(value: String) {
 
+    lazy val applyWisconsinGovernmentTags: Option[URI] = {
+      val wisconsinTag = URI("wisconsin_gov_doc")
+      val taggingValues = Seq(
+          "p267601coll4",
+          "p16831coll2",
+          "p16831coll3",
+          "p16831coll4",
+          "p16831coll5",
+          "p16831coll6",
+          "p16831coll8"
+      )
+
+      if(taggingValues.contains(value)) {
+        Some(wisconsinTag)
+      } else {
+        None
+      }
+
+    }
+
     /**
      * Applies at standard tag for records to be included in the PanAm portal
      */

--- a/src/main/scala/dpla/ingestion3/mappers/providers/WiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/WiMapping.scala
@@ -1,8 +1,9 @@
 package dpla.ingestion3.mappers.providers
 
+import dpla.ingestion3.enrichments.TaggingUtils.Tags
 import dpla.ingestion3.enrichments.normalizations.StringNormalizationUtils._
 import dpla.ingestion3.enrichments.normalizations.filters.{DigitalSurrogateBlockList, ExtentIdentificationList}
-import dpla.ingestion3.mappers.utils.{Document, XmlMapping, XmlExtractor}
+import dpla.ingestion3.mappers.utils.{Document, XmlExtractor, XmlMapping}
 import dpla.ingestion3.messages.IngestMessageTemplates
 import dpla.ingestion3.model.DplaMapData.{ExactlyOne, ZeroToMany, ZeroToOne}
 import dpla.ingestion3.model._
@@ -133,6 +134,10 @@ class WiMapping extends XmlMapping with XmlExtractor
 
   override def sidecar(data: Document[NodeSeq]): JValue =
     ("prehashId" -> buildProviderBaseId()(data)) ~ ("dplaId" -> mintDplaId(data))
+
+  override def tags(data: Document[NodeSeq]): ZeroToMany[URI] =
+    extractStrings(data \ "header" \ "setSpec").flatMap(_.applyWisconsinGovernmentTags)
+
 
 
   def agent = EdmAgent(

--- a/src/test/scala/dpla/ingestion3/mappers/providers/WiMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/WiMappingTest.scala
@@ -60,4 +60,16 @@ class WiMappingTest extends FlatSpec with BeforeAndAfter {
     val expected = Seq("Access rights")
     assert(extractor.rights(Document(xml)) === expected)
   }
+
+  it should "apply the correct tags" in {
+    val xml =
+      <record>
+        <header>
+          <setSpec>p267601coll4</setSpec>
+        </header>
+      </record>
+
+    val expected = Seq(URI("wisconsin_gov_doc"))
+    assert(extractor.tags(Document(xml)) === expected)
+  }
 }


### PR DESCRIPTION
Addresses request for creating a group of government documents in Recollection Wisconsin local. Uses the `setSpec` value to tag item records. 