### PR TITLE
Bugfix for "Harvest all records" failure in dpla-combine

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/oai/refactor/AllRecordsOaiRelation.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/refactor/AllRecordsOaiRelation.scala
@@ -29,8 +29,9 @@ class AllRecordsOaiRelation(oaiConfiguration: OaiConfiguration, oaiMethods: OaiM
       .read
       .format("com.databricks.spark.csv")
       .option("header", "false")
-      //.option("mode", "FAILFAST")
-      .load(tempFile.getAbsolutePath)
+//    //.option("mode", "FAILFAST")
+      //.load(tempFile.getAbsolutePath)
+      .load("file://" + tempFile.getAbsolutePath)
       .rdd
 
     val eitherRdd = csvRdd.map(handleCsvRow)


### PR DESCRIPTION
In order to read local /tmp file instead of hdfs file. Otherwise, I get the following error:

'Path does not exist: hdfs://hadoop-namenode/tmp/oai7424538003476557972.txt;'