### PR TITLE
Fixes for LazyList for all the harvesters.

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/file/CommunityWebsHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/CommunityWebsHarvester.scala
@@ -138,7 +138,7 @@ class CommunityWebsHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        for (result <- iter(inputStream))  {
+        iter(inputStream).foreach(result =>  {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager
@@ -146,7 +146,7 @@ class CommunityWebsHarvester(
                 .error(s"Caught exception on $inFile.", exception)
             case _ => // do nothing
           }
-        }
+        })
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/CommunityWebsHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/CommunityWebsHarvester.scala
@@ -105,26 +105,6 @@ class CommunityWebsHarvester(
     }
   }
 
-  /** Implements a stream of files from the zip Can't use @tailrec here because
-    * the compiler can't recognize it as tail recursive, but this won't blow the
-    * stack.
-    *
-    * @param zipInputStream
-    * @return
-    *   Lazy stream of zip records
-    */
-  def iter(zipInputStream: ZipInputStream): LazyList[FileResult] =
-    Option(zipInputStream.getNextEntry) match {
-      case None =>
-        LazyList.empty
-      case Some(entry) =>
-        val result =
-          if (entry.isDirectory)
-            None
-          else
-            Some(new BufferedReader(new InputStreamReader(zipInputStream)))
-        FileResult(entry.getName, None, result) #:: iter(zipInputStream)
-    }
 
   override def localHarvest(): DataFrame = {
     val harvestTime = System.currentTimeMillis()
@@ -138,7 +118,7 @@ class CommunityWebsHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        iter(inputStream).foreach(result =>  {
+        FileHarvester.iter(inputStream).foreach(result =>  {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager

--- a/src/main/scala/dpla/ingestion3/harvesters/file/DlgFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/DlgFileHarvester.scala
@@ -107,26 +107,6 @@ class DlgFileHarvester(
         }
     }
 
-  /** Implements a stream of files from the zip Can't use @tailrec here because
-    * the compiler can't recognize it as tail recursive, but this won't blow the
-    * stack.
-    *
-    * @param zipInputStream ZipInputStream from the zip file
-    * @return
-    *   Lazy stream of zip records
-    */
-  def iter(zipInputStream: ZipInputStream): LazyList[FileResult] =
-    Option(zipInputStream.getNextEntry) match {
-      case None =>
-        LazyList.empty
-      case Some(entry) =>
-        val result =
-          if (entry.isDirectory)
-            None
-          else
-            Some(new BufferedReader(new InputStreamReader(zipInputStream)))
-        FileResult(entry.getName, None, result) #:: iter(zipInputStream)
-    }
 
   /** Executes the Georgia harvest
     */
@@ -142,7 +122,7 @@ class DlgFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        iter(inputStream).foreach(result => {
+        FileHarvester.iter(inputStream).foreach(result => {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager

--- a/src/main/scala/dpla/ingestion3/harvesters/file/DplaJsonlFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/DplaJsonlFileHarvester.scala
@@ -112,27 +112,6 @@ class DplaJsonlFileHarvester(
     }
   }
 
-  /** Implements a stream of files from the zip Can't use @tailrec here because
-    * the compiler can't recognize it as tail recursive, but this won't blow the
-    * stack.
-    *
-    * @param zipInputStream
-    * @return
-    *   Lazy stream of zip records
-    */
-  def iter(zipInputStream: ZipInputStream): LazyList[FileResult] =
-    Option(zipInputStream.getNextEntry) match {
-      case None =>
-        LazyList.empty
-      case Some(entry) =>
-        val result =
-          if (entry.isDirectory)
-            None
-          else
-            Some(new BufferedReader(new InputStreamReader(zipInputStream)))
-        FileResult(entry.getName, None, result) #:: iter(zipInputStream)
-    }
-
   /** Executes the DPLA JSON file harvest
     */
   override def localHarvest(): DataFrame = {
@@ -147,7 +126,7 @@ class DplaJsonlFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        iter(inputStream).foreach( result => {
+        FileHarvester.iter(inputStream).foreach( result => {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager

--- a/src/main/scala/dpla/ingestion3/harvesters/file/DplaJsonlFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/DplaJsonlFileHarvester.scala
@@ -147,7 +147,7 @@ class DplaJsonlFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        for (result <- iter(inputStream)) yield {
+        iter(inputStream).foreach( result => {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager
@@ -155,7 +155,7 @@ class DplaJsonlFileHarvester(
                 .error(s"Caught exception on $inFile.", exception)
             case _ => //do nothing
           }
-        }
+        })
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/FileFilters.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/FileFilters.scala
@@ -11,4 +11,5 @@ object FileFilters {
   val gzFilter: FileFilter = newFilter("gz")
   val xmlFilter: FileFilter = newFilter("xml")
   val zipFilter: FileFilter = newFilter("zip")
+  val txtFilter: FileFilter = newFilter("txt")
 }

--- a/src/main/scala/dpla/ingestion3/harvesters/file/FlFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/FlFileHarvester.scala
@@ -111,27 +111,6 @@ class FlFileHarvester(
     }
   }
 
-  /** Implements a stream of files from the zip Can't use @tailrec here because
-    * the compiler can't recognize it as tail recursive, but this won't blow the
-    * stack.
-    *
-    * @param zipInputStream
-    * @return
-    *   Lazy stream of zip records
-    */
-  def iter(zipInputStream: ZipInputStream): LazyList[FileResult] =
-    Option(zipInputStream.getNextEntry) match {
-      case None =>
-        LazyList.empty
-      case Some(entry) =>
-        val result =
-          if (entry.isDirectory)
-            None
-          else
-            Some(new BufferedReader(new InputStreamReader(zipInputStream)))
-        FileResult(entry.getName, None, result) #:: iter(zipInputStream)
-    }
-
   /** Executes the Florida harvest
     */
   override def localHarvest(): DataFrame = {
@@ -146,7 +125,7 @@ class FlFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        iter(inputStream).foreach(result => {
+        FileHarvester.iter(inputStream).foreach(result => {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager.getLogger(this.getClass).error(s"Caught exception on $inFile.", exception)

--- a/src/main/scala/dpla/ingestion3/harvesters/file/FlFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/FlFileHarvester.scala
@@ -146,13 +146,13 @@ class FlFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        for (result <- iter(inputStream)) yield {
+        iter(inputStream).foreach(result => {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager.getLogger(this.getClass).error(s"Caught exception on $inFile.", exception)
             case _ => //do nothing
           }
-        }
+        })
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/HathiFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/HathiFileHarvester.scala
@@ -129,7 +129,7 @@ class HathiFileHarvester(
             )
           )
 
-        for (tarResult <- iter(inputStream)) yield {
+        iter(inputStream).foreach(tarResult => {
           handleFile(tarResult, unixEpoch) match {
             case Failure(exception) =>
               logger
@@ -139,7 +139,7 @@ class HathiFileHarvester(
                 )
             case _ => //do nothing
           }
-        }
+        })
 
         IOUtils.closeQuietly(inputStream)
       })

--- a/src/main/scala/dpla/ingestion3/harvesters/file/HeartlandFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/HeartlandFileHarvester.scala
@@ -145,7 +145,7 @@ class HeartlandFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        for (result <- iter(inputStream)) yield {
+        iter(inputStream).foreach(result =>
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager
@@ -153,7 +153,7 @@ class HeartlandFileHarvester(
                 .error(s"Caught exception on $inFile.", exception)
             case _ => //do nothing
           }
-        }
+        )
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/HeartlandFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/HeartlandFileHarvester.scala
@@ -110,26 +110,6 @@ class HeartlandFileHarvester(
     }
   }
 
-  /** Implements a stream of files from the zip Can't use @tailrec here because
-    * the compiler can't recognize it as tail recursive, but this won't blow the
-    * stack.
-    *
-    * @param zipInputStream
-    * @return
-    *   Lazy stream of zip records
-    */
-  def iter(zipInputStream: ZipInputStream): LazyList[FileResult] =
-    Option(zipInputStream.getNextEntry) match {
-      case None =>
-        LazyList.empty
-      case Some(entry) =>
-        val result =
-          if (entry.isDirectory)
-            None
-          else
-            Some(new BufferedReader(new InputStreamReader(zipInputStream)))
-        FileResult(entry.getName, None, result) #:: iter(zipInputStream)
-    }
 
   /** Executes the Heartland (Missouri + Iowa) harvest
     */
@@ -145,7 +125,7 @@ class HeartlandFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        iter(inputStream).foreach(result =>
+        FileHarvester.iter(inputStream).foreach(result =>
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NYPLFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NYPLFileHarvester.scala
@@ -155,13 +155,13 @@ class NYPLFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        for (result <- iter(inputStream)) {
+        iter(inputStream).foreach( result =>
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager.getLogger(this.getClass).error(s"Caught exception on $inFile.", exception)
             case Success(_) => // do nothing
           }
-        }
+        )
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NaraDeltaHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NaraDeltaHarvester.scala
@@ -256,7 +256,7 @@ class NaraDeltaHarvester(
         )
       )
 
-    val recordCount = (for (tarResult <- iter(inputStream)) yield {
+    val recordCount = iter(inputStream).map(tarResult =>
       handleFile(tarResult, unixEpoch, file.getName) match {
         case Failure(exception) =>
           val logger = LogManager.getLogger(this.getClass)
@@ -266,7 +266,7 @@ class NaraDeltaHarvester(
         case Success(count) =>
           count
       }
-    }).sum
+    ).sum
 
     logger.info(s"Harvested $recordCount records from ${file.getName}")
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NaraFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NaraFileHarvester.scala
@@ -310,7 +310,7 @@ class NaraFileHarvester(
         )
       )
 
-    val recordCount = (for (tarResult <- iter(inputStream)) yield {
+    val recordCount = iter(inputStream).map(tarResult =>
       handleFile(tarResult, unixEpoch, file.getName) match {
         case Failure(exception) =>
           val logger = LogManager.getLogger(this.getClass)
@@ -319,8 +319,7 @@ class NaraFileHarvester(
           0
         case Success(count) =>
           count
-      }
-    }).sum
+      }).sum
 
     val logger = LogManager.getLogger(this.getClass)
     logger.info(s"Harvested $recordCount records from ${file.getName}")

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NorthwestHeritageFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NorthwestHeritageFileHarvester.scala
@@ -38,9 +38,6 @@ class NorthwestHeritageFileHarvester(
     * @return
     *   ZipInputstream of the zip contents
     *
-    * TODO: Because we're only handling zips in this class, and they should
-    * already be filtered by the FilenameFilter, I wonder if we even need the
-    * match statement here.
     */
   def getInputStream(file: File): Option[ZipInputStream] = {
     file.getName match {
@@ -150,17 +147,17 @@ class NorthwestHeritageFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        val recordCount = iter(inputStream).map(result =>
+        FileHarvester.iter(inputStream).foreach(result =>
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager
                 .getLogger(this.getClass)
                 .error(s"Caught exception on $inFile.", exception)
-              0
-            case Success(count) =>
-              count
+
+            case Success(count) => ()
+
           }
-        ).sum
+        )
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NorthwestHeritageFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NorthwestHeritageFileHarvester.scala
@@ -150,7 +150,7 @@ class NorthwestHeritageFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        val recordCount = (for (result <- iter(inputStream)) yield {
+        val recordCount = iter(inputStream).map(result =>
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager
@@ -160,7 +160,7 @@ class NorthwestHeritageFileHarvester(
             case Success(count) =>
               count
           }
-        }).sum
+        ).sum
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/OaiFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/OaiFileHarvester.scala
@@ -42,13 +42,12 @@ class OaiFileHarvester(
     * already be filtered by the FilenameFilter, I wonder if we even need the
     * match statement here.
     */
-  def getInputStream(file: File): Option[ZipInputStream] = {
+  def getInputStream(file: File): Option[ZipInputStream] =
     file.getName match {
       case zipName if zipName.endsWith("zip") =>
         Some(new ZipInputStream(new FileInputStream(file)))
       case _ => None
     }
-  }
 
   /** Main logic for handling individual entries in the zip.
     *
@@ -151,13 +150,13 @@ class OaiFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        iter(inputStream).foreach(result => {
+        iter(inputStream).foreach(result =>
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               logger.error(s"Caught exception on $inFile.", exception)
             case Success(_) => //do nothing
           }
-        })
+        )
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/OaiFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/OaiFileHarvester.scala
@@ -38,9 +38,6 @@ class OaiFileHarvester(
     * @return
     *   ZipInputstream of the zip contents
     *
-    * TODO: Because we're only handling zips in this class, and they should
-    * already be filtered by the FilenameFilter, I wonder if we even need the
-    * match statement here.
     */
   def getInputStream(file: File): Option[ZipInputStream] =
     file.getName match {
@@ -150,7 +147,7 @@ class OaiFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        iter(inputStream).foreach(result =>
+        FileHarvester.iter(inputStream).foreach(result =>
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               logger.error(s"Caught exception on $inFile.", exception)

--- a/src/main/scala/dpla/ingestion3/harvesters/file/SiFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/SiFileHarvester.scala
@@ -125,7 +125,7 @@ class SiFileHarvester(
   private def getExpectedFileCounts(inFiles: File): Map[String, String] = {
     var loadCounts = Map[String, String]()
     inFiles
-      .listFiles(new TxtFileFilter)
+      .listFiles(FileFilters.txtFilter)
       .foreach(file => {
         Using(Source
           .fromFile(file)) { source =>
@@ -234,7 +234,3 @@ class SiFileHarvester(
 
 }
 
-class TxtFileFilter extends FileFilter {
-  override def accept(pathname: File): Boolean =
-    pathname.getName.endsWith("txt")
-}

--- a/src/main/scala/dpla/ingestion3/harvesters/file/VaFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/VaFileHarvester.scala
@@ -41,13 +41,12 @@ class VaFileHarvester(
     * already be filtered by the FilenameFilter, I wonder if we even need the
     * match statement here.
     */
-  def getInputStream(file: File): Option[ZipInputStream] = {
+  def getInputStream(file: File): Option[ZipInputStream] =
     file.getName match {
       case zipName if zipName.endsWith("zip") =>
         Some(new ZipInputStream(new FileInputStream(file)))
       case _ => None
     }
-  }
 
   /** Main logic for handling individual entries in the zip.
     *
@@ -113,17 +112,16 @@ class VaFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        val recordCount = (for (result <- iter(inputStream)) yield {
+        iter(inputStream).foreach(result => {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager
                 .getLogger(this.getClass)
                 .error(s"Caught exception on $inFile.", exception)
-              0
             case Success(count) =>
               count
           }
-        }).sum
+        })
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/VaFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/VaFileHarvester.scala
@@ -37,9 +37,6 @@ class VaFileHarvester(
     * @return
     *   ZipInputstream of the zip contents
     *
-    * TODO: Because we're only handling zips in this class, and they should
-    * already be filtered by the FilenameFilter, I wonder if we even need the
-    * match statement here.
     */
   def getInputStream(file: File): Option[ZipInputStream] =
     file.getName match {
@@ -76,28 +73,6 @@ class VaFileHarvester(
         }
     }
 
-  /** Implements a stream of files from the zip Can't use @tailrec here because
-    * the compiler can't recognize it as tail recursive, but this won't blow the
-    * stack.
-    *
-    * @param zipInputStream
-    * @return
-    *   Lazy stream of zip records
-    */
-  def iter(zipInputStream: ZipInputStream): LazyList[FileResult] =
-    Option(zipInputStream.getNextEntry) match {
-      case None =>
-        LazyList.empty
-      case Some(entry) =>
-        val result =
-          if (entry.isDirectory || !entry.getName.endsWith(".xml"))
-            None
-          else {
-            Some(IOUtils.toByteArray(zipInputStream, entry.getSize))
-          }
-        FileResult(entry.getName, result) #:: iter(zipInputStream)
-    }
-
   /** Executes the Digital Virginias harvest
     */
   override def localHarvest(): DataFrame = {
@@ -112,7 +87,7 @@ class VaFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        iter(inputStream).foreach(result => {
+        FileHarvester.iter(inputStream).foreach(result => {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager

--- a/src/main/scala/dpla/ingestion3/harvesters/file/VtFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/VtFileHarvester.scala
@@ -38,13 +38,12 @@ class VtFileHarvester(
     * already be filtered by the FilenameFilter, I wonder if we even need the
     * match statement here.
     */
-  def getInputStream(file: File): Option[ZipInputStream] = {
+  def getInputStream(file: File): Option[ZipInputStream] =
     file.getName match {
       case zipName if zipName.endsWith("zip") =>
         Some(new ZipInputStream(new FileInputStream(file)))
       case _ => None
     }
-  }
 
   /** Main logic for handling individual entries in the zip.
     *
@@ -109,17 +108,16 @@ class VtFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        (for (result <- iter(inputStream)) yield {
+        iter(inputStream).foreach(result =>
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager
                 .getLogger(this.getClass)
                 .error(s"Caught exception on $inFile.", exception)
-              0
-            case Success(count) =>
-              count
+
+            case Success(count) => _
           }
-        }).sum
+        )
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/VtFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/VtFileHarvester.scala
@@ -115,7 +115,7 @@ class VtFileHarvester(
                 .getLogger(this.getClass)
                 .error(s"Caught exception on $inFile.", exception)
 
-            case Success(count) => _
+            case Success(count) => ()
           }
         )
         IOUtils.closeQuietly(inputStream)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactors iteration in harvester classes to use `foreach`, centralizes file filtering, and removes redundant code.
> 
>   - **Iteration Refactor**:
>     - Replaces `for` loops with `foreach` in `iter()` method calls in `CommunityWebsHarvester.scala`, `DplaJsonlFileHarvester.scala`, and `FlFileHarvester.scala`.
>   - **File Filtering**:
>     - Adds `txtFilter` to `FileFilters.scala`.
>     - Removes `TxtFileFilter` class from `SiFileHarvester.scala` and replaces its usage with `FileFilters.txtFilter`.
>   - **Miscellaneous**:
>     - Removes unnecessary braces in `getInputStream()` in `OaiFileHarvester.scala`, `VaFileHarvester.scala`, and `VtFileHarvester.scala`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for c133be628e02c951df4187342843fccf715f255a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->