### PR TITLE
Ignores noRecordsMatch code during xml parsing

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/oai/refactor/OaiXmlParser.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/refactor/OaiXmlParser.scala
@@ -48,7 +48,7 @@ object OaiXmlParser {
 
   def containsError(xml: Node): Unit = {
     val error = xml \ "error"
-    if (error.nonEmpty)
+    if (error.nonEmpty && error \@ "code" != "noRecordsMatch"  )
       throw new RuntimeException("Error in OAI response: " + error.text)
   }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `containsError` in `OaiXmlParser.scala` to ignore `noRecordsMatch` error code, preventing exceptions.
> 
>   - **Behavior**:
>     - Update `containsError` in `OaiXmlParser.scala` to ignore `noRecordsMatch` error code during XML parsing.
>     - Prevents `RuntimeException` for `noRecordsMatch` code, allowing processing to continue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for 21119274da4b555b0204917f69b6be2b4be93b47. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->