### PR TITLE
set up codacy coverage

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -19,6 +19,6 @@ jobs:
         uses: codacy/codacy-coverage-reporter-action@v1.3.0
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: target/scala-2.13/scoverage-data/scoverage.coverage
+          #coverage-reports: target/scala-2.13/scoverage-data/scoverage.coverage
           # or a comma-separated list for multiple reports
           # coverage-reports: <PATH_TO_REPORT>, <PATH_TO_REPORT>

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -14,4 +14,11 @@ jobs:
           java-version: 11
           cache: sbt
       - name: Run tests
-        run: sbt clean compile test
+        run: sbt clean coverage test coverageReport
+      - name: Codacy Coverage Reporter
+        uses: codacy/codacy-coverage-reporter-action@v1.3.0
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: target/scala-2.13/scoverage-data/scoverage.coverage
+          # or a comma-separated list for multiple reports
+          # coverage-reports: <PATH_TO_REPORT>, <PATH_TO_REPORT>

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -16,9 +16,6 @@ jobs:
       - name: Run tests
         run: sbt clean coverage test coverageReport
       - name: Codacy Coverage Reporter
-        uses: codacy/codacy-coverage-reporter-action@v1.3.0
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          #coverage-reports: target/scala-2.13/scoverage-data/scoverage.coverage
-          # or a comma-separated list for multiple reports
-          # coverage-reports: <PATH_TO_REPORT>, <PATH_TO_REPORT>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
 resolvers += "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/"
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
-addSbtPlugin("com.codacy" % "sbt-codacy-coverage" % "3.0.3")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Set up Codacy coverage reporting by updating GitHub Actions and SBT plugins for a Scala project.
> 
>   - **GitHub Actions**:
>     - Update `.github/workflows/scala.yml` to include Codacy coverage reporting.
>     - Add `Codacy Coverage Reporter` step using `codacy/codacy-coverage-reporter-action@v1.3.0`.
>     - Modify test step to run `sbt clean coverage test coverageReport`.
>   - **SBT Plugins**:
>     - Update `sbt-scoverage` plugin to version `2.2.2` in `plugins.sbt`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for 5ff172ca734453172bc39a536e8676e909742b28. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->