### PR TITLE
Suppressed spark-originating unsafe warnings.

### DIFF
--- a/src/main/scala/dpla/ingestion3/entries/Entry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/Entry.scala
@@ -1,0 +1,7 @@
+package dpla.ingestion3.entries
+
+import java.lang.annotation.Target
+
+object Entry {
+  def suppressUnsafeWarnings(): Unit = classOf[Target].getModule.addOpens("java.nio", classOf[org.apache.spark.unsafe.Platform].getModule)
+}

--- a/src/main/scala/dpla/ingestion3/entries/ingest/EnrichEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/EnrichEntry.scala
@@ -1,6 +1,7 @@
 package dpla.ingestion3.entries.ingest
 
 import dpla.ingestion3.confs.{CmdArgs, Ingestion3Conf, i3Conf}
+import dpla.ingestion3.entries.Entry
 import dpla.ingestion3.executors.EnrichExecutor
 import org.apache.spark.SparkConf
 
@@ -17,6 +18,8 @@ import org.apache.spark.SparkConf
 object EnrichEntry extends EnrichExecutor {
 
   def main(args: Array[String]): Unit = {
+
+    Entry.suppressUnsafeWarnings()
 
     // Read in command line args
     val cmdArgs = new CmdArgs(args)

--- a/src/main/scala/dpla/ingestion3/entries/ingest/HarvestEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/HarvestEntry.scala
@@ -1,6 +1,7 @@
 package dpla.ingestion3.entries.ingest
-
+import java.lang.annotation.Target
 import dpla.ingestion3.confs.{CmdArgs, Ingestion3Conf, i3Conf}
+import dpla.ingestion3.entries.Entry
 import dpla.ingestion3.executors.HarvestExecutor
 import org.apache.spark.SparkConf
 
@@ -14,6 +15,8 @@ import org.apache.spark.SparkConf
 object HarvestEntry extends HarvestExecutor {
 
   def main(args: Array[String]): Unit = {
+
+    Entry.suppressUnsafeWarnings()
 
     // Read in command line args.
     val cmdArgs = new CmdArgs(args)

--- a/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/IngestRemap.scala
@@ -2,6 +2,7 @@ package dpla.ingestion3.entries.ingest
 
 import dpla.ingestion3.confs.{CmdArgs, Ingestion3Conf}
 import dpla.ingestion3.dataStorage.InputHelper
+import dpla.ingestion3.entries.Entry
 import dpla.ingestion3.executors._
 import dpla.ingestion3.utils.Emailer
 import org.apache.logging.log4j.LogManager
@@ -49,6 +50,8 @@ object IngestRemap
     with WikimediaMetadataExecutor {
 
   def main(args: Array[String]): Unit = {
+
+    Entry.suppressUnsafeWarnings()
 
     val logger = LogManager.getLogger(this.getClass)
 

--- a/src/main/scala/dpla/ingestion3/entries/ingest/JsonlEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/JsonlEntry.scala
@@ -1,6 +1,7 @@
 package dpla.ingestion3.entries.ingest
 
 import dpla.ingestion3.confs.CmdArgs
+import dpla.ingestion3.entries.Entry
 import dpla.ingestion3.executors.JsonlExecutor
 import org.apache.spark.SparkConf
 
@@ -20,6 +21,8 @@ import org.apache.spark.SparkConf
 object JsonlEntry extends JsonlExecutor {
 
   def main(args: Array[String]): Unit = {
+
+    Entry.suppressUnsafeWarnings()
 
     // Read in command line args.
     val cmdArgs = new CmdArgs(args)

--- a/src/main/scala/dpla/ingestion3/entries/ingest/MappingEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/ingest/MappingEntry.scala
@@ -1,6 +1,7 @@
 package dpla.ingestion3.entries.ingest
 
 import dpla.ingestion3.confs.{CmdArgs, Ingestion3Conf, i3Conf}
+import dpla.ingestion3.entries.Entry
 import dpla.ingestion3.executors.MappingExecutor
 import org.apache.spark.SparkConf
 
@@ -17,6 +18,9 @@ import org.apache.spark.SparkConf
 object MappingEntry extends MappingExecutor {
 
   def main(args: Array[String]): Unit = {
+
+    Entry.suppressUnsafeWarnings()
+
     // Read in command line args.
     val cmdArgs = new CmdArgs(args)
 

--- a/src/main/scala/dpla/ingestion3/entries/utils/DeleteEntry.scala
+++ b/src/main/scala/dpla/ingestion3/entries/utils/DeleteEntry.scala
@@ -2,6 +2,7 @@ package dpla.ingestion3.entries.utils
 
 import dpla.ingestion3.confs.CmdArgs
 import dpla.ingestion3.dataStorage.InputHelper
+import dpla.ingestion3.entries.Entry
 import dpla.ingestion3.executors.DeleteExecutor
 import dpla.ingestion3.utils.Utils
 import org.apache.spark.SparkConf
@@ -23,6 +24,8 @@ import org.apache.spark.SparkConf
 object DeleteEntry extends DeleteExecutor {
 
   def main(args: Array[String]): Unit = {
+
+    Entry.suppressUnsafeWarnings()
 
     // Read in command line args.
     val cmdArgs = new CmdArgs(args)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added `suppressUnsafeWarnings()` in `Entry` to suppress Spark warnings, invoked in multiple entry classes.
> 
>   - **Behavior**:
>     - Added `suppressUnsafeWarnings()` method in `Entry` object to suppress Spark-originating unsafe warnings.
>     - Invoked `suppressUnsafeWarnings()` in `main()` of `EnrichEntry`, `HarvestEntry`, `IngestRemap`, `JsonlEntry`, `MappingEntry`, and `DeleteEntry` to suppress warnings.
>   - **Files**:
>     - `Entry.scala`: New file with `suppressUnsafeWarnings()` method.
>     - `EnrichEntry.scala`, `HarvestEntry.scala`, `IngestRemap.scala`: Updated to call `suppressUnsafeWarnings()`.
>     - `JsonlEntry.scala`, `MappingEntry.scala`, `DeleteEntry.scala`: Updated to call `suppressUnsafeWarnings()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for 6c29ccc9a2f979ecf725fc20fbf1445f7e5cd25e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->