### PR TITLE
Adds http://rightsstatements.org/vocab/NoC-US/ to eligible rights URIs.

### DIFF
--- a/src/main/scala/dpla/ingestion3/wiki/WikiMapper.scala
+++ b/src/main/scala/dpla/ingestion3/wiki/WikiMapper.scala
@@ -33,6 +33,7 @@ trait WikiMapper extends JsonExtractor {
 
   /** Standardized rightsstatment and creative commons URIs eligible for
     * Wikimedia upload NoC-US http://rightsstatements.org/vocab/NoC-US PDM
+    * http://rightsstatements.org/vocab/NKC/
     * http://creativecommons.org/publicdomain/mark CC0
     * http://creativecommons.org/publicdomain/zero CC-BY
     * http://creativecommons.org/licenses/by CC-BY-SA
@@ -40,6 +41,7 @@ trait WikiMapper extends JsonExtractor {
     */
   protected val wikiEligibleRightsUris = Seq(
     "http://rightsstatements.org/vocab/NoC-US/",
+    "http://rightsstatements.org/vocab/NKC/",
     "http://creativecommons.org/publicdomain/mark/",
     "http://creativecommons.org/publicdomain/zero/",
     "http://creativecommons.org/licenses/by/",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `http://rightsstatements.org/vocab/NKC/` to `wikiEligibleRightsUris` in `WikiMapper`.
> 
>   - **Behavior**:
>     - Adds `http://rightsstatements.org/vocab/NKC/` to `wikiEligibleRightsUris` in `WikiMapper` for Wikimedia upload eligibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for 710a5f6b70d32b9df840dd88477f118b6b6f57eb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->