### PR TITLE
Added provision to sleep in between requests.

### DIFF
--- a/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
+++ b/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
@@ -176,7 +176,8 @@ case class Harvest(
     // Process NARA ingest using a incremental update of records
     update: Option[String] = None, // Path to delta update records
     previous: Option[String] = None, // Path to previously harvested records
-    deletes: Option[String] = None // Path to deletes
+    deletes: Option[String] = None, // Path to deletes
+    sleep: Option[String] = None
 )
 
 case class i3Conf(

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/OaiHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/OaiHarvester.scala
@@ -26,7 +26,8 @@ class OaiHarvester(
       "setlist" -> conf.harvest.setlist,
       "blacklist" -> conf.harvest.blacklist,
       "endpoint" -> conf.harvest.endpoint,
-      "removeDeleted" -> Some("true")
+      "removeDeleted" -> Some("true"),
+      "sleep" -> conf.harvest.sleep
     ).collect { case (key, Some(value)) => key -> value } // remove None values
 
     // Run harvest.

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/refactor/OaiConfiguration.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/refactor/OaiConfiguration.scala
@@ -47,6 +47,8 @@ case class OaiConfiguration(parameters: Map[String, String]) {
 
   def metadataPrefix: Option[String] = parameters.get("metadataPrefix")
 
+  def sleep: Int = parameters.getOrElse("sleep", "0").toInt
+
   def harvestAllSets: Boolean = parameters
     .get("harvestAllSets")
     .map(_.toLowerCase) match {

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/refactor/OaiMultiPageResponseBuilder.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/refactor/OaiMultiPageResponseBuilder.scala
@@ -5,14 +5,14 @@ import java.net.URL
 import dpla.ingestion3.utils.HttpUtils
 import org.apache.http.client.utils.URIBuilder
 
-import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
 
 class OaiMultiPageResponseBuilder(
     endpoint: String,
     verb: String,
     metadataPrefix: Option[String] = None,
-    set: Option[String] = None
+    set: Option[String] = None,
+    sleep: Int = 0
 ) extends Serializable {
 
   /** Main entry point. Get all pages of results from an OAI feed. OaiPages may
@@ -66,6 +66,9 @@ class OaiMultiPageResponseBuilder(
       // Error building URL
       case Failure(e) => Left(OaiError(e.toString))
       case Success(url) => {
+        if (sleep > 0) {
+          Thread.sleep(sleep)
+        }
         HttpUtils.makeGetRequest(url) match {
           // HTTP error
           case Failure(e) => Left(OaiError(e.toString, Some(url.toString)))

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/refactor/OaiProtocol.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/refactor/OaiProtocol.scala
@@ -11,7 +11,9 @@ class OaiProtocol(oaiConfiguration: OaiConfiguration)
     new OaiMultiPageResponseBuilder(
       endpoint,
       "ListRecords",
-      metadataPrefix
+      metadataPrefix,
+      None,
+      oaiConfiguration.sleep
     ).getResponse.iterator
 
   override def listAllRecordPagesForSet(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 064047781be76e805c0945d7212a4f8b1e929720  | 
|--------|--------|

### Summary:
Added a `sleep` parameter to the OAI harvester configuration to pause between requests, preventing server overload.

**Key points**:
- Added `sleep` parameter to `Harvest` case class in `src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala`.
- Passed `sleep` parameter to `OaiHarvester` in `src/main/scala/dpla/ingestion3/harvesters/oai/OaiHarvester.scala`.
- Added `sleep` method to `OaiConfiguration` in `src/main/scala/dpla/ingestion3/harvesters/oai/refactor/OaiConfiguration.scala`.
- Modified `OaiMultiPageResponseBuilder` in `src/main/scala/dpla/ingestion3/harvesters/oai/refactor/OaiMultiPageResponseBuilder.scala` to use `sleep` parameter for pausing between requests.
- Updated `OaiProtocol` in `src/main/scala/dpla/ingestion3/harvesters/oai/refactor/OaiProtocol.scala` to pass `sleep` parameter to `OaiMultiPageResponseBuilder`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->