### PR TITLE
Dependency upgrade dec 2024

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,10 +2,10 @@
 name := "ingestion3"
 organization := "dpla"
 version := "0.0.1"
-scalaVersion := "2.13.13"
+scalaVersion := "2.13.15"
 fork  := true
 outputStrategy := Some(StdoutOutput)
-val SPARK_VERSION = "3.5.1"
+val SPARK_VERSION = "3.5.3"
 
 ThisBuild / Test / parallelExecution := false
 
@@ -19,18 +19,18 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-sql" % SPARK_VERSION,
   "org.apache.spark" %% "spark-avro" % SPARK_VERSION,
   "org.apache.spark" %% "spark-hadoop-cloud" % SPARK_VERSION,
-  "org.eclipse.rdf4j" % "rdf4j" % "2.2",
-  "org.eclipse.rdf4j" % "rdf4j-model" % "2.2",
-  "org.jsoup" % "jsoup" % "1.17.2",
-  "org.apache.commons" % "commons-text" % "1.11.0",
-  "org.rogach" % "scallop_2.13" % "5.1.0",
-  "org.scalamock" %% "scalamock" % "5.1.0" % "test",
-  "com.holdenkarau" %% "spark-testing-base" % "3.5.0_1.4.7" % "test",
-  "com.typesafe" % "config" % "1.3.1",
-  "com.opencsv" % "opencsv" % "3.7",
+  "org.eclipse.rdf4j" % "rdf4j" % "5.1.0",
+  "org.eclipse.rdf4j" % "rdf4j-model" % "5.1.0",
+  "org.jsoup" % "jsoup" % "1.18.3",
+  "org.apache.commons" % "commons-text" % "1.12.0",
+  "org.rogach" % "scallop_2.13" % "5.2.0",
+  "org.scalamock" %% "scalamock" % "6.0.0" % "test",
+  "com.holdenkarau" %% "spark-testing-base" % "3.5.3_2.0.1" % "test",
+  "com.typesafe" % "config" % "1.4.3",
+  "com.opencsv" % "opencsv" % "5.9",
   "net.lingala.zip4j" % "zip4j" % "2.11.5",
   "javax.mail" % "mail" % "1.4.7",
-  "org.apache.ant" % "ant" % "1.8.0",
+  "org.apache.ant" % "ant" % "1.10.15",
   "org.apache.ant" % "ant-compress" % "1.5"
 )
 

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/refactor/AllRecordsOaiRelation.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/refactor/AllRecordsOaiRelation.scala
@@ -36,7 +36,7 @@ class AllRecordsOaiRelation(
 
     val eitherRdd = csvRdd.map(handleCsvRow)
     val pagesEitherRdd = eitherRdd.flatMap(
-      oaiMethods.parsePageIntoRecords(_, oaiConfiguration.removeDeleted)
+      oaiMethods.parsePageIntoRecords(_, oaiConfiguration.removeDeleted())
     )
     pagesEitherRdd.map(OaiRelation.convertToOutputRow)
   }
@@ -52,13 +52,15 @@ class AllRecordsOaiRelation(
 
   private[refactor] def cacheTempFile(tempFile: File): Unit = {
     //
-    def t(n: Object*) = n
+    def t(n: Object*): Seq[Object] = n
 
     val writer = new CSVWriter(
       new FileWriter(tempFile),
       ',',
-      CSVWriter.DEFAULT_QUOTE_CHARACTER,
-      '\\'
+      '"',
+      '\\',
+      "\n"
+
     )
 
     try {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Upgrade dependencies in `build.sbt` and adjust method call in `AllRecordsOaiRelation.scala`.
> 
>   - **Dependencies**:
>     - Upgrade `scalaVersion` to `2.13.15` and `SPARK_VERSION` to `3.5.3` in `build.sbt`.
>     - Update library versions: `rdf4j` to `5.1.0`, `jsoup` to `1.18.3`, `commons-text` to `1.12.0`, `scallop_2.13` to `5.2.0`, `scalamock` to `6.0.0`, `spark-testing-base` to `3.5.3_2.0.1`, `config` to `1.4.3`, `opencsv` to `5.9`, and `ant` to `1.10.15`.
>   - **Code Changes**:
>     - Modify `parsePageIntoRecords` call in `AllRecordsOaiRelation.scala` to use `oaiConfiguration.removeDeleted()` instead of `oaiConfiguration.removeDeleted`.
>     - Adjust `CSVWriter` instantiation in `cacheTempFile` to include newline character `"\n"`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for 8df660da31a176a5cb122b867f8499c70b5ab85e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->