### PR TITLE
Got rid of datasource persist to avoid using lots of ram

### DIFF
--- a/src/main/scala/dpla/ingestion3/executors/JsonlExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/JsonlExecutor.scala
@@ -57,17 +57,16 @@ trait JsonlExecutor extends Serializable {
         val record = ModelConverter.toModel(row)
         jsonlRecord(record)
       })
-      .persist(StorageLevel.MEMORY_AND_DISK_SER)
-
-    val indexCount = indexRecords.count
 
     // This should always write out as #text() because if we use #json() then the
     // data will be written out inside a JSON object (e.g. {'value': <doc>}) which is
     // invalid for our use
     indexRecords.write.option("compression", "gzip").text(outputPath)
+    indexRecords.unpersist(false)
+
+    val indexCount = spark.read.text(outputPath).count()
 
     // Create and write manifest.
-
     val manifestOpts: Map[String, String] = Map(
       "Activity" -> "JSON-L",
       "Provider" -> shortName,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removed `persist` on `indexRecords` in `JsonlExecutor.scala` to reduce RAM usage and adjusted `indexCount` calculation.
> 
>   - **Memory Optimization**:
>     - Removed `.persist(StorageLevel.MEMORY_AND_DISK_SER)` from `indexRecords` in `JsonlExecutor.scala` to reduce RAM usage.
>     - Added `indexRecords.unpersist(false)` after writing to disk to ensure memory is freed.
>   - **Index Count Calculation**:
>     - Changed `indexCount` to read from the output path instead of counting `indexRecords` directly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for 227fe87a0113f9e1ff1fd5d05f2113b577700486. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->