### PR TITLE
Adding several TX Wikidata IDs

### DIFF
--- a/src/main/resources/wiki/institutions_v2.json
+++ b/src/main/resources/wiki/institutions_v2.json
@@ -36727,27 +36727,27 @@
         "upload" : false
       },
       "African American Museum of Dallas" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q4689666",
         "upload" : false
       },
       "Albert and Shirley Small Special Collections Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q15179080",
         "upload" : false
       },
       "Alexander Architectural Archive, University of Texas at Austin" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q96203905",
         "upload" : false
       },
       "Alexander Memorial Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492508",
         "upload" : false
       },
       "Allen Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q30257868",
         "upload" : false
       },
       "Alvin Community College" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q4738072",
         "upload" : false
       },
       "Alvin Museum Society" : {
@@ -36759,7 +36759,7 @@
         "upload" : false
       },
       "Amarillo Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69970666",
         "upload" : false
       },
       "Amon Carter Museum" : {
@@ -36795,7 +36795,7 @@
         "upload" : false
       },
       "Arkansas State Archives" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q98358573",
         "upload" : false
       },
       "Arlington Historical Society’s Fielder House Museum" : {
@@ -36819,7 +36819,7 @@
         "upload" : false
       },
       "Austin History Center, Austin Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q2872117",
         "upload" : false
       },
       "Austin Memorial Library" : {
@@ -36835,7 +36835,7 @@
         "upload" : false
       },
       "Bandera Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69491752",
         "upload" : false
       },
       "Bartlett Activities Center and the Historical Society of Bartlett" : {
@@ -36879,7 +36879,7 @@
         "upload" : false
       },
       "Botanical Research Institute of Texas" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q2759819",
         "upload" : false
       },
       "Botanical Research Institute of Texas Library" : {
@@ -36903,15 +36903,15 @@
         "upload" : false
       },
       "Breckenridge Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492836",
         "upload" : false
       },
       "Brian W. Schenk Archives, Stephen F. Austin High School" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q65121866",
         "upload" : false
       },
       "Brown County Museum of History" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q107319400",
         "upload" : false
       },
       "Brownsville Historical Association" : {
@@ -36919,7 +36919,7 @@
         "upload" : false
       },
       "Brownwood Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492399",
         "upload" : false
       },
       "Bryan Wildenthal Memorial Library (Archives of the Big Bend)" : {
@@ -36939,7 +36939,7 @@
         "upload" : false
       },
       "Calhoun County Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69491960",
         "upload" : false
       },
       "Canyon Area Library" : {
@@ -36947,11 +36947,11 @@
         "upload" : false
       },
       "Carl and Mary Welhausen Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492223",
         "upload" : false
       },
       "Carnegie Library of Ballinger" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69491725",
         "upload" : false
       },
       "Carrollton Public Library" : {
@@ -36959,7 +36959,7 @@
         "upload" : false
       },
       "Carson County Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69491903",
         "upload" : false
       },
       "Casey Memorial Library" : {
@@ -36971,7 +36971,7 @@
         "upload" : false
       },
       "Cathedral of Saint Matthew" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q603535",
         "upload" : false
       },
       "Cattle Raisers Museum" : {
@@ -37015,11 +37015,11 @@
         "upload" : false
       },
       "City of Clarendon" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q979382",
         "upload" : false
       },
       "City of College Station" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q695511",
         "upload" : false
       },
       "City of Denton Parks and Recreation" : {
@@ -37031,15 +37031,15 @@
         "upload" : false
       },
       "City of Grapevine" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q185216",
         "upload" : false
       },
       "City of Lakeway" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q974112",
         "upload" : false
       },
       "City of Quanah" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q974733",
         "upload" : false
       },
       "Clark Hotel Museum" : {
@@ -37063,7 +37063,7 @@
         "upload" : false
       },
       "Coates Library, Trinity University" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q108073203",
         "upload" : false
       },
       "Coleman Public Library" : {
@@ -37099,7 +37099,7 @@
         "upload" : false
       },
       "Courthouse-on-the-Square Museum" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q5259599",
         "upload" : false
       },
       "Cowtown Coliseum" : {
@@ -37107,11 +37107,11 @@
         "upload" : false
       },
       "Cozby Library and Community Commons" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69970387",
         "upload" : false
       },
       "Crosby County Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492520",
         "upload" : false
       },
       "Cross Plains Public Library" : {
@@ -37127,7 +37127,7 @@
         "upload" : false
       },
       "Dallas Area Rapid Transit (DART)" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q380660",
         "upload" : false
       },
       "Dallas County Community College District" : {
@@ -37151,7 +37151,7 @@
         "upload" : false
       },
       "Dallas Market Center" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q5211363",
         "upload" : false
       },
       "Dallas Municipal Archives" : {
@@ -37163,7 +37163,7 @@
         "upload" : false
       },
       "Dallas News Corporation" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q2483225",
         "upload" : false
       },
       "Dallas Public Library" : {
@@ -37203,11 +37203,11 @@
         "upload" : false
       },
       "Dr. Hector P. Garcia Memorial Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69491813",
         "upload" : false
       },
       "Dr. Pepper Museum" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q25421126",
         "upload" : false
       },
       "Dr. Pound Historical Farmstead" : {
@@ -37223,7 +37223,7 @@
         "upload" : false
       },
       "Duval County Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492624",
         "upload" : false
       },
       "East Parker County Genealogy and Historical Society" : {
@@ -37235,7 +37235,7 @@
         "upload" : false
       },
       "Eastland Centennial Memorial Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69969036",
         "upload" : false
       },
       "Ed & Hazel Richmond Public Library" : {
@@ -37247,11 +37247,11 @@
         "upload" : false
       },
       "El Paso Community College" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q5351764",
         "upload" : false
       },
       "El Paso County Historical Society" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q85723769",
         "upload" : false
       },
       "El Paso Public Library" : {
@@ -37263,11 +37263,11 @@
         "upload" : false
       },
       "Elgin Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69472284",
         "upload" : false
       },
       "Ellis Memorial Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69491954",
         "upload" : false
       },
       "Ennis Public Library" : {
@@ -37283,15 +37283,15 @@
         "upload" : false
       },
       "FM Buck Richards Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492262",
         "upload" : false
       },
       "Fairfield Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q66815889",
         "upload" : false
       },
       "Fannie Brown Booth Memorial Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69970578",
         "upload" : false
       },
       "Fannin County Historical Commission" : {
@@ -37299,11 +37299,11 @@
         "upload" : false
       },
       "Fannin County Museum of History" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q107321906",
         "upload" : false
       },
       "Fayette Public Library, Museum and Archives" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69491699",
         "upload" : false
       },
       "Ferris Public Library" : {
@@ -37319,7 +37319,7 @@
         "upload" : false
       },
       "First Christian Church of Arlington" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q19865514",
         "upload" : false
       },
       "First Christian Church of Port Arthur" : {
@@ -37331,7 +37331,7 @@
         "upload" : false
       },
       "First United Methodist Church of Dallas" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q105320447",
         "upload" : false
       },
       "Flower Mound Public Library" : {
@@ -37379,7 +37379,7 @@
         "upload" : false
       },
       "Franklin County Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69482017",
         "upload" : false
       },
       "French Legation Museum" : {
@@ -37431,7 +37431,7 @@
         "upload" : false
       },
       "German-Texan Heritage Society" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q126171647",
         "upload" : false
       },
       "Gibbs Memorial Library" : {
@@ -37439,7 +37439,7 @@
         "upload" : false
       },
       "Giddings Public Library and Cultural Center" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69491500",
         "upload" : false
       },
       "Gillespie County Historical Society" : {
@@ -37451,7 +37451,7 @@
         "upload" : false
       },
       "Gladys Johnson Ritchie Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69491636",
         "upload" : false
       },
       "Grand Prairie Genealogical Society" : {
@@ -37459,7 +37459,7 @@
         "upload" : false
       },
       "Grandview Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492724",
         "upload" : false
       },
       "Grayson College Foundation" : {
@@ -37479,7 +37479,7 @@
         "upload" : false
       },
       "Harrie P. Woodson Memorial Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492419",
         "upload" : false
       },
       "Harris County Archives" : {
@@ -37495,7 +37495,7 @@
         "upload" : false
       },
       "Harrison County Historical Museum" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q5665574",
         "upload" : false
       },
       "Haslet Public Library" : {
@@ -37519,7 +37519,7 @@
         "upload" : false
       },
       "Heritage Crossing" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q109975691",
         "upload" : false
       },
       "Heritage House Museum" : {
@@ -37563,7 +37563,7 @@
         "upload" : false
       },
       "Houston Metropolitan Research Center at Houston Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69969369",
         "upload" : false
       },
       "Howard Payne University Library" : {
@@ -37579,7 +37579,7 @@
         "upload" : false
       },
       "Hutchinson County Library, Borger Branch" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q107320707",
         "upload" : false
       },
       "Interurban Railway Museum" : {
@@ -37603,7 +37603,7 @@
         "upload" : false
       },
       "Jennie Trent Dew Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69970924",
         "upload" : false
       },
       "Johnson County Genealogical Society" : {
@@ -37627,7 +37627,7 @@
         "upload" : false
       },
       "Kerens Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492846",
         "upload" : false
       },
       "Kerr County Historical Commission" : {
@@ -37643,7 +37643,7 @@
         "upload" : false
       },
       "Krum Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69970465",
         "upload" : false
       },
       "Krum United Methodist Church" : {
@@ -37659,7 +37659,7 @@
         "upload" : false
       },
       "Lamar State College – Orange" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q6480920",
         "upload" : false
       },
       "Lamar University" : {
@@ -37683,7 +37683,7 @@
         "upload" : false
       },
       "League City Helen Hall Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69969684",
         "upload" : false
       },
       "Lee College" : {
@@ -37691,7 +37691,7 @@
         "upload" : false
       },
       "Lee Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q17553094",
         "upload" : false
       },
       "Lena Armstrong Public Library" : {
@@ -37699,15 +37699,15 @@
         "upload" : false
       },
       "Leonard Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492310",
         "upload" : false
       },
       "Library of Congress Manuscript Division" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q106477161",
         "upload" : false
       },
       "Little Elm Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q19100245",
         "upload" : false
       },
       "Livingston Municipal Library" : {
@@ -37715,19 +37715,19 @@
         "upload" : false
       },
       "Llano County Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69491745",
         "upload" : false
       },
       "Lockheed Martin Aeronautics Company, Fort Worth" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q1627738",
         "upload" : false
       },
       "Log Cabin Village" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q85781905",
         "upload" : false
       },
       "Lone Star Flight Museum" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q6671427",
         "upload" : false
       },
       "Longview Public Library" : {
@@ -37747,7 +37747,7 @@
         "upload" : false
       },
       "Madison County Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q77062440",
         "upload" : false
       },
       "Marfa Public Library" : {
@@ -37759,11 +37759,11 @@
         "upload" : false
       },
       "Matagorda County Museum & Bay City Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q107318157",
         "upload" : false
       },
       "Mathis Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69969758",
         "upload" : false
       },
       "Matthews Family and Lambshead Ranch" : {
@@ -37863,7 +37863,7 @@
         "upload" : false
       },
       "Museum of the Big Bend" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q98525423",
         "upload" : false
       },
       "Museum of the Gulf Coast" : {
@@ -37871,15 +37871,15 @@
         "upload" : false
       },
       "Nancy Carol Roberts Memorial Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492314",
         "upload" : false
       },
       "National Cowboy and Western Heritage Museum" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q6971981",
         "upload" : false
       },
       "National Museum of the Pacific War/Admiral Nimitz Foundation" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q6974516",
         "upload" : false
       },
       "National WASP WWII Museum" : {
@@ -37887,7 +37887,7 @@
         "upload" : false
       },
       "Navasota Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69969823",
         "upload" : false
       },
       "Nellie Pederson Civic Library" : {
@@ -37903,7 +37903,7 @@
         "upload" : false
       },
       "Nicholas P. Sims Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492185",
         "upload" : false
       },
       "Northeast Lakeview College" : {
@@ -37915,7 +37915,7 @@
         "upload" : false
       },
       "Odem Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69491875",
         "upload" : false
       },
       "Oklahoma Historical Society" : {
@@ -37923,7 +37923,7 @@
         "upload" : false
       },
       "Old City Park" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q49534940",
         "upload" : false
       },
       "Old Settler's Association of Grayson County" : {
@@ -37931,7 +37931,7 @@
         "upload" : false
       },
       "Olney Community Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69776915",
         "upload" : false
       },
       "Orange County Historical Society" : {
@@ -37939,11 +37939,11 @@
         "upload" : false
       },
       "Other" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q48270",
         "upload" : false
       },
       "Our Lady of the Lake University" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q7111021",
         "upload" : false
       },
       "Palacios Area Historical Association" : {
@@ -37959,7 +37959,7 @@
         "upload" : false
       },
       "Palo Alto College" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q7128504",
         "upload" : false
       },
       "Palo Pinto County Historical Association" : {
@@ -37967,7 +37967,7 @@
         "upload" : false
       },
       "Panhandle-Plains Historical Museum" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q7131023",
         "upload" : false
       },
       "Panola College" : {
@@ -37983,7 +37983,7 @@
         "upload" : false
       },
       "Permian Basin Petroleum Museum, Library and Hall of Fame" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q7169319",
         "upload" : false
       },
       "Pharr Memorial Library" : {
@@ -37991,7 +37991,7 @@
         "upload" : false
       },
       "Philosophical Society of Texas" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q100304802",
         "upload" : false
       },
       "Pioneer City County Museum" : {
@@ -38007,7 +38007,7 @@
         "upload" : false
       },
       "Pottsboro Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492594",
         "upload" : false
       },
       "Prairie View A&M University" : {
@@ -38015,7 +38015,7 @@
         "upload" : false
       },
       "Preservation Dallas" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q107322163",
         "upload" : false
       },
       "Price Johnson Family Collection" : {
@@ -38195,7 +38195,7 @@
         "upload" : false
       },
       "Rains County Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69491424",
         "upload" : false
       },
       "Reagan County Library" : {
@@ -38215,11 +38215,11 @@
         "upload" : false
       },
       "Rice University Woodson Research Center" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q8033379",
         "upload" : false
       },
       "Richard S. and Leah Morris Memorial Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492896",
         "upload" : false
       },
       "Richardson Public Library" : {
@@ -38235,7 +38235,7 @@
         "upload" : false
       },
       "River Valley Pioneer Museum" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q107320741",
         "upload" : false
       },
       "Rose Marine Theatre" : {
@@ -38247,15 +38247,15 @@
         "upload" : false
       },
       "Round Rock Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q7371126",
         "upload" : false
       },
       "Rusk County Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69969246",
         "upload" : false
       },
       "SMU Libraries" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q47089628",
         "upload" : false
       },
       "Sachse Public Library" : {
@@ -38267,11 +38267,11 @@
         "upload" : false
       },
       "Sam Houston High School" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q7407640",
         "upload" : false
       },
       "Sam Rayburn House State Historical Site" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q7408057",
         "upload" : false
       },
       "Sammy Brown Library" : {
@@ -38279,7 +38279,7 @@
         "upload" : false
       },
       "San Antonio College" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q7413315",
         "upload" : false
       },
       "San Antonio Conservation Society" : {
@@ -38319,11 +38319,11 @@
         "upload" : false
       },
       "Sherman Jazz Museum" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q107321847",
         "upload" : false
       },
       "Shiner Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492682",
         "upload" : false
       },
       "Silsbee Public Library" : {
@@ -38343,7 +38343,7 @@
         "upload" : false
       },
       "Slovanska Podporujici Jednota Statu Texas" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q117511806",
         "upload" : false
       },
       "Smith County Historical Society" : {
@@ -38351,7 +38351,7 @@
         "upload" : false
       },
       "Smith Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492220",
         "upload" : false
       },
       "Smithville Heritage Society" : {
@@ -38371,7 +38371,7 @@
         "upload" : false
       },
       "South Plains College" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q7568230",
         "upload" : false
       },
       "South Texas College of Law" : {
@@ -38403,7 +38403,7 @@
         "upload" : false
       },
       "St. Mary's University Louis J. Blume Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q84082375",
         "upload" : false
       },
       "St. Mary’s University School of Law" : {
@@ -38411,7 +38411,7 @@
         "upload" : false
       },
       "St. Philips College" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q7591515",
         "upload" : false
       },
       "Stamford Carnegie Library" : {
@@ -38435,11 +38435,11 @@
         "upload" : false
       },
       "Sterling Municipal Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69969851",
         "upload" : false
       },
       "Stewart Title Company" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q126649640",
         "upload" : false
       },
       "Stonewall County Library" : {
@@ -38475,7 +38475,7 @@
         "upload" : false
       },
       "Tarrant County Archives" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q98695538",
         "upload" : false
       },
       "Tarrant County Black Historical and Genealogical Society" : {
@@ -38483,7 +38483,7 @@
         "upload" : false
       },
       "Tarrant County College NE, Heritage Room" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q7686664",
         "upload" : false
       },
       "Taylor Public Library" : {
@@ -38499,7 +38499,7 @@
         "upload" : false
       },
       "Texas A&M University Kingsville" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q7707478",
         "upload" : false
       },
       "Texas Archeological Society" : {
@@ -38531,7 +38531,7 @@
         "upload" : false
       },
       "Texas Gulf Historical Society" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q127513160",
         "upload" : false
       },
       "Texas Historical Commission" : {
@@ -38563,7 +38563,7 @@
         "upload" : false
       },
       "Texas State Genealogical Society" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q127625114",
         "upload" : false
       },
       "Texas State Historical Association" : {
@@ -38583,7 +38583,7 @@
         "upload" : false
       },
       "Texas Tech University Rawls College of Business" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q7297042",
         "upload" : false
       },
       "Texas Wesleyan University" : {
@@ -38599,7 +38599,7 @@
         "upload" : false
       },
       "The 12th Armored Division Memorial Museum" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q107320203",
         "upload" : false
       },
       "The Colony Public Library" : {
@@ -38607,7 +38607,7 @@
         "upload" : false
       },
       "The Dolph Briscoe Center for American History" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q5289588",
         "upload" : false
       },
       "The Grace Museum" : {
@@ -38619,7 +38619,7 @@
         "upload" : false
       },
       "The Library of Graham" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69491509",
         "upload" : false
       },
       "The Museum of Fine Arts, Houston" : {
@@ -38627,11 +38627,11 @@
         "upload" : false
       },
       "The Old Jail Art Center" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q92090211",
         "upload" : false
       },
       "The Sherman Museum" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q107321848",
         "upload" : false
       },
       "The Sixth Floor Museum at Dealey Plaza" : {
@@ -38639,7 +38639,7 @@
         "upload" : false
       },
       "The Thanks-Giving Foundation" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q28405347",
         "upload" : false
       },
       "The University of Texas at Dallas" : {
@@ -38647,11 +38647,11 @@
         "upload" : false
       },
       "The University of Texas – Rio Grande Valley" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q17028121",
         "upload" : false
       },
       "The Williamson Museum" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q17066354",
         "upload" : false
       },
       "Timpson Public Library" : {
@@ -38727,23 +38727,23 @@
         "upload" : false
       },
       "UNT Press" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q7895979",
         "upload" : false
       },
       "UT San Antonio Libraries Special Collections" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q21016293",
         "upload" : false
       },
       "UT Southwestern Medical Center Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q2725999",
         "upload" : false
       },
       "UT Southwestern Medical Center Special Collections Library and Archives" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q2725999",
         "upload" : false
       },
       "University Relations, Communications & Marketing department for UNT" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q860527",
         "upload" : false
       },
       "University of Dallas" : {
@@ -38751,7 +38751,7 @@
         "upload" : false
       },
       "University of Houston Libraries' Special Collections" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q108878346",
         "upload" : false
       },
       "University of North Texas" : {
@@ -38759,11 +38759,11 @@
         "upload" : false
       },
       "University of Texas Health Science Center Libraries" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q30264447",
         "upload" : false
       },
       "University of Texas MD Anderson Center" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q1525831",
         "upload" : false
       },
       "University of Texas Permian Basin" : {
@@ -38771,7 +38771,7 @@
         "upload" : false
       },
       "University of Texas at Arlington Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q73495409",
         "upload" : false
       },
       "University of Texas at El Paso" : {
@@ -38779,7 +38779,7 @@
         "upload" : false
       },
       "Upshur County Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69491501",
         "upload" : false
       },
       "Val Verde County Historical Commission" : {
@@ -38791,7 +38791,7 @@
         "upload" : false
       },
       "Vernon College" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q7922092",
         "upload" : false
       },
       "Victoria College/University of Houston-Victoria Library" : {
@@ -38799,7 +38799,7 @@
         "upload" : false
       },
       "Virgil and Josephine Gordon Memorial Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492068",
         "upload" : false
       },
       "Walker County Genealogical Society" : {
@@ -38811,7 +38811,7 @@
         "upload" : false
       },
       "Weatherford High School" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q7978285",
         "upload" : false
       },
       "Weslaco Museum" : {
@@ -38839,7 +38839,7 @@
         "upload" : false
       },
       "Whitewright Public Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69970343",
         "upload" : false
       },
       "Wiley College" : {
@@ -38863,9 +38863,9 @@
         "upload" : false
       },
       "Zula B. Wylie Memorial Library" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q69492245",
         "upload" : false
-      }
+      },
     },
     "upload" : true
   },
@@ -38873,7 +38873,7 @@
     "Wikidata" : "Q2928358",
     "institutions" : {
       "United States Government Publishing Office (GPO)" : {
-        "Wikidata" : "",
+        "Wikidata" : "Q2928358",
         "upload" : false
       }
     },

--- a/src/main/resources/wiki/institutions_v2.json
+++ b/src/main/resources/wiki/institutions_v2.json
@@ -38865,7 +38865,7 @@
       "Zula B. Wylie Memorial Library" : {
         "Wikidata" : "Q69492245",
         "upload" : false
-      },
+      }
     },
     "upload" : true
   },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added Wikidata IDs to multiple institutions in `institutions_v2.json`.
> 
>   - **Data Update**:
>     - Added Wikidata IDs for multiple institutions in `institutions_v2.json`.
>     - Examples include "African American Museum of Dallas" (Q4689666), "Albert and Shirley Small Special Collections Library" (Q15179080), and "Alexander Architectural Archive, University of Texas at Austin" (Q96203905).
>     - Over 100 institutions updated with their respective Wikidata IDs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for fc697518c9f2255677be6346b6c69fb3b16a25e7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->