### PR TITLE
Fixed hardcoded minnesota endpoint.

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/api/MdlHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/MdlHarvester.scala
@@ -25,8 +25,10 @@ class MdlHarvester(
   protected val defaultQuery = "*:*"
 
   override protected val queryParams: Map[String, String] = Map(
+    "endpoint" -> conf.harvest.endpoint.getOrElse(""),
     "query" -> conf.harvest.query.getOrElse(defaultQuery),
-    "rows" -> conf.harvest.rows.getOrElse(defaultRows)
+    "rows" -> conf.harvest.rows.getOrElse(defaultRows),
+
   )
 
   override def localHarvest(): DataFrame = {
@@ -132,10 +134,7 @@ class MdlHarvester(
     *   URI
     */
   def getFirstUrl(queryParams: Map[String, String]): String = {
-    val url = new URIBuilder()
-      .setScheme("https")
-      .setHost("lib-metl-prd-01.oit.umn.edu")
-      .setPath("/api/v2/records")
+    val url = new URIBuilder(queryParams.getOrElse("endpoint", ""))
       .setParameter("page[size]", queryParams.getOrElse("rows", defaultRows))
 
     /** This is a real mangling. The configuration file does not really support


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removed hardcoded endpoint in `MdlHarvester` and made it configurable via `queryParams`.
> 
>   - **Behavior**:
>     - Removed hardcoded endpoint URL in `getFirstUrl()` in `MdlHarvester.scala`.
>     - Endpoint is now configurable via `queryParams` map using `conf.harvest.endpoint`.
>   - **Configuration**:
>     - Added `endpoint` to `queryParams` map in `MdlHarvester.scala`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for 61e9873430b53fb4c26490dd69435171afc6ac42. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->