### PR TITLE
Fixed propagating of sleep config for oai

### DIFF
--- a/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
+++ b/src/main/scala/dpla/ingestion3/confs/Ingestion3Conf.scala
@@ -58,7 +58,8 @@ class Ingestion3Conf(confFilePath: String, providerName: Option[String] = None)
         // Properties for FileDelta harvests
         update = getProp(providerConf, "harvest.delta.update"),
         previous = getProp(providerConf, "harvest.delta.previous"),
-        deletes = getProp(providerConf, "harvest.delta.deletes")
+        deletes = getProp(providerConf, "harvest.delta.deletes"),
+        sleep = getProp(providerConf, "harvest.sleep")
       ),
       i3Spark(
         // FIXME these should be removed

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/LocalOaiHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/LocalOaiHarvester.scala
@@ -28,7 +28,8 @@ class LocalOaiHarvester(
     "setlist" -> conf.harvest.setlist,
     "blacklist" -> conf.harvest.blacklist,
     "endpoint" -> conf.harvest.endpoint,
-    "removeDeleted" -> Some("true")
+    "removeDeleted" -> Some("true"),
+    "sleep" -> conf.harvest.sleep
   ).collect { case (key, Some(value)) => key -> value }
 
   private val oaiConfig = OaiConfiguration(readerOptions)

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/refactor/OaiProtocol.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/refactor/OaiProtocol.scala
@@ -23,18 +23,17 @@ class OaiProtocol(oaiConfiguration: OaiConfiguration)
   override def listAllRecordPagesForSet(
       set: OaiSet
   ): IterableOnce[OaiPage] = {
-
-    logger.info("IN: listAllRecordPagesForSet {}", set)
     new OaiMultiPageResponseBuilder(
       endpoint,
       "ListRecords",
       metadataPrefix,
-      Some(set.id)
+      Some(set.id),
+      oaiConfiguration.sleep
     ).getResponse.iterator
   }
 
   override def listAllSetPages(): IterableOnce[OaiPage] = {
-    new OaiMultiPageResponseBuilder(endpoint, "ListSets").getResponse.iterator
+    new OaiMultiPageResponseBuilder(endpoint, "ListSets", None, None, oaiConfiguration.sleep).getResponse.iterator
   }
 
   override def parsePageIntoRecords(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `sleep` configuration to OAI harvesting process, updating `Ingestion3Conf`, `LocalOaiHarvester`, and `OaiProtocol`.
> 
>   - **Configuration**:
>     - Add `sleep` property to `Harvest` in `Ingestion3Conf.scala`.
>   - **Harvester**:
>     - Pass `sleep` configuration to `readerOptions` in `LocalOaiHarvester.scala`.
>   - **Protocol**:
>     - Update `OaiProtocol` to use `sleep` in `listAllRecordPages`, `listAllRecordPagesForSet`, and `listAllSetPages`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for 5943258c02d5d7f80d7c23bd24bf9c67e51b921b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->