### PR TITLE
removed nara filter

### DIFF
--- a/src/main/scala/dpla/ingestion3/executors/WikimediaMetadataExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/WikimediaMetadataExecutor.scala
@@ -11,8 +11,6 @@ import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 import java.time.LocalDateTime
 import scala.util.{Failure, Success, Try}
 
-case class WikimediaMetadata(dplaId: String, wikiMarkup: String)
-
 trait WikimediaMetadataExecutor extends Serializable with WikiMapper {
 
   /** Generate Wiki metadata JSON files from AVRO file
@@ -55,9 +53,8 @@ trait WikimediaMetadataExecutor extends Serializable with WikiMapper {
     // Need to keep this here despite what IntelliJ and Codacy say
     import spark.implicits._
 
-    val aSeq = allowedIds.toSeq
     val enrichedRows =
-      spark.read.format("avro").load(dataIn) //.filter($"dplaUri".isin(aSeq: _*))
+      spark.read.format("avro").load(dataIn)
 
     val enrichResults = enrichedRows.rdd.map(row => {
       Try { ModelConverter.toModel(row) } match {

--- a/src/main/scala/dpla/ingestion3/executors/WikimediaMetadataExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/WikimediaMetadataExecutor.scala
@@ -57,7 +57,7 @@ trait WikimediaMetadataExecutor extends Serializable with WikiMapper {
 
     val aSeq = allowedIds.toSeq
     val enrichedRows =
-      spark.read.format("avro").load(dataIn).filter($"dplaUri".isin(aSeq: _*))
+      spark.read.format("avro").load(dataIn) //.filter($"dplaUri".isin(aSeq: _*))
 
     val enrichResults = enrichedRows.rdd.map(row => {
       Try { ModelConverter.toModel(row) } match {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit eec19d79b69833178ffa4a14f117c6fc43609eb7  | 
|--------|--------|

### Summary:
Removed `dplaUri` filter and `allowedIds` sequence in `WikimediaMetadataExecutor.scala` to process all records from the input AVRO file.

**Key points**:
- Removed `dplaUri` filter in `src/main/scala/dpla/ingestion3/executors/WikimediaMetadataExecutor.scala`.
- Modified `executeWikimediaMetadata` function to read all records from the input AVRO file without filtering by `allowedIds`.
- Commented out the line `filter($"dplaUri".isin(aSeq: _*))`.
- Removed `allowedIds` sequence.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->