### PR TITLE
Moved default handling of duplicate IDs to false.

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
@@ -57,7 +57,7 @@ trait Mapping[T] {
   def title(data: Document[T]): AtLeastOne[String] = emptySeq
   def `type`(data: Document[T]): ZeroToMany[String] = emptySeq
 
-  val enforceDuplicateIds: Boolean = true
+  val enforceDuplicateIds: Boolean = false
 
   /** Define the defaults for required field validations
     */


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 56d4eb23d3bf1311d2a342d3544464563279f876  | 
|--------|--------|

### Summary:
Changed default handling of duplicate IDs to `false` in the `Mapping` trait.

**Key points**:
- Changed default value of `enforceDuplicateIds` from `true` to `false` in `src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala`.
- Affects duplicate ID handling in the `Mapping` trait and its implementations.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->