### PR TITLE
Better implementation of NYPL fix.

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/NYPLMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/NYPLMapping.scala
@@ -325,7 +325,7 @@ class NyplMapping extends JsonMapping with IngestMessageTemplates {
 
   override def title(data: Document[json4s.JValue]): AtLeastOne[String] =
     // titleInfo \ "title" @usage='primary'
-    (modsXml.get().get \ "titleInfo")
+    (getMods \ "titleInfo")
       .flatMap(node => xml.getByAttribute(node, "usage", "primary"))
       .flatMap(node => xml.extractStrings(node \ "title"))
 
@@ -334,7 +334,7 @@ class NyplMapping extends JsonMapping with IngestMessageTemplates {
   ): ZeroToMany[String] =
     // all other title values
     xml
-      .extractStrings(modsXml.get().get \ "titleInfo" \ "title")
+      .extractStrings(getMods \ "titleInfo" \ "title")
       .diff(title(data))
 
   override def identifier(data: Document[json4s.JValue]): ZeroToMany[String] = {

--- a/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
@@ -19,7 +19,7 @@ trait Mapping[T] {
   and serializable or transient.
    */
   def preMap(data: Document[T]): Document[T] = data
-  def postMap(data: Document[T]): Unit
+  def postMap(data: Document[T]): Unit = ()
 
   // OreAggregation
   def dplaUri(data: Document[T]): ZeroToOne[URI] = None

--- a/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/utils/Mapping.scala
@@ -12,6 +12,15 @@ trait Mapping[T] {
 
   implicit def unwrap(document: Document[T]): T = document.get
 
+  /*
+  Hooks to allow setup and teardown for an individual map.
+  Note that the mapper instance is used by multiple threads,
+  and may be serialized, so any local state should be thread-safe
+  and serializable or transient.
+   */
+  def preMap(data: Document[T]): Document[T] = data
+  def postMap(data: Document[T]): Unit
+
   // OreAggregation
   def dplaUri(data: Document[T]): ZeroToOne[URI] = None
   def dataProvider(data: Document[T]): ZeroToMany[EdmAgent] = Seq()

--- a/src/main/scala/dpla/ingestion3/profiles/CHProfile.scala
+++ b/src/main/scala/dpla/ingestion3/profiles/CHProfile.scala
@@ -26,7 +26,10 @@ trait CHProfile[T] extends Serializable {
     val mapper = getMapper
 
     val document = parser.parse(data)
-    mapper.map(document, mapping)
+    val internalDoc = mapping.preMap(document)
+    val oreAggregation = mapper.map(internalDoc, mapping)
+    mapping.postMap(internalDoc)
+    oreAggregation
   }
 }
 

--- a/src/test/scala/dpla/ingestion3/mappers/providers/NYPLMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/NYPLMappingTest.scala
@@ -19,6 +19,15 @@ class NYPLMappingTest extends AnyFlatSpec with BeforeAndAfter {
   val json: Document[JValue] = Document(parse(jsonString))
   val extractor = new NyplMapping
 
+  before {
+    extractor.preMap(json)
+  }
+
+  after {
+    extractor.postMap(json)
+  }
+
+
   it should "extract the correct original ID " in {
     val expected = Some("93cd9a10-c552-012f-20e8-58d385a7bc34")
     assert(extractor.originalId(json) === expected)


### PR DESCRIPTION
No longer leaks all the memory.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `NYPLMapping` to use `ThreadLocal` for MODS XML, improving memory management and preventing leaks.
> 
>   - **Memory Management**:
>     - Replaces LRU cache with `ThreadLocal` for MODS XML in `NYPLMapping` to prevent memory leaks.
>     - Introduces `preMap` and `postMap` methods in `NYPLMapping` to manage `ThreadLocal` lifecycle.
>   - **Mapping Trait**:
>     - Adds `preMap` and `postMap` methods to `Mapping` trait.
>   - **CHProfile**:
>     - Updates `mapOreAggregation` to call `preMap` and `postMap`.
>   - **Tests**:
>     - Updates `NYPLMappingTest` to use `preMap` and `postMap` in setup and teardown.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for de7a8e0623edd0b4ffa8691d48581c4e85002b1b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->