### PR TITLE
Fixed LazyList for Oai Files.

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/file/OaiFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/OaiFileHarvester.scala
@@ -151,13 +151,13 @@ class OaiFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        for (result <- iter(inputStream)) {
+        iter(inputStream).foreach(result => {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               logger.error(s"Caught exception on $inFile.", exception)
             case Success(_) => //do nothing
           }
-        }
+        })
         IOUtils.closeQuietly(inputStream)
       })
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `localHarvest()` in `OaiFileHarvester.scala` to use `foreach` instead of `for` loop for `LazyList` processing.
> 
>   - **Refactor**:
>     - Change `for` loop to `foreach` in `localHarvest()` method of `OaiFileHarvester.scala` for processing `LazyList` elements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for f992060a878f139918a20d0f77a22933a73f52bc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->