### PR TITLE
fixes related to new IL feed.

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/file/OaiFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/OaiFileHarvester.scala
@@ -148,8 +148,6 @@ class OaiFileHarvester(
     val harvestTime = System.currentTimeMillis()
     val unixEpoch = harvestTime / 1000L
     val inFiles = new File(conf.harvest.endpoint.getOrElse("in"))
-    println(s"Harvesting from $inFiles")
-    println(s"${inFiles.listFiles().length} files found")
 
     inFiles
       .listFiles(new ZipFileFilter)

--- a/src/main/scala/dpla/ingestion3/harvesters/file/OaiFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/OaiFileHarvester.scala
@@ -1,6 +1,6 @@
 package dpla.ingestion3.harvesters.file
 
-import java.io.{File, FileInputStream}
+import java.io.{ByteArrayInputStream, File, FileInputStream}
 import java.util.zip.ZipInputStream
 import dpla.ingestion3.confs.i3Conf
 import dpla.ingestion3.harvesters.file.FileFilters.ZipFileFilter
@@ -66,8 +66,7 @@ class OaiFileHarvester(
 
       case Some(data) =>
         Try {
-          val xml = XML.loadString(new String(data)) // parse string to XML
-
+          val xml = XML.load(new ByteArrayInputStream(data))
           val items = handleXML(xml)
 
           val counts = for {
@@ -149,6 +148,8 @@ class OaiFileHarvester(
     val harvestTime = System.currentTimeMillis()
     val unixEpoch = harvestTime / 1000L
     val inFiles = new File(conf.harvest.endpoint.getOrElse("in"))
+    println(s"Harvesting from $inFiles")
+    println(s"${inFiles.listFiles().length} files found")
 
     inFiles
       .listFiles(new ZipFileFilter)

--- a/src/main/scala/dpla/ingestion3/profiles/CHProviderProfiles.scala
+++ b/src/main/scala/dpla/ingestion3/profiles/CHProviderProfiles.scala
@@ -129,7 +129,7 @@ class HathiProfile extends XmlProfile {
 class IlProfile extends XmlProfile {
   type Mapping = IllinoisMapping
 
-  override def getHarvester: Class[OaiHarvester] = classOf[OaiHarvester]
+  override def getHarvester: Class[OaiFileHarvester] = classOf[OaiFileHarvester]
   override def getMapping = new IllinoisMapping
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1049eb5379dadb54729d096226cea192d834c19f  | 
|--------|--------|

### Summary:
Updated `OaiFileHarvester` to use `ByteArrayInputStream` for XML parsing, removed debug print statements, and modified `IlProfile` to use `OaiFileHarvester`.

**Key points**:
- Updated `OaiFileHarvester` in `src/main/scala/dpla/ingestion3/harvesters/file/OaiFileHarvester.scala` to use `ByteArrayInputStream` for XML parsing.
- Removed debug print statements from `OaiFileHarvester.localHarvest` in `src/main/scala/dpla/ingestion3/harvesters/file/OaiFileHarvester.scala`.
- Changed `IlProfile.getHarvester` in `src/main/scala/dpla/ingestion3/profiles/CHProviderProfiles.scala` to return `OaiFileHarvester` instead of `OaiHarvester`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->