### PR TITLE
made jsonl writes use gzip compression.

### DIFF
--- a/src/main/scala/dpla/ingestion3/executors/JsonlExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/JsonlExecutor.scala
@@ -64,7 +64,7 @@ trait JsonlExecutor extends Serializable {
     // This should always write out as #text() because if we use #json() then the
     // data will be written out inside a JSON object (e.g. {'value': <doc>}) which is
     // invalid for our use
-    indexRecords.write.text(outputPath)
+    indexRecords.write.option("compression", "gzip").text(outputPath)
 
     // Create and write manifest.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds gzip compression to JSONL file writes in `JsonlExecutor.scala`.
> 
>   - **Behavior**:
>     - Adds gzip compression to JSONL file writes in `JsonlExecutor.scala` by setting `option("compression", "gzip")` in `indexRecords.write.text(outputPath)`.
>   - **Misc**:
>     - No other changes or refactoring in the code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for 5a5ac38b71e12cd942a543d2ba4ca0b320802cc8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->