### PR TITLE
2024-10 performance enhancements

### DIFF
--- a/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
@@ -106,14 +106,6 @@ object IngestRemap
     // Json - l
     executeJsonl(sparkConf, enrichDataOut, baseDataOut, shortName)
 
-    // Wikimedia
-    executeWikimediaMetadata(
-      sparkConf,
-      enrichDataOut,
-      baseDataOut,
-      shortName
-    )
-
     // Email
     Emailer.emailSummary(mapDataOut, shortName, conf)
   }

--- a/src/main/scala/dpla/ingestion3/utils/Utils.scala
+++ b/src/main/scala/dpla/ingestion3/utils/Utils.scala
@@ -61,11 +61,11 @@ object Utils {
     val runDuration = Duration.create(runtime, MILLISECONDS)
     val hr = StringUtils.leftPad(runDuration.toHours.toString, 2, "0")
     val min =
-      StringUtils.leftPad((runDuration.toMinutes % 60).round.toString, 2, "0")
+      StringUtils.leftPad((runDuration.toMinutes % 60).toString, 2, "0")
     val sec =
-      StringUtils.leftPad((runDuration.toSeconds % 60).round.toString, 2, "0")
+      StringUtils.leftPad((runDuration.toSeconds % 60).toString, 2, "0")
     val ms =
-      StringUtils.rightPad((runDuration.toMillis % 1000).round.toString, 3, "0")
+      StringUtils.rightPad((runDuration.toMillis % 1000).toString, 3, "0")
 
     s"$hr:$min:$sec.$ms"
   }
@@ -178,6 +178,7 @@ object Utils {
       .write
       .mode(SaveMode.Overwrite)
       .option("header", "true")
+      .option("compression", "gzip")
       .csv(out)
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Performance enhancements by removing Wikimedia metadata execution and adding gzip compression in CSV output.
> 
>   - **Performance Enhancements**:
>     - Removed `executeWikimediaMetadata` call from `IngestRemap.scala` to streamline processing.
>     - Added gzip compression option in `writeLogsAsCsv` in `Utils.scala` to reduce output file size.
>   - **Code Simplification**:
>     - Removed unnecessary `.round` calls in `formatRuntime` in `Utils.scala` for more accurate time formatting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for fc56d88fb74ca9445ad228f8d67daa1fbd16a783. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->