### PR TITLE
Gets rid of harmless jline warning when running with sbt.

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 #temporary not latest because 24 is broken
     steps:
       - uses: actions/checkout@v4
       - name: Setup JDK
@@ -12,5 +12,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
+          cache: sbt
       - name: Run tests
         run: sbt clean compile test

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.3


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `sbt.version` and modify CI workflow to fix jline warning and address Ubuntu version issues.
> 
>   - **Build Configuration**:
>     - Update `sbt.version` in `build.properties` from `1.9.9` to `1.10.3` to remove a harmless jline warning.
>   - **CI Workflow**:
>     - Change `runs-on` in `.github/workflows/scala.yml` from `ubuntu-latest` to `ubuntu-22.04` due to issues with version 24.
>     - Add `cache: sbt` to the `Setup JDK` step in `.github/workflows/scala.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for 60591b75e3f1f4fced9f0574b9c8447d23ce2630. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->