### PR TITLE
Fix lazy list

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/file/CommunityWebsHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/CommunityWebsHarvester.scala
@@ -138,7 +138,7 @@ class CommunityWebsHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        for (result <- iter(inputStream))  {
+        iter(inputStream).foreach(result =>  {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager
@@ -146,7 +146,7 @@ class CommunityWebsHarvester(
                 .error(s"Caught exception on $inFile.", exception)
             case _ => // do nothing
           }
-        }
+        })
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/CommunityWebsHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/CommunityWebsHarvester.scala
@@ -28,20 +28,6 @@ class CommunityWebsHarvester(
 
   protected val extractor = new FlFileExtractor()
 
-  /** Loads .zip files
-    *
-    * @param file
-    *   File to parse
-    * @return
-    *   ZipInputstream of the zip contents
-    */
-  def getInputStream(file: File): Option[ZipInputStream] =
-    file.getName match {
-      case zipName if zipName.endsWith("zip") =>
-        Some(new ZipInputStream(new FileInputStream(file)))
-      case _ => None
-    }
-
   /** Parses JValue to extract item local item id and renders compact full
     * record
     *
@@ -114,7 +100,7 @@ class CommunityWebsHarvester(
     inFiles
       .listFiles(zipFilter)
       .foreach(inFile => {
-        val inputStream: ZipInputStream = getInputStream(inFile)
+        val inputStream: ZipInputStream = FileHarvester.getZipInputStream(inFile)
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )

--- a/src/main/scala/dpla/ingestion3/harvesters/file/CommunityWebsHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/CommunityWebsHarvester.scala
@@ -105,26 +105,6 @@ class CommunityWebsHarvester(
     }
   }
 
-  /** Implements a stream of files from the zip Can't use @tailrec here because
-    * the compiler can't recognize it as tail recursive, but this won't blow the
-    * stack.
-    *
-    * @param zipInputStream
-    * @return
-    *   Lazy stream of zip records
-    */
-  def iter(zipInputStream: ZipInputStream): LazyList[FileResult] =
-    Option(zipInputStream.getNextEntry) match {
-      case None =>
-        LazyList.empty
-      case Some(entry) =>
-        val result =
-          if (entry.isDirectory)
-            None
-          else
-            Some(new BufferedReader(new InputStreamReader(zipInputStream)))
-        FileResult(entry.getName, None, result) #:: iter(zipInputStream)
-    }
 
   override def localHarvest(): DataFrame = {
     val harvestTime = System.currentTimeMillis()
@@ -138,7 +118,7 @@ class CommunityWebsHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        iter(inputStream).foreach(result =>  {
+        FileHarvester.iter(inputStream).foreach(result =>  {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager

--- a/src/main/scala/dpla/ingestion3/harvesters/file/DlgFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/DlgFileHarvester.scala
@@ -33,19 +33,6 @@ class DlgFileHarvester(
 
   protected val extractor = new DlgFileExtractor()
 
-  /** Loads .zip files
-    *
-    * @param file
-    *   File to parse
-    * @return
-    *   ZipInputstream of the zip contents
-    */
-  def getInputStream(file: File): Option[ZipInputStream] =
-    file.getName match {
-      case zipName if zipName.endsWith("zip") =>
-        Some(new ZipInputStream(new FileInputStream(file)))
-      case _ => None
-    }
 
   /** Parses JValue to extract item local item id and renders compact full
     * record
@@ -118,7 +105,7 @@ class DlgFileHarvester(
     inFiles
       .listFiles(zipFilter)
       .foreach(inFile => {
-        val inputStream: ZipInputStream = getInputStream(inFile)
+        val inputStream: ZipInputStream = FileHarvester.getZipInputStream(inFile)
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )

--- a/src/main/scala/dpla/ingestion3/harvesters/file/DlgFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/DlgFileHarvester.scala
@@ -107,26 +107,6 @@ class DlgFileHarvester(
         }
     }
 
-  /** Implements a stream of files from the zip Can't use @tailrec here because
-    * the compiler can't recognize it as tail recursive, but this won't blow the
-    * stack.
-    *
-    * @param zipInputStream ZipInputStream from the zip file
-    * @return
-    *   Lazy stream of zip records
-    */
-  def iter(zipInputStream: ZipInputStream): LazyList[FileResult] =
-    Option(zipInputStream.getNextEntry) match {
-      case None =>
-        LazyList.empty
-      case Some(entry) =>
-        val result =
-          if (entry.isDirectory)
-            None
-          else
-            Some(new BufferedReader(new InputStreamReader(zipInputStream)))
-        FileResult(entry.getName, None, result) #:: iter(zipInputStream)
-    }
 
   /** Executes the Georgia harvest
     */
@@ -142,7 +122,7 @@ class DlgFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        iter(inputStream).foreach(result => {
+        FileHarvester.iter(inputStream).foreach(result => {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager

--- a/src/main/scala/dpla/ingestion3/harvesters/file/DplaJsonlFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/DplaJsonlFileHarvester.scala
@@ -112,27 +112,6 @@ class DplaJsonlFileHarvester(
     }
   }
 
-  /** Implements a stream of files from the zip Can't use @tailrec here because
-    * the compiler can't recognize it as tail recursive, but this won't blow the
-    * stack.
-    *
-    * @param zipInputStream
-    * @return
-    *   Lazy stream of zip records
-    */
-  def iter(zipInputStream: ZipInputStream): LazyList[FileResult] =
-    Option(zipInputStream.getNextEntry) match {
-      case None =>
-        LazyList.empty
-      case Some(entry) =>
-        val result =
-          if (entry.isDirectory)
-            None
-          else
-            Some(new BufferedReader(new InputStreamReader(zipInputStream)))
-        FileResult(entry.getName, None, result) #:: iter(zipInputStream)
-    }
-
   /** Executes the DPLA JSON file harvest
     */
   override def localHarvest(): DataFrame = {
@@ -147,7 +126,7 @@ class DplaJsonlFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        iter(inputStream).foreach( result => {
+        FileHarvester.iter(inputStream).foreach( result => {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager

--- a/src/main/scala/dpla/ingestion3/harvesters/file/DplaJsonlFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/DplaJsonlFileHarvester.scala
@@ -147,7 +147,7 @@ class DplaJsonlFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        for (result <- iter(inputStream)) yield {
+        iter(inputStream).foreach( result => {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager
@@ -155,7 +155,7 @@ class DplaJsonlFileHarvester(
                 .error(s"Caught exception on $inFile.", exception)
             case _ => //do nothing
           }
-        }
+        })
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/DplaJsonlFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/DplaJsonlFileHarvester.scala
@@ -32,21 +32,6 @@ class DplaJsonlFileHarvester(
 
   protected val extractor = new DplaJsonlFileExtractor()
 
-  /** Loads .zip files containing DPLA JSONL
-    *
-    * @param file
-    *   File to parse
-    * @return
-    *   FileInputStream of the file contents
-    */
-  def getInputStream(file: File): Option[ZipInputStream] = {
-    file.getName match {
-      case zipName if zipName.endsWith("zip") =>
-        Some(new ZipInputStream(new FileInputStream(file)))
-      case _ => None
-    }
-  }
-
   /** Parses JValue to extract item local item id and renders compact full
     * record
     *
@@ -122,7 +107,7 @@ class DplaJsonlFileHarvester(
     inFiles
       .listFiles(zipFilter)
       .foreach(inFile => {
-        val inputStream: ZipInputStream = getInputStream(inFile)
+        val inputStream: ZipInputStream = FileHarvester.getZipInputStream(inFile)
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )

--- a/src/main/scala/dpla/ingestion3/harvesters/file/FileFilters.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/FileFilters.scala
@@ -11,4 +11,5 @@ object FileFilters {
   val gzFilter: FileFilter = newFilter("gz")
   val xmlFilter: FileFilter = newFilter("xml")
   val zipFilter: FileFilter = newFilter("zip")
+  val txtFilter: FileFilter = newFilter("txt")
 }

--- a/src/main/scala/dpla/ingestion3/harvesters/file/FlFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/FlFileHarvester.scala
@@ -111,27 +111,6 @@ class FlFileHarvester(
     }
   }
 
-  /** Implements a stream of files from the zip Can't use @tailrec here because
-    * the compiler can't recognize it as tail recursive, but this won't blow the
-    * stack.
-    *
-    * @param zipInputStream
-    * @return
-    *   Lazy stream of zip records
-    */
-  def iter(zipInputStream: ZipInputStream): LazyList[FileResult] =
-    Option(zipInputStream.getNextEntry) match {
-      case None =>
-        LazyList.empty
-      case Some(entry) =>
-        val result =
-          if (entry.isDirectory)
-            None
-          else
-            Some(new BufferedReader(new InputStreamReader(zipInputStream)))
-        FileResult(entry.getName, None, result) #:: iter(zipInputStream)
-    }
-
   /** Executes the Florida harvest
     */
   override def localHarvest(): DataFrame = {
@@ -146,7 +125,7 @@ class FlFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        iter(inputStream).foreach(result => {
+        FileHarvester.iter(inputStream).foreach(result => {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager.getLogger(this.getClass).error(s"Caught exception on $inFile.", exception)

--- a/src/main/scala/dpla/ingestion3/harvesters/file/FlFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/FlFileHarvester.scala
@@ -146,13 +146,13 @@ class FlFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        for (result <- iter(inputStream)) yield {
+        iter(inputStream).foreach(result => {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager.getLogger(this.getClass).error(s"Caught exception on $inFile.", exception)
             case _ => //do nothing
           }
-        }
+        })
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/FlFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/FlFileHarvester.scala
@@ -1,6 +1,6 @@
 package dpla.ingestion3.harvesters.file
 
-import java.io.{BufferedReader, File, FileInputStream, InputStreamReader}
+import java.io.{File, FileInputStream}
 import java.util.zip.ZipInputStream
 import dpla.ingestion3.confs.i3Conf
 import dpla.ingestion3.harvesters.file.FileFilters.zipFilter
@@ -8,7 +8,7 @@ import dpla.ingestion3.mappers.utils.JsonExtractor
 import dpla.ingestion3.model.AVRO_MIME_JSON
 import org.apache.avro.generic.GenericData
 import org.apache.commons.io.IOUtils
-import org.apache.log4j.Logger
+
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -33,20 +33,6 @@ class FlFileHarvester(
 
   protected val extractor = new FlFileExtractor()
 
-  /** Loads .zip files
-    *
-    * @param file
-    *   File to parse
-    * @return
-    *   ZipInputstream of the zip contents
-    */
-  def getInputStream(file: File): Option[ZipInputStream] = {
-    file.getName match {
-      case zipName if zipName.endsWith("zip") =>
-        Some(new ZipInputStream(new FileInputStream(file)))
-      case _ => None
-    }
-  }
 
   /** Parses JValue to extract item local item id and renders compact full
     * record
@@ -121,7 +107,7 @@ class FlFileHarvester(
     inFiles
       .listFiles(zipFilter)
       .foreach(inFile => {
-        val inputStream: ZipInputStream = getInputStream(inFile)
+        val inputStream: ZipInputStream = FileHarvester.getZipInputStream(inFile)
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )

--- a/src/main/scala/dpla/ingestion3/harvesters/file/HathiFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/HathiFileHarvester.scala
@@ -129,7 +129,7 @@ class HathiFileHarvester(
             )
           )
 
-        for (tarResult <- iter(inputStream)) yield {
+        iter(inputStream).foreach(tarResult => {
           handleFile(tarResult, unixEpoch) match {
             case Failure(exception) =>
               logger
@@ -139,7 +139,7 @@ class HathiFileHarvester(
                 )
             case _ => //do nothing
           }
-        }
+        })
 
         IOUtils.closeQuietly(inputStream)
       })

--- a/src/main/scala/dpla/ingestion3/harvesters/file/HeartlandFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/HeartlandFileHarvester.scala
@@ -145,7 +145,7 @@ class HeartlandFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        for (result <- iter(inputStream)) yield {
+        iter(inputStream).foreach(result =>
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager
@@ -153,7 +153,7 @@ class HeartlandFileHarvester(
                 .error(s"Caught exception on $inFile.", exception)
             case _ => //do nothing
           }
-        }
+        )
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/HeartlandFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/HeartlandFileHarvester.scala
@@ -110,26 +110,6 @@ class HeartlandFileHarvester(
     }
   }
 
-  /** Implements a stream of files from the zip Can't use @tailrec here because
-    * the compiler can't recognize it as tail recursive, but this won't blow the
-    * stack.
-    *
-    * @param zipInputStream
-    * @return
-    *   Lazy stream of zip records
-    */
-  def iter(zipInputStream: ZipInputStream): LazyList[FileResult] =
-    Option(zipInputStream.getNextEntry) match {
-      case None =>
-        LazyList.empty
-      case Some(entry) =>
-        val result =
-          if (entry.isDirectory)
-            None
-          else
-            Some(new BufferedReader(new InputStreamReader(zipInputStream)))
-        FileResult(entry.getName, None, result) #:: iter(zipInputStream)
-    }
 
   /** Executes the Heartland (Missouri + Iowa) harvest
     */
@@ -145,7 +125,7 @@ class HeartlandFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        iter(inputStream).foreach(result =>
+        FileHarvester.iter(inputStream).foreach(result =>
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager

--- a/src/main/scala/dpla/ingestion3/harvesters/file/HeartlandFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/HeartlandFileHarvester.scala
@@ -32,20 +32,6 @@ class HeartlandFileHarvester(
 
   protected val extractor = new HeartlandFileExtractor()
 
-  /** Loads .zip files
-    *
-    * @param file
-    *   File to parse
-    * @return
-    *   ZipInputstream of the zip contents
-    */
-  def getInputStream(file: File): Option[ZipInputStream] = {
-    file.getName match {
-      case zipName if zipName.endsWith("zip") =>
-        Some(new ZipInputStream(new FileInputStream(file)))
-      case _ => None
-    }
-  }
 
   /** Parses JValue to extract item local item id and renders compact full
     * record
@@ -121,7 +107,7 @@ class HeartlandFileHarvester(
     inFiles
       .listFiles(zipFilter)
       .foreach(inFile => {
-        val inputStream: ZipInputStream = getInputStream(inFile)
+        val inputStream: ZipInputStream = FileHarvester.getZipInputStream(inFile)
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NYPLFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NYPLFileHarvester.scala
@@ -155,13 +155,13 @@ class NYPLFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        for (result <- iter(inputStream)) {
+        iter(inputStream).foreach( result =>
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager.getLogger(this.getClass).error(s"Caught exception on $inFile.", exception)
             case Success(_) => // do nothing
           }
-        }
+        )
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NYPLFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NYPLFileHarvester.scala
@@ -37,20 +37,6 @@ class NYPLFileHarvester(
 
   protected val extractor = new FlFileExtractor()
 
-  /** Loads .zip files
-    *
-    * @param file
-    *   File to parse
-    * @return
-    *   ZipInputstream of the zip contents
-    */
-  def getInputStream(file: File): Option[ZipInputStream] = {
-    file.getName match {
-      case zipName if zipName.endsWith("zip") =>
-        Some(new ZipInputStream(new FileInputStream(file)))
-      case _ => None
-    }
-  }
 
   /** @param json
     *   Full JSON item record
@@ -130,7 +116,7 @@ class NYPLFileHarvester(
     inFiles
       .listFiles(zipFilter)
       .foreach(inFile => {
-        val inputStream: ZipInputStream = getInputStream(inFile)
+        val inputStream: ZipInputStream = FileHarvester.getZipInputStream(inFile)
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NaraDeltaHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NaraDeltaHarvester.scala
@@ -256,7 +256,7 @@ class NaraDeltaHarvester(
         )
       )
 
-    val recordCount = (for (tarResult <- iter(inputStream)) yield {
+    val recordCount = iter(inputStream).map(tarResult =>
       handleFile(tarResult, unixEpoch, file.getName) match {
         case Failure(exception) =>
           val logger = LogManager.getLogger(this.getClass)
@@ -266,7 +266,7 @@ class NaraDeltaHarvester(
         case Success(count) =>
           count
       }
-    }).sum
+    ).sum
 
     logger.info(s"Harvested $recordCount records from ${file.getName}")
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NaraFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NaraFileHarvester.scala
@@ -310,7 +310,7 @@ class NaraFileHarvester(
         )
       )
 
-    val recordCount = (for (tarResult <- iter(inputStream)) yield {
+    val recordCount = iter(inputStream).map(tarResult =>
       handleFile(tarResult, unixEpoch, file.getName) match {
         case Failure(exception) =>
           val logger = LogManager.getLogger(this.getClass)
@@ -319,8 +319,7 @@ class NaraFileHarvester(
           0
         case Success(count) =>
           count
-      }
-    }).sum
+      }).sum
 
     val logger = LogManager.getLogger(this.getClass)
     logger.info(s"Harvested $recordCount records from ${file.getName}")

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NaraFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NaraFileHarvester.scala
@@ -4,7 +4,7 @@ import java.io.{BufferedReader, File, FileInputStream}
 import java.util.zip.GZIPInputStream
 import dpla.ingestion3.confs.i3Conf
 import dpla.ingestion3.harvesters.file.FileFilters.{avroFilter, gzFilter, xmlFilter}
-import dpla.ingestion3.harvesters.{AvroHelper, LocalHarvester}
+import dpla.ingestion3.harvesters.{AvroHelper, Harvester, LocalHarvester}
 import dpla.ingestion3.model.AVRO_MIME_XML
 import dpla.ingestion3.utils.{FlatFileIO, Utils}
 import org.apache.avro.Schema
@@ -82,7 +82,7 @@ class NaraFileHarvester(
       case record: Node =>
         val id =
           (record \ "digitalObjectArray" \ "digitalObject" \ "objectIdentifier").text
-        val outputXML = xmlToString(record)
+        val outputXML = Harvester.xmlToString(record)
         Some(ParsedResult(id, outputXML))
       case _ =>
         val logger = LogManager.getLogger(this.getClass)
@@ -304,13 +304,5 @@ class NaraFileHarvester(
     IOUtils.closeQuietly(inputStream)
   }
 
-  /** Converts a Node to an xml string
-    *
-    * @param node
-    *   The root of the tree to write to a string
-    * @return
-    *   a String containing xml
-    */
-  def xmlToString(node: Node): String =
-    Utility.serialize(node, minimizeTags = MinimizeMode.Always).toString
+
 }

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NorthwestHeritageFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NorthwestHeritageFileHarvester.scala
@@ -38,9 +38,6 @@ class NorthwestHeritageFileHarvester(
     * @return
     *   ZipInputstream of the zip contents
     *
-    * TODO: Because we're only handling zips in this class, and they should
-    * already be filtered by the FilenameFilter, I wonder if we even need the
-    * match statement here.
     */
   def getInputStream(file: File): Option[ZipInputStream] = {
     file.getName match {
@@ -150,17 +147,17 @@ class NorthwestHeritageFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        val recordCount = iter(inputStream).map(result =>
+        FileHarvester.iter(inputStream).foreach(result =>
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager
                 .getLogger(this.getClass)
                 .error(s"Caught exception on $inFile.", exception)
-              0
-            case Success(count) =>
-              count
+
+            case Success(count) => ()
+
           }
-        ).sum
+        )
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NorthwestHeritageFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NorthwestHeritageFileHarvester.scala
@@ -3,6 +3,7 @@ package dpla.ingestion3.harvesters.file
 import java.io.{File, FileInputStream}
 import java.util.zip.ZipInputStream
 import dpla.ingestion3.confs.i3Conf
+import dpla.ingestion3.harvesters.Harvester
 import dpla.ingestion3.harvesters.file.FileFilters.zipFilter
 import dpla.ingestion3.mappers.utils.XmlExtractor
 import dpla.ingestion3.model.AVRO_MIME_XML
@@ -31,21 +32,6 @@ class NorthwestHeritageFileHarvester(
 
   protected val extractor = new OaiFileExtractor()
 
-  /** Loads .zip files
-    *
-    * @param file
-    *   File to parse
-    * @return
-    *   ZipInputstream of the zip contents
-    *
-    */
-  def getInputStream(file: File): Option[ZipInputStream] = {
-    file.getName match {
-      case zipName if zipName.endsWith("zip") =>
-        Some(new ZipInputStream(new FileInputStream(file)))
-      case _ => None
-    }
-  }
 
   /** Main logic for handling individual entries in the zip.
     *
@@ -93,7 +79,7 @@ class NorthwestHeritageFileHarvester(
         // Extract required record identifier
         val id: Option[String] = extractor.extractString(record \ "identifier")
 
-        val outputXML = xmlToString(record)
+        val outputXML = Harvester.xmlToString(record)
 
         id match {
           case None =>
@@ -143,7 +129,7 @@ class NorthwestHeritageFileHarvester(
     inFiles
       .listFiles(zipFilter)
       .foreach(inFile => {
-        val inputStream = getInputStream(inFile)
+        val inputStream = FileHarvester.getZipInputStream(inFile)
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
@@ -168,13 +154,4 @@ class NorthwestHeritageFileHarvester(
     spark.read.format("avro").load(tmpOutStr)
   }
 
-  /** Converts a Node to an xml string
-    *
-    * @param node
-    *   The root of the tree to write to a string
-    * @return
-    *   a String containing xml
-    */
-  def xmlToString(node: Node): String =
-    Utility.serialize(node, minimizeTags = MinimizeMode.Always).toString
 }

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NorthwestHeritageFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NorthwestHeritageFileHarvester.scala
@@ -150,7 +150,7 @@ class NorthwestHeritageFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        val recordCount = (for (result <- iter(inputStream)) yield {
+        val recordCount = iter(inputStream).map(result =>
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager
@@ -160,7 +160,7 @@ class NorthwestHeritageFileHarvester(
             case Success(count) =>
               count
           }
-        }).sum
+        ).sum
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/OaiFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/OaiFileHarvester.scala
@@ -42,13 +42,12 @@ class OaiFileHarvester(
     * already be filtered by the FilenameFilter, I wonder if we even need the
     * match statement here.
     */
-  def getInputStream(file: File): Option[ZipInputStream] = {
+  def getInputStream(file: File): Option[ZipInputStream] =
     file.getName match {
       case zipName if zipName.endsWith("zip") =>
         Some(new ZipInputStream(new FileInputStream(file)))
       case _ => None
     }
-  }
 
   /** Main logic for handling individual entries in the zip.
     *
@@ -151,13 +150,13 @@ class OaiFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        iter(inputStream).foreach(result => {
+        iter(inputStream).foreach(result =>
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               logger.error(s"Caught exception on $inFile.", exception)
             case Success(_) => //do nothing
           }
-        })
+        )
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/OaiFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/OaiFileHarvester.scala
@@ -38,9 +38,6 @@ class OaiFileHarvester(
     * @return
     *   ZipInputstream of the zip contents
     *
-    * TODO: Because we're only handling zips in this class, and they should
-    * already be filtered by the FilenameFilter, I wonder if we even need the
-    * match statement here.
     */
   def getInputStream(file: File): Option[ZipInputStream] =
     file.getName match {
@@ -150,7 +147,7 @@ class OaiFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        iter(inputStream).foreach(result =>
+        FileHarvester.iter(inputStream).foreach(result =>
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               logger.error(s"Caught exception on $inFile.", exception)

--- a/src/main/scala/dpla/ingestion3/harvesters/file/SiFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/SiFileHarvester.scala
@@ -3,6 +3,7 @@ package dpla.ingestion3.harvesters.file
 import java.io.{File, FileFilter, FileInputStream, InputStreamReader}
 import java.util.zip.GZIPInputStream
 import dpla.ingestion3.confs.i3Conf
+import dpla.ingestion3.harvesters.Harvester
 import dpla.ingestion3.harvesters.file.FileFilters.gzFilter
 import dpla.ingestion3.model.AVRO_MIME_XML
 import dpla.ingestion3.utils.Utils
@@ -26,26 +27,6 @@ class SiFileHarvester(
 
   def mimeType: GenericData.EnumSymbol = AVRO_MIME_XML
 
-  /** Loads .gz files
-    *
-    * @param file
-    *   File to parse
-    * @return
-    *   Option[InputStreamReader] of the zip contents
-    *
-    * TODO: Because we're only handling zips in this class, and they should
-    * already be filtered by the FilenameFilter, I wonder if we even need the
-    * match statement here.
-    */
-  def getInputStream(file: File): Option[InputStreamReader] = {
-    file.getName match {
-      case zipName if zipName.endsWith("gz") =>
-        Some(
-          new InputStreamReader(new GZIPInputStream(new FileInputStream(file)))
-        )
-      case _ => None
-    }
-  }
 
   /** Takes care of parsing an xml file into a list of Nodes each representing
     * an item
@@ -66,7 +47,7 @@ class SiFileHarvester(
         val id = Option(
           (record \ "descriptiveNonRepeating" \ "record_ID").text
         )
-        val outputXML = xmlToString(record)
+        val outputXML = Harvester.xmlToString(record)
 
         id match {
           case None =>
@@ -160,7 +141,7 @@ class SiFileHarvester(
     inFiles
       .listFiles(gzFilter)
       .foreach(inFile => {
-        val inputStream = getInputStream(inFile)
+        val inputStream = FileHarvester.getTarInputStream(inFile)
           .getOrElse(
             throw new IllegalArgumentException(
               s"Couldn't load file, ${inFile.getAbsolutePath}"
@@ -168,7 +149,7 @@ class SiFileHarvester(
           )
 
         // create lineIterator to read contents one line at a time
-        val iter = IOUtils.lineIterator(inputStream)
+        val iter = IOUtils.lineIterator(inputStream, "utf-8")
 
         var lineCount: Int = 0
 
@@ -212,16 +193,6 @@ class SiFileHarvester(
     // Read harvested data into Spark DataFrame and return.
     spark.read.format("avro").load(tmpOutStr)
   }
-
-  /** Converts a Node to an xml string
-    *
-    * @param node
-    *   The root of the tree to write to a string
-    * @return
-    *   a String containing xml
-    */
-  def xmlToString(node: Node): String =
-    Utility.serialize(node, minimizeTags = MinimizeMode.Always).toString
 
   /** Parses and extracts ZipInputStream and writes parses records out.
     *

--- a/src/main/scala/dpla/ingestion3/harvesters/file/SiFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/SiFileHarvester.scala
@@ -125,7 +125,7 @@ class SiFileHarvester(
   private def getExpectedFileCounts(inFiles: File): Map[String, String] = {
     var loadCounts = Map[String, String]()
     inFiles
-      .listFiles(new TxtFileFilter)
+      .listFiles(FileFilters.txtFilter)
       .foreach(file => {
         Using(Source
           .fromFile(file)) { source =>
@@ -234,7 +234,3 @@ class SiFileHarvester(
 
 }
 
-class TxtFileFilter extends FileFilter {
-  override def accept(pathname: File): Boolean =
-    pathname.getName.endsWith("txt")
-}

--- a/src/main/scala/dpla/ingestion3/harvesters/file/VaFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/VaFileHarvester.scala
@@ -41,13 +41,12 @@ class VaFileHarvester(
     * already be filtered by the FilenameFilter, I wonder if we even need the
     * match statement here.
     */
-  def getInputStream(file: File): Option[ZipInputStream] = {
+  def getInputStream(file: File): Option[ZipInputStream] =
     file.getName match {
       case zipName if zipName.endsWith("zip") =>
         Some(new ZipInputStream(new FileInputStream(file)))
       case _ => None
     }
-  }
 
   /** Main logic for handling individual entries in the zip.
     *
@@ -113,17 +112,16 @@ class VaFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        val recordCount = (for (result <- iter(inputStream)) yield {
+        iter(inputStream).foreach(result => {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager
                 .getLogger(this.getClass)
                 .error(s"Caught exception on $inFile.", exception)
-              0
             case Success(count) =>
               count
           }
-        }).sum
+        })
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/VaFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/VaFileHarvester.scala
@@ -3,6 +3,7 @@ package dpla.ingestion3.harvesters.file
 import java.io.{File, FileInputStream}
 import java.util.zip.ZipInputStream
 import dpla.ingestion3.confs.i3Conf
+import dpla.ingestion3.harvesters.Harvester
 import dpla.ingestion3.mappers.utils.XmlExtractor
 import org.apache.commons.io.IOUtils
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -30,20 +31,7 @@ class VaFileHarvester(
 
   protected val extractor = new VaFileExtractor()
 
-  /** Loads .zip files
-    *
-    * @param file
-    *   File to parse
-    * @return
-    *   ZipInputstream of the zip contents
-    *
-    */
-  def getInputStream(file: File): Option[ZipInputStream] =
-    file.getName match {
-      case zipName if zipName.endsWith("zip") =>
-        Some(new ZipInputStream(new FileInputStream(file)))
-      case _ => None
-    }
+
 
   /** Main logic for handling individual entries in the zip.
     *
@@ -64,7 +52,7 @@ class VaFileHarvester(
           } match {
             case Success(xml) =>
               val id: String = zipResult.entryName
-              val outputXml: String = xmlToString(xml)
+              val outputXml: String = Harvester.xmlToString(xml)
               val item: ParsedResult = ParsedResult(id, outputXml)
               writeOut(unixEpoch, item)
               1
@@ -83,7 +71,7 @@ class VaFileHarvester(
     inFiles
       .listFiles(zipFilter)
       .foreach(inFile => {
-        val inputStream = getInputStream(inFile)
+        val inputStream = FileHarvester.getZipInputStream(inFile)
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
@@ -106,14 +94,4 @@ class VaFileHarvester(
     // Read harvested data into Spark DataFrame and return.
     spark.read.format("avro").load(tmpOutStr)
   }
-
-  /** Converts a Node to an xml string
-    *
-    * @param node
-    *   The root of the tree to write to a string
-    * @return
-    *   a String containing xml
-    */
-  def xmlToString(node: Node): String =
-    Utility.serialize(node, minimizeTags = MinimizeMode.Always).toString
 }

--- a/src/main/scala/dpla/ingestion3/harvesters/file/VaFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/VaFileHarvester.scala
@@ -37,9 +37,6 @@ class VaFileHarvester(
     * @return
     *   ZipInputstream of the zip contents
     *
-    * TODO: Because we're only handling zips in this class, and they should
-    * already be filtered by the FilenameFilter, I wonder if we even need the
-    * match statement here.
     */
   def getInputStream(file: File): Option[ZipInputStream] =
     file.getName match {
@@ -76,28 +73,6 @@ class VaFileHarvester(
         }
     }
 
-  /** Implements a stream of files from the zip Can't use @tailrec here because
-    * the compiler can't recognize it as tail recursive, but this won't blow the
-    * stack.
-    *
-    * @param zipInputStream
-    * @return
-    *   Lazy stream of zip records
-    */
-  def iter(zipInputStream: ZipInputStream): LazyList[FileResult] =
-    Option(zipInputStream.getNextEntry) match {
-      case None =>
-        LazyList.empty
-      case Some(entry) =>
-        val result =
-          if (entry.isDirectory || !entry.getName.endsWith(".xml"))
-            None
-          else {
-            Some(IOUtils.toByteArray(zipInputStream, entry.getSize))
-          }
-        FileResult(entry.getName, result) #:: iter(zipInputStream)
-    }
-
   /** Executes the Digital Virginias harvest
     */
   override def localHarvest(): DataFrame = {
@@ -112,7 +87,7 @@ class VaFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        iter(inputStream).foreach(result => {
+        FileHarvester.iter(inputStream).foreach(result => {
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager

--- a/src/main/scala/dpla/ingestion3/harvesters/file/VtFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/VtFileHarvester.scala
@@ -38,13 +38,12 @@ class VtFileHarvester(
     * already be filtered by the FilenameFilter, I wonder if we even need the
     * match statement here.
     */
-  def getInputStream(file: File): Option[ZipInputStream] = {
+  def getInputStream(file: File): Option[ZipInputStream] =
     file.getName match {
       case zipName if zipName.endsWith("zip") =>
         Some(new ZipInputStream(new FileInputStream(file)))
       case _ => None
     }
-  }
 
   /** Main logic for handling individual entries in the zip.
     *
@@ -109,17 +108,16 @@ class VtFileHarvester(
           .getOrElse(
             throw new IllegalArgumentException("Couldn't load ZIP files.")
           )
-        (for (result <- iter(inputStream)) yield {
+        iter(inputStream).foreach(result =>
           handleFile(result, unixEpoch) match {
             case Failure(exception) =>
               LogManager
                 .getLogger(this.getClass)
                 .error(s"Caught exception on $inFile.", exception)
-              0
-            case Success(count) =>
-              count
+
+            case Success(count) => _
           }
-        }).sum
+        )
         IOUtils.closeQuietly(inputStream)
       })
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/VtFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/VtFileHarvester.scala
@@ -115,7 +115,7 @@ class VtFileHarvester(
                 .getLogger(this.getClass)
                 .error(s"Caught exception on $inFile.", exception)
 
-            case Success(count) => _
+            case Success(count) => ()
           }
         )
         IOUtils.closeQuietly(inputStream)

--- a/src/main/scala/dpla/ingestion3/harvesters/oai/LocalOaiHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/oai/LocalOaiHarvester.scala
@@ -1,6 +1,7 @@
 package dpla.ingestion3.harvesters.oai
 
 import dpla.ingestion3.confs.i3Conf
+import dpla.ingestion3.harvesters.file.ParsedResult
 import dpla.ingestion3.harvesters.oai.refactor.{OaiConfiguration, OaiProtocol, OaiRecord, OaiSet}
 import dpla.ingestion3.harvesters.{Harvester, LocalHarvester}
 import dpla.ingestion3.model.AVRO_MIME_XML
@@ -61,7 +62,7 @@ class LocalOaiHarvester(
         page,
         removeDeleted = oaiConfig.removeDeleted()
       )
-    } writeRecord(unixEpoch, record)
+    } writeOut(unixEpoch, ParsedResult(record.id, record.document))
   }
 
   private def allSetsHarvest(): Unit = {
@@ -74,7 +75,7 @@ class LocalOaiHarvester(
         pageEither,
         removeDeleted = oaiConfig.removeDeleted()
       )
-    } writeRecord(unixEpoch, record)
+    } writeOut(unixEpoch, ParsedResult(record.id, record.document))
   }
 
   private def allRecordsHarvest(): Unit = {
@@ -85,7 +86,7 @@ class LocalOaiHarvester(
         pageEither,
         removeDeleted = oaiConfig.removeDeleted()
       )
-    } writeRecord(unixEpoch, record)
+    } writeOut(unixEpoch, ParsedResult(record.id, record.document))
   }
 
   private def banlistHarvest(
@@ -104,23 +105,8 @@ class LocalOaiHarvester(
         pageEither,
         removeDeleted = oaiConfig.removeDeleted()
       )
-    } writeRecord(unixEpoch, record)
+    } writeOut(unixEpoch, ParsedResult(record.id, record.document))
   }
-
-  private def writeRecord(
-      unixEpoch: Long,
-      record: OaiRecord
-  ): Unit = {
-    val genericRecord = new GenericData.Record(Harvester.schema)
-    genericRecord.put("id", record.id)
-    genericRecord.put("ingestDate", unixEpoch)
-    genericRecord.put("provider", shortName)
-    genericRecord.put("document", record.document)
-    genericRecord.put("mimetype", mimeType)
-    avroWriter.append(genericRecord)
-
-  }
-
   private def getUnixEpoch: Long = System.currentTimeMillis() / 1000L
 
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Centralizes `iter` function for compressed file iteration and adds `txtFilter` for `.txt` files, removing redundant code across multiple harvesters.
> 
>   - **Refactoring**:
>     - Centralized `iter` function for `ZipInputStream` and `TarInputStream` in `FileHarvester.scala`.
>     - Removed individual `iter` implementations from `CommunityWebsHarvester.scala`, `DlgFileHarvester.scala`, `DplaJsonlFileHarvester.scala`, and 10 other files.
>   - **File Filters**:
>     - Added `txtFilter` to `FileFilters.scala` for filtering `.txt` files.
>   - **Miscellaneous**:
>     - Updated `SiFileHarvester.scala` to use `FileFilters.txtFilter` instead of a custom filter class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for 7f024b3979fc39f368aca870cce80e1d28156ff4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->