### PR TITLE
NWDH OAI mapping update

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/NorthwestHeritageMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/NorthwestHeritageMapping.scala
@@ -26,19 +26,19 @@ class NorthwestHeritageMapping extends XmlMapping with XmlExtractor with IngestM
   override def getProviderName(): Option[String] = Some("nwdh")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
-    extractString(data \ "identifier")
+    extractString(data \ "header" \ "identifier")
       .map(_.trim)
 
   override def iiifManifest(data: Document[NodeSeq]): ZeroToMany[URI] =
     // <mods:location><mods:url note="iiifManifest">
-    (data \ "location" \ "url")
+    (getRoot(data) \ "location" \ "url")
       .flatMap(node => getByAttribute(node, "note", "iiifManifest"))
       .flatMap(extractStrings)
       .map(URI)
 
   override def mediaMaster(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
     // <mods:location><mods:url note="iiifManifest">
-    (data \ "location" \ "url")
+    (getRoot(data) \ "location" \ "url")
       .flatMap(node => getByAttribute(node, "note", "mediaMaster"))
       .flatMap(extractStrings)
       .map(stringOnlyWebResource)
@@ -46,112 +46,112 @@ class NorthwestHeritageMapping extends XmlMapping with XmlExtractor with IngestM
   // SourceResource mapping
   override def collection(data: Document[NodeSeq]): ZeroToMany[DcmiTypeCollection] =
   // <mods:relatedItem type=host><mods:titleInfo><mods:title>
-    (data \ "relatedItem")
+    (getRoot(data) \ "relatedItem")
       .flatMap(node => getByAttribute(node, "type", "host"))
       .flatMap(collection => extractStrings(collection \ "titleInfo" \ "title"))
       .map(nameOnlyCollection)
 
   override def contributor(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
   // when <role><roleTerm> DOES equal "contributor>
-    (data \ "name")
+    (getRoot(data) \ "name")
       .filter(node => (node \ "role" \ "roleTerm").text.equalsIgnoreCase("contributor"))
       .flatMap(n => extractStrings(n \ "namePart"))
       .map(nameOnlyAgent)
 
   override def creator(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
   // <mods:name><mods:namePart> when <role><roleTerm> is 'creator'
-    (data \ "name")
+    (getRoot(data) \ "name")
       .filter(node => (node \ "role" \ "roleTerm").text.equalsIgnoreCase("creator"))
       .flatMap(n => extractStrings(n \ "namePart"))
       .map(nameOnlyAgent)
 
   override def date(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] =
   // <mods:originInfo><mods:dateCreated>
-    extractStrings(data \ "originInfo" \ "dateCreated")
+    extractStrings(getRoot(data) \ "originInfo" \ "dateCreated")
       .map(stringOnlyTimeSpan)
 
   override def description(data: Document[NodeSeq]): Seq[String] = {
     // <mods:note> and <mods:abstract>
-    extractStrings(data \\ "mods" \ "abstract")
+    extractStrings(getRoot(data) \\ "mods" \ "abstract")
   }
 
   override def extent(data: Document[NodeSeq]): ZeroToMany[String] =
   // <mods:physicalDescription><mods:extent>
-    extractStrings(data \\ "mods" \ "physicalDescription" \ "extent")
+    extractStrings(getRoot(data) \\ "mods" \ "physicalDescription" \ "extent")
 
   override def format(data: Document[NodeSeq]): Seq[String] =
   // <mods:genre> AND <mods:physicalDescription><mods:form>
-    (extractStrings(data \\ "mods" \ "genre") ++
-      extractStrings(data \\ "mods" \ "physicalDescription" \ "form"))
+    (extractStrings(getRoot(data) \\ "mods" \ "genre") ++
+      extractStrings(getRoot(data) \\ "mods" \ "physicalDescription" \ "form"))
       .map(_.applyBlockFilter(formatBlockList))
       .filter(_.nonEmpty)
 
   override def identifier(data: Document[NodeSeq]): Seq[String] =
   // <mods:recordInfo> \ "recordIdentifier"
-    extractStrings(data \\ "recordInfo" \ "recordIdentifier")
+    extractStrings(getRoot(data) \\ "recordInfo" \ "recordIdentifier")
 
   override def language(data: Document[NodeSeq]): Seq[SkosConcept] =
   // <mods:language><mods:languageTerm>
-    extractStrings(data \ "language" \ "languageTerm")
+    extractStrings(getRoot(data) \ "language" \ "languageTerm")
       .map(nameOnlyConcept)
 
   override def place(data: Document[NodeSeq]): Seq[DplaPlace] =
   // <mods:subject><mods:geographic>
   // drop lat long coordinates from place mapping
-    extractStrings(data \ "subject" \ "geographic")
+    extractStrings(getRoot(data) \ "subject" \ "geographic")
       .filterNot(str => str.matches(latLongRegex))
       .map(nameOnlyPlace)
 
   override def publisher(data: Document[NodeSeq]): Seq[EdmAgent] =
   // <mods:originInfo><mods:publisher>
-    extractStrings(data \\ "mods" \ "originInfo" \ "publisher")
+    extractStrings(getRoot(data) \\ "mods" \ "originInfo" \ "publisher")
       .map(nameOnlyAgent)
 
   override def rights(data: Document[NodeSeq]): Seq[String] = {
 //    <mods:note type=“freetext”>Blah blah blah</mods:note>
-    (data \ "note")
+    (getRoot(data) \ "note")
       .flatMap(node => getByAttribute(node, "type", "freetext"))
       .flatMap(extractStrings)
   }
   override def subject(data: Document[NodeSeq]): Seq[SkosConcept] =
   // <mods:subject><mods:topic>
-    extractStrings(data \ "subject" \ "topic").map(nameOnlyConcept)
+    extractStrings(getRoot(data) \ "subject" \ "topic").map(nameOnlyConcept)
 
   override def title(data: Document[NodeSeq]): Seq[String] =
   // <mods:titleInfo><mods:title>
-    extractStrings(data \ "titleInfo" \ "title")
+    extractStrings(getRoot(data) \ "titleInfo" \ "title")
 
   override def `type`(data: Document[NodeSeq]): Seq[String] =
   // <mods:typeOfResource>
-    extractStrings(data \ "typeOfResource")
+    extractStrings(getRoot(data) \ "typeOfResource")
 
   // OreAggregation
   override def dplaUri(data: Document[NodeSeq]): ZeroToOne[URI] = mintDplaItemUri(data)
 
   override def dataProvider(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
   // note @type='ownershpip'
-    (data \ "note")
+    (getRoot(data) \ "note")
       .flatMap(node => getByAttribute(node, "type", "ownership"))
       .flatMap(extractStrings)
       .map(nameOnlyAgent)
 
   override def intermediateProvider(data: Document[NodeSeq]): ZeroToOne[EdmAgent] =
   // note @type='admin'
-    (data \ "note")
+    (getRoot(data) \ "note")
       .flatMap(node => getByAttribute(node, "type", "admin"))
       .flatMap(extractStrings)
       .map(nameOnlyAgent)
       .headOption
 
   override def edmRights(data: Document[NodeSeq]): ZeroToMany[URI] =
-    (data \ "accessCondition")
+    (getRoot(data) \ "accessCondition")
       .flatMap(node => getByAttribute(node, "type", "use and reproduction"))
       .flatMap(extractStrings)
       .map(URI)
 
   override def isShownAt(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
   // <mods:location><mods:url usage="primary">
-    (data \ "location" \ "url")
+    (getRoot(data) \ "location" \ "url")
       .flatMap(node => getByAttribute(node, "access", "object in context"))
       .flatMap(extractStrings)
       .map(stringOnlyWebResource)
@@ -160,7 +160,7 @@ class NorthwestHeritageMapping extends XmlMapping with XmlExtractor with IngestM
 
   override def preview(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
   // <mods:location><mods:url access="preview">
-    (data \ "location" \ "url")
+    (getRoot(data) \ "location" \ "url")
       .flatMap(node => getByAttribute(node, "access", "preview"))
       .flatMap(extractStrings)
       .map(stringOnlyWebResource)
@@ -178,4 +178,8 @@ class NorthwestHeritageMapping extends XmlMapping with XmlExtractor with IngestM
     name = Some("Northwest Digital Heritage"),
     uri = Some(URI("http://dp.la/api/contributor/northwest-digital-heritage"))
   )
+
+  def getRoot(data: Document[NodeSeq]): NodeSeq = {
+    data \ "metadata" \ "mods"
+  }
 }

--- a/src/test/resources/northwest-heritage.xml
+++ b/src/test/resources/northwest-heritage.xml
@@ -1,65 +1,74 @@
-<mods:mods xmlns:oai="http://www.openarchives.org/OAI/2.0/"
-           xmlns:mods="http://www.loc.gov/mods/v3"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://www.loc.gov/mods/v3 https://www.loc.gov/standards/mods/mods.xsd">
-    <mods:identifier>oai:nwdh:densho:ddr.densho.org:ddr-densho-101-1</mods:identifier>
-    <mods:titleInfo>
-        <mods:title>Group in front of the Japanese American Courier offices</mods:title>
-    </mods:titleInfo>
-    <mods:typeOfResource>Image</mods:typeOfResource>
-    <mods:abstract>(L to R): Yone Bartholomew, Clarence Arai, unidentified, Misao Sakamoto holding daughter Marie, Jimmie Sakamoto, Slocum Nishimura (Tokie Slocum) in front of the offices of the Japanese American Courier. Names: Bartholomew, Yone; Arai, Clarence; Sakamoto, Misao; Sakamoto, Marie; Sakamoto, Jimmie; Nishimura, Slocum</mods:abstract>
-    <mods:subject>
-        <mods:topic>Industry and employment -- Journalism</mods:topic>
-        <mods:geographic>Seattle, Washington (State), United States</mods:geographic>
-    </mods:subject>
-    <mods:genre authority="aat">photographs</mods:genre>
-    <mods:note type="ownership">Densho</mods:note>
-    <mods:physicalDescription>
-        <mods:form>image/jpeg</mods:form>
-        <mods:extent>3.5 x 7 in.</mods:extent>
-    </mods:physicalDescription>
-    <mods:recordInfo>
-        <mods:recordIdentifier>ddr-densho-101-1</mods:recordIdentifier>
-    </mods:recordInfo>
-    <mods:accessCondition type="use and reproduction">http://rightsstatements.org/vocab/InC/1.0/</mods:accessCondition>
-    <mods:note type="freetext">blah blah blah</mods:note>
-    <mods:location>
-        <mods:url usage="primary" access="object in context">http://ddr.densho.org/ddr-densho-101-1/</mods:url>
-    </mods:location>
-    <mods:location>
-        <mods:url note="iiifManifest">http://iiif.manifest/</mods:url>
-    </mods:location>
-    <mods:location>
-        <mods:url note="mediaMaster">http://media.master/</mods:url>
-    </mods:location>
-    <mods:location>
-        <mods:url access="preview">https://ddr.densho.org/media/ddr-densho-101/ddr-densho-101-1-mezzanine-96054e814c-a.jpg</mods:url>
-    </mods:location>
-    <mods:location>
-        <mods:url access="raw object">https://ddr.densho.org/media/ddr-densho-101/ddr-densho-101-1-mezzanine-96054e814c-a.jpg</mods:url>
-    </mods:location>
-    <mods:name>
-        <mods:namePart>Lenggenhager, Werner W., 1899-1988</mods:namePart>
-        <mods:role>
-            <mods:roleTerm>creator</mods:roleTerm>
-        </mods:role>
-    </mods:name>
-    <mods:name>
-        <mods:namePart>Thiry, Paul, 1904-1993</mods:namePart>
-        <mods:role>
-            <mods:roleTerm>contributor</mods:roleTerm>
-        </mods:role>
-    </mods:name>
-    <mods:language>
-        <mods:languageTerm>eng</mods:languageTerm>
-    </mods:language>
-    <mods:originInfo>
-        <mods:publisher>Watkins, Carleton E., 1829-1916</mods:publisher>
-        <mods:dateCreated>1891?</mods:dateCreated>
-    </mods:originInfo>
-    <mods:relatedItem type="host">
-        <mods:titleInfo>
-            <mods:title>Seattle Historical Photograph Collection</mods:title>
-        </mods:titleInfo>
-    </mods:relatedItem>
-</mods:mods>
+
+<record>
+    <header>
+        <identifier>oai:nwdh:densho:ddr.densho.org:ddr-densho-101-1</identifier>
+        <datestamp>2023-11-13T16:50:24Z</datestamp>
+    </header>
+    <metadata>
+        <mods:mods xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+                   xmlns:mods="http://www.loc.gov/mods/v3"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.loc.gov/mods/v3 https://www.loc.gov/standards/mods/mods.xsd">
+            <mods:identifier>oai:nwdh:densho:ddr.densho.org:ddr-densho-101-1</mods:identifier>
+            <mods:titleInfo>
+                <mods:title>Group in front of the Japanese American Courier offices</mods:title>
+            </mods:titleInfo>
+            <mods:typeOfResource>Image</mods:typeOfResource>
+            <mods:abstract>(L to R): Yone Bartholomew, Clarence Arai, unidentified, Misao Sakamoto holding daughter Marie, Jimmie Sakamoto, Slocum Nishimura (Tokie Slocum) in front of the offices of the Japanese American Courier. Names: Bartholomew, Yone; Arai, Clarence; Sakamoto, Misao; Sakamoto, Marie; Sakamoto, Jimmie; Nishimura, Slocum</mods:abstract>
+            <mods:subject>
+                <mods:topic>Industry and employment -- Journalism</mods:topic>
+                <mods:geographic>Seattle, Washington (State), United States</mods:geographic>
+            </mods:subject>
+            <mods:genre authority="aat">photographs</mods:genre>
+            <mods:note type="ownership">Densho</mods:note>
+            <mods:physicalDescription>
+                <mods:form>image/jpeg</mods:form>
+                <mods:extent>3.5 x 7 in.</mods:extent>
+            </mods:physicalDescription>
+            <mods:recordInfo>
+                <mods:recordIdentifier>ddr-densho-101-1</mods:recordIdentifier>
+            </mods:recordInfo>
+            <mods:accessCondition type="use and reproduction">http://rightsstatements.org/vocab/InC/1.0/</mods:accessCondition>
+            <mods:note type="freetext">blah blah blah</mods:note>
+            <mods:location>
+                <mods:url usage="primary" access="object in context">http://ddr.densho.org/ddr-densho-101-1/</mods:url>
+            </mods:location>
+            <mods:location>
+                <mods:url note="iiifManifest">http://iiif.manifest/</mods:url>
+            </mods:location>
+            <mods:location>
+                <mods:url note="mediaMaster">http://media.master/</mods:url>
+            </mods:location>
+            <mods:location>
+                <mods:url access="preview">https://ddr.densho.org/media/ddr-densho-101/ddr-densho-101-1-mezzanine-96054e814c-a.jpg</mods:url>
+            </mods:location>
+            <mods:location>
+                <mods:url access="raw object">https://ddr.densho.org/media/ddr-densho-101/ddr-densho-101-1-mezzanine-96054e814c-a.jpg</mods:url>
+            </mods:location>
+            <mods:name>
+                <mods:namePart>Lenggenhager, Werner W., 1899-1988</mods:namePart>
+                <mods:role>
+                    <mods:roleTerm>creator</mods:roleTerm>
+                </mods:role>
+            </mods:name>
+            <mods:name>
+                <mods:namePart>Thiry, Paul, 1904-1993</mods:namePart>
+                <mods:role>
+                    <mods:roleTerm>contributor</mods:roleTerm>
+                </mods:role>
+            </mods:name>
+            <mods:language>
+                <mods:languageTerm>eng</mods:languageTerm>
+            </mods:language>
+            <mods:originInfo>
+                <mods:publisher>Watkins, Carleton E., 1829-1916</mods:publisher>
+                <mods:dateCreated>1891?</mods:dateCreated>
+            </mods:originInfo>
+            <mods:relatedItem type="host">
+                <mods:titleInfo>
+                    <mods:title>Seattle Historical Photograph Collection</mods:title>
+                </mods:titleInfo>
+            </mods:relatedItem>
+        </mods:mods>
+    </metadata>
+</record>


### PR DESCRIPTION
Revise NWDH test data to match OAI respone
Update NWDH mapping to extract from a different root Persistent ID is now in header \ identifier and not in mods:identifier