### PR TITLE
Gets rid of NoSuchFileException at exit when running a spark job in sbt.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ name := "ingestion3"
 organization := "dpla"
 version := "0.0.1"
 scalaVersion := "2.13.13"
+fork  := true
+outputStrategy := Some(StdoutOutput)
 val SPARK_VERSION = "3.5.1"
 
 ThisBuild / Test / parallelExecution := false


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `fork` and `outputStrategy` in `build.sbt` to prevent `NoSuchFileException` at Spark job exit.
> 
>   - **Configuration**:
>     - Set `fork := true` in `build.sbt` to run Spark jobs in a separate process.
>     - Set `outputStrategy := Some(StdoutOutput)` in `build.sbt` to direct output to standard output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for 571ec58e171c5f7fe648c89a4c7e0f96fb8c562a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->