### PR TITLE
removed okhttp

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,6 @@ libraryDependencies ++= Seq(
   "org.scalamock" %% "scalamock" % "5.1.0" % "test",
   "com.holdenkarau" %% "spark-testing-base" % "3.5.0_1.4.7" % "test",
   "com.typesafe" % "config" % "1.3.1",
-  "com.squareup.okhttp3" % "okhttp" % "3.8.0",
   "com.opencsv" % "opencsv" % "3.7",
   "net.lingala.zip4j" % "zip4j" % "2.11.5",
   "javax.mail" % "mail" % "1.4.7",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2bb862f9fc23598860cd08c91164c7c10e75f763  | 
|--------|--------|

### Summary:
Removed `com.squareup.okhttp3:okhttp:3.8.0` dependency from `build.sbt`.

**Key points**:
- Removed `com.squareup.okhttp3:okhttp:3.8.0` dependency from `build.sbt`
- No other files or code changes are involved


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->