### PR TITLE
Pruned obsolete contributing institutions with no Wikidata identifier.

### DIFF
--- a/src/main/resources/wiki/institutions_v2.json
+++ b/src/main/resources/wiki/institutions_v2.json
@@ -124,28 +124,8 @@
   "Big Sky Country Digital Network" : {
     "Wikidata" : "Q83878447",
     "institutions" : {
-      "Alternative Energy Resources Organization" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Augusta Area Historical Society Museum; Lewis & Clark Library Augusta Branch" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Beaverhead County Museum" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Big Horn County Library and Big Horn County Genealogical Society" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Big Sandy High School" : {
         "Wikidata" : "Q4906277",
-        "upload" : false
-      },
-      "Big Timber Carnegie Public Library" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Billings Public Library" : {
@@ -156,20 +136,12 @@
         "Wikidata" : "Q69482196",
         "upload" : false
       },
-      "Blaine County Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Bowman Regional Public Library" : {
         "Wikidata" : "",
         "upload" : false
       },
       "Bozeman Public Library" : {
         "Wikidata" : "Q4952827",
-        "upload" : false
-      },
-      "Bridger Canyon Women's Club" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Butte-Silver Bow Public Archives" : {
@@ -180,36 +152,8 @@
         "Wikidata" : "Q69481684",
         "upload" : false
       },
-      "C.M. Russell Museum" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Carroll College, Helena, Montana" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Carter County Museum" : {
         "Wikidata" : "Q18344059",
-        "upload" : false
-      },
-      "Carter County Museum, Tooke Bucking Horses" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Carter County Museum; Carter County High School (CCHS)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Cascade County Histoical Society; The History Museum" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Cascade County Historical Society; Cascade County Historical Society/The History Museum" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Cascade County Historical Society; The History Museum" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Casselton Heritage Center" : {
@@ -220,20 +164,8 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Choteau High School Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Chouteau County Library" : {
         "Wikidata" : "Q69481755",
-        "upload" : false
-      },
-      "Conrad Public Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Conrad Transportation and Historical Museum" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Darby Community Public Library" : {
@@ -248,10 +180,6 @@
         "Wikidata" : "Q69481731",
         "upload" : false
       },
-      "Drummond School and Community Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Eddy County Historical Society" : {
         "Wikidata" : "",
         "upload" : false
@@ -264,18 +192,6 @@
         "Wikidata" : "Q69481658",
         "upload" : false
       },
-      "Fort Peck Tribal Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Gallatin History Museum" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Garfield County Free Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Glacier County Library" : {
         "Wikidata" : "Q69481711",
         "upload" : false
@@ -284,15 +200,7 @@
         "Wikidata" : "Q373567",
         "upload" : false
       },
-      "Glendive Public Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Harvey Public Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Hearst Free Library; Copper Village Museum and Art Center" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -302,22 +210,6 @@
       },
       "Hellgate High School" : {
         "Wikidata" : "Q5707506",
-        "upload" : false
-      },
-      "Hellgate High School and Missoula County Public Schools" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Hobson Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Huntley Project Museum of Irrigated Agriculture" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "ImagineIF Libraries, Flathead County" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Judith Basin County Free Library" : {
@@ -332,35 +224,15 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Lewis & Clark Library; GFWC" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Lewis and Clark County" : {
         "Wikidata" : "Q496656",
-        "upload" : false
-      },
-      "Lewistown Public Library, Lewistown, Montana" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Liberty County Library" : {
         "Wikidata" : "Q69481691",
         "upload" : false
       },
-      "Liberty County Museum and MSU Liberty County Extension" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Logan County Historical Society" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "MSU Bilings Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "MSU Billings Library" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -384,39 +256,11 @@
         "Wikidata" : "Q69481816",
         "upload" : false
       },
-      "Montana Historical Society Research Center" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Montana State Historic Preservation Office" : {
         "Wikidata" : "Q58015044",
         "upload" : false
       },
-      "Montana State University Library, Special Collections" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Montana State University--Bozeman" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Montana State University--Bozeman. Associated Students" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Montana Tech Library, Montana Tech of The University of Montana" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Mott Public Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Museum of the Beartooths, Stillwater County, Columbus, MT" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Museum of the Beartooths, Stillwater County, MT" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -436,22 +280,6 @@
         "Wikidata" : "Q69481918",
         "upload" : false
       },
-      "North Lake County Public Library, Polson, Montana" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Northwest Montana History Museum" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Old Trail Museum" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Park High School" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Pembina County Historical Society" : {
         "Wikidata" : "",
         "upload" : false
@@ -460,15 +288,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Range Riders Museum, Inc. and Miles City Star" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Richland County Historical Museum" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Rocky Mountain College, Paul M. Adams Memorial Library" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -480,40 +300,12 @@
         "Wikidata" : "Q69481747",
         "upload" : false
       },
-      "Roundup Community Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Seeley-Swan High School Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Sheridan County Library" : {
         "Wikidata" : "Q69481828",
         "upload" : false
       },
-      "Sidney-Richland Public Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "State Historical Society of North Dakota" : {
         "Wikidata" : "Q7603365",
-        "upload" : false
-      },
-      "State Law Library of Montana" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "State Law Library of Montana; Montana Historical Society Research Center" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "The Historical Museum at Fort Missoula" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Theodore Roosevelt Center at Dickinson State University" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Toole County Library" : {
@@ -528,36 +320,8 @@
         "Wikidata" : "Q3551358",
         "upload" : false
       },
-      "University of Montana--Missoula. Mansfield Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "University of Montana-Missoula. Mansfield Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "University of Montana—Missoula" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Upper Musselshell Museum" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Upper Swan Valley Historical Society" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Valier Public Library" : {
         "Wikidata" : "Q69513959",
-        "upload" : false
-      },
-      "Valley County Historical Society" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Vande Bogart Library, Montana State University-Northern" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Walsh County Historical Society" : {
@@ -576,28 +340,8 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Winifred Museum" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "World Museum of Mining" : {
         "Wikidata" : "Q8035977",
-        "upload" : false
-      },
-      "Yellowstone Art Museum Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Yellowstone Gateway Museum" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Yellowstone Historic Center" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Yellowstone National Park Heritage and Research Center" : {
-        "Wikidata" : "",
         "upload" : false
       }
     },
@@ -614,15 +358,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "ASC - York University Libraries (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Abraham Lincoln Presidential Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Abraham Lincoln Presidential Library (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -638,10 +374,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Agriculture and Agri-Food Canada (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Alabama Academy of Science" : {
         "Wikidata" : "Q45133260",
         "upload" : false
@@ -654,15 +386,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Alberta Legislature Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Allen County Public Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Allen County Public Library Genealogy Center (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -710,10 +434,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Archives of Ontario (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Arkansas Native Plant Society" : {
         "Wikidata" : "",
         "upload" : false
@@ -731,10 +451,6 @@
         "upload" : false
       },
       "Auckland War Memorial Museum Tāmaki Paenga Hira" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Australasian Native Orchid Society" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -763,10 +479,6 @@
         "upload" : false
       },
       "Australian National Insect Collection" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Australian National Insect Collection (CSIRO)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -830,15 +542,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Booth Library, Eastern Illinois University (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Boston College Libraries" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Boston College Libraries (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -846,15 +550,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Boston Public Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Boston University Libraries" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Boston University Libraries (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -862,23 +558,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Brandeis University Libraries (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Brigham Young University Hawaii, Joseph F. Smith Library" : {
         "Wikidata" : "",
         "upload" : false
       },
-      "Brigham Young University Hawaii, Joseph F. Smith Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Brigham Young University-Idaho" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Brigham Young University-Idaho (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -890,10 +574,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Brock University (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Brooklyn Botanic Garden" : {
         "Wikidata" : "Q1360424",
         "upload" : false
@@ -902,15 +582,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Brown University Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Bureau of Land Management" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Bureau of Land Management (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -919,10 +591,6 @@
         "upload" : false
       },
       "California Department of Fish and Game" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "California Department of Fish and Game (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -942,10 +610,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "California State Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Cambridge University Library" : {
         "Wikidata" : "Q1028334",
         "upload" : false
@@ -955,10 +619,6 @@
         "upload" : false
       },
       "Canadiana.org" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Canadiana.org (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -990,10 +650,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Claire T. Carney Library, UMass Dartmouth (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Clemson University Libraries" : {
         "Wikidata" : "",
         "upload" : false
@@ -1003,10 +659,6 @@
         "upload" : false
       },
       "Columbia University Libraries" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Columbia University Libraries (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1066,15 +718,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Dorothy H. Hoover Library, Ontario College of Art & Design (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Duke University Libraries" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Duke University Libraries (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1098,15 +742,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Emory University, Manuscript, Archives and Rare Book Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Emory University, Pitts Theology Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Emory University, Pitts Theology Library (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1114,15 +750,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Emory University, Robert W. Woodruff Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Emory University, Woodruff Health Sciences Center Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Emory University, Woodruff Health Sciences Center Library (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1150,10 +778,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Environmental Services & Library Systems (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "European Association of Zoos and Aquaria" : {
         "Wikidata" : "Q60290",
         "upload" : false
@@ -1163,10 +787,6 @@
         "upload" : false
       },
       "FAO Regional Office for Africa" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "FAO Regional Office for Africa (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1198,10 +818,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Fordham University Libraries (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Fossil Collectors' Association of Australasia" : {
         "Wikidata" : "",
         "upload" : false
@@ -1210,19 +826,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Francis A. Countway Library of Medicine (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Friends of the Innamincka Reserves" : {
         "Wikidata" : "",
         "upload" : false
       },
       "Frost - York University Libraries" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Frost - York University Libraries (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1239,10 +847,6 @@
         "upload" : false
       },
       "Glasgow Natural History Society" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Golden Gate Audubon Society" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1263,10 +867,6 @@
         "upload" : false
       },
       "Harold B. Lee Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Harold B. Lee Library (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1295,10 +895,6 @@
         "upload" : false
       },
       "History of Modern Biomedicine Research Group" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "History of Modern Biomedicine Research Group (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1382,15 +978,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "John Adams Library at the Boston Public Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "John Carter Brown Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "John Carter Brown Library (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1398,23 +986,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "John Gilmore (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Joint Committee on Taxation, US Congress" : {
         "Wikidata" : "",
         "upload" : false
       },
-      "Joint Committee on Taxation, US Congress (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Joseph Palmer Knapp Library, UNC School of Government" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Joseph Palmer Knapp Library, UNC School of Government (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1446,15 +1022,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "King's College London, Foyle Special Collections Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Lancaster County Historical Society" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Lancaster County Historical Society (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1466,15 +1034,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Law Library, University of North Carolina at Chapel Hill (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Leo Baeck Institute Archives" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Leo Baeck Institute Archives (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1482,15 +1042,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Lewis & Clark Community College / NGRREC (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Library and Archives Canada - Bibliothèque et Archives Canada" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Library and Archives Canada - Bibliothèque et Archives Canada (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1502,19 +1054,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Library of the Marine Corps (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Library of the Netherlands Entomological Society, Naturalis Biodiversity Center" : {
         "Wikidata" : "",
         "upload" : false
       },
       "Lincoln Financial Collection" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Lincoln Financial Collection (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1531,10 +1075,6 @@
         "upload" : false
       },
       "London School of Hygiene & Tropical Medicine Library & Archives Service" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "London School of Hygiene & Tropical Medicine Library & Archives Service (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1558,10 +1098,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "MIT Libraries (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Mantis Study Group" : {
         "Wikidata" : "Q51389893",
         "upload" : false
@@ -1575,10 +1111,6 @@
         "upload" : false
       },
       "McGill University Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "McGill University Library (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1610,15 +1142,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Montana State Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Morris Library, Southern Illinois University Carbondale" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Morris Library, Southern Illinois University Carbondale (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1627,10 +1151,6 @@
         "upload" : false
       },
       "Mugar Memorial Library, Boston University" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Mugar Memorial Library, Boston University (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1678,23 +1198,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "NC History of Health Digital Collection (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "NCSU Libraries" : {
         "Wikidata" : "",
         "upload" : false
       },
-      "NCSU Libraries (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "NIH Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "NIH Library (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1706,23 +1214,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "National Library of Medicine (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "National Library of Norway" : {
         "Wikidata" : "",
         "upload" : false
       },
-      "National Library of Norway (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "National Library of Scotland" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "National Library of Scotland (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1758,19 +1254,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Naturbruksskolornas Förening (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Nature Kenya, East Africa Natural History Society" : {
         "Wikidata" : "",
         "upload" : false
       },
       "Naval Postgraduate School" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Naval Postgraduate School (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1782,19 +1270,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "New College of California (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "New York Botanical Garden, LuEsther T. Mertz Library" : {
         "Wikidata" : "",
         "upload" : false
       },
       "New York Public Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "New York Public Library (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1807,10 +1287,6 @@
         "upload" : false
       },
       "Nipissing University/Canadore College Libraries" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Nipissing University/Canadore College Libraries (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1831,10 +1307,6 @@
         "upload" : false
       },
       "Northeastern University, Snell Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Northeastern University, Snell Library (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1866,15 +1338,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Ontario Ministry of Natural Resources Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Ontario Ministry of the Environment" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Ontario Ministry of the Environment (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1902,10 +1366,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Penn State University (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Pennsylvania Horticultural Society" : {
         "Wikidata" : "Q7163761",
         "upload" : false
@@ -1915,10 +1375,6 @@
         "upload" : false
       },
       "Philadelphia Museum of Art, Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Philadelphia Museum of Art, Library (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1942,23 +1398,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Prelinger Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Princeton Theological Seminary Library" : {
         "Wikidata" : "",
         "upload" : false
       },
-      "Princeton Theological Seminary Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Public.Resource.Org" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Public.Resource.Org (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1967,10 +1411,6 @@
         "upload" : false
       },
       "Queen's University, W.D. Jordan Special Collections & Music Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Queen's University, W.D. Jordan Special Collections & Music Library (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -1994,10 +1434,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Research Library, The Getty Research Institute (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Ringwood Field Naturalists Club" : {
         "Wikidata" : "",
         "upload" : false
@@ -2011,10 +1447,6 @@
         "upload" : false
       },
       "Roman Catholic Archdiocese of Toronto" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Roman Catholic Archdiocese of Toronto (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2034,23 +1466,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Royal College of Physicians in Edinburgh (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Royal College of Physicians, London" : {
         "Wikidata" : "",
         "upload" : false
       },
-      "Royal College of Physicians, London (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Royal College of Surgeons of England" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Royal College of Surgeons of England (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2059,10 +1479,6 @@
         "upload" : false
       },
       "Royal Ontario Museum" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Royal Ontario Museum (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2086,15 +1502,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Rutgers University Libraries (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Ryerson University Library Special Collections" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Ryerson University Library Special Collections (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2106,15 +1514,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Saint Louis Public Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Saint Mary's College of California" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Saint Mary's College of California (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2130,15 +1530,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "San Francisco Public Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "School of Government Library, University of North Carolina at Chapel Hill" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "School of Government Library, University of North Carolina at Chapel Hill (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2146,15 +1538,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "School of Theology, Boston University (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Scott - York University Libraries" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Scott - York University Libraries (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2218,15 +1602,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "State Botanical Collection, Royal Botanic Gardens Victoria" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "State Library of Massachusetts" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "State Library of Massachusetts (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2238,15 +1614,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "State Library of North Carolina (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "State Library of Pennsylvania" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "State Library of Pennsylvania (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2255,10 +1623,6 @@
         "upload" : false
       },
       "Sterling and Francine Clark Art Institute Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Sterling and Francine Clark Art Institute Library (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2271,10 +1635,6 @@
         "upload" : false
       },
       "Sweet Briar College" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Sweet Briar College (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2306,23 +1666,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "The Arboretum Library at the Los Angeles County Arboretum and Botanic Garden" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "The Bancroft Library" : {
         "Wikidata" : "",
         "upload" : false
       },
-      "The Bancroft Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "The Coleopterists Society" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "The Fossil Collectors' Association of Australasia" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2335,10 +1683,6 @@
         "upload" : false
       },
       "The Johns Hopkins University Sheridan Libraries" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "The Johns Hopkins University Sheridan Libraries (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2362,19 +1706,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "The Newberry Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "The Royal Botanic Gardens and Domain Trust, New South Wales, Australia" : {
         "Wikidata" : "",
         "upload" : false
       },
       "The University of Western Ontario, Western Archives" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "The University of Western Ontario, Western Archives (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2390,23 +1726,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Tisch Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Toronto Public Library : North York Central" : {
         "Wikidata" : "",
         "upload" : false
       },
-      "Toronto Public Library : North York Central (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Toronto Public Library: Research and Reference Libraries" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Toronto Public Library: Research and Reference Libraries (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2419,10 +1743,6 @@
         "upload" : false
       },
       "Tufts University" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Tufts University (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2442,15 +1762,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "U.S. Dept. of the Treasury, Treasury Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "U.S. Government Printing Office" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "U.S. Government Printing Office (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2458,15 +1770,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "UCL Library Services, University College London (UCL) (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "UCLA Library, Preservation Department" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "UCLA Library, Preservation Department (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2474,15 +1778,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "UMass Amherst Libraries (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "UNEP-WCMC, Cambridge" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "UNEP-WCMC, Cambridge (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2494,15 +1790,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Univ. of Mass Medical School, Lamar Soutter Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Universal Digital Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Universal Digital Library (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2526,14 +1814,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "University Library, University of North Carolina at Chapel Hill (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "University of Alberta Libraries (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "University of Alberta Library" : {
         "Wikidata" : "",
         "upload" : false
@@ -2550,15 +1830,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "University of British Columbia Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "University of California" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "University of California (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2566,23 +1838,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "University of California Libraries (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "University of California, Davis Libraries" : {
         "Wikidata" : "",
         "upload" : false
       },
-      "University of California, Davis Libraries (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "University of Connecticut Libraries" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "University of Connecticut Libraries (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2598,15 +1858,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "University of Glasgow Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "University of Illinois at Chicago" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "University of Illinois at Chicago (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2622,15 +1874,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "University of Maryland, College Park (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "University of Michigan" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "University of Michigan (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2638,15 +1882,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "University of New Hampshire Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "University of North Carolina at Chapel Hill" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "University of North Carolina at Chapel Hill (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2654,23 +1890,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "University of Ottawa (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "University of Pennsylvania Libraries" : {
         "Wikidata" : "",
         "upload" : false
       },
-      "University of Pennsylvania Libraries (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "University of Pittsburgh Library System" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "University of Pittsburgh Library System (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2679,10 +1903,6 @@
         "upload" : false
       },
       "University of Southampton" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "University of Southampton (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2810,23 +2030,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Webster Family Library of Veterinary Medicine (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Wellcome Library" : {
         "Wikidata" : "",
         "upload" : false
       },
-      "Wellcome Library (archive.org)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Wellesley College Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Wellesley College Library (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2835,10 +2043,6 @@
         "upload" : false
       },
       "West Virginia University Libraries" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "West Virginia University Libraries (archive.org)" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -2863,10 +2067,6 @@
         "upload" : false
       },
       "Williams College Libraries" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Williams College Libraries (archive.org)-DELETE" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -3776,10 +2976,6 @@
         "Wikidata" : "Q2901530",
         "upload" : false
       },
-      "San Francisco State University, J. Paul Leonard Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "San Francisco State University, Labor Archives and Research Center" : {
         "Wikidata" : "",
         "upload" : false
@@ -4060,10 +3256,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "UC Cooperative Extension Archive" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "UC Davis, University Library, Special Collections" : {
         "Wikidata" : "",
         "upload" : false
@@ -4181,10 +3373,6 @@
         "upload" : false
       },
       "UC Santa Cruz, Special Collections and Archives" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "UCLA, Charles E. Young Research Library" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -4936,10 +4124,6 @@
         "Wikidata" : "Q4818564",
         "upload" : false
       },
-      "Atwood House Museum of the Chatham Historical Society" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Atwood Museum of the Chatham Historical Society" : {
         "Wikidata" : "",
         "upload" : false
@@ -5273,10 +4457,6 @@
         "upload" : false
       },
       "Faulkner Morgan Archive" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Faulkner-Morgan Pagan Babies Archive" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -5768,10 +4948,6 @@
         "Wikidata" : "Q72174465",
         "upload" : false
       },
-      "Latino GLBT History Project" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Lawrence History Center" : {
         "Wikidata" : "Q72377261",
         "upload" : false
@@ -5814,10 +4990,6 @@
       },
       "Library of Congress" : {
         "Wikidata" : "Q131454",
-        "upload" : false
-      },
-      "Lili Elbe Archive" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Lincoln Public Library" : {
@@ -7778,10 +6950,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Reese Library. Special Collections" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Regional African American Museum of Northeast GA, Inc" : {
         "Wikidata" : "",
         "upload" : false
@@ -7830,10 +6998,6 @@
         "Wikidata" : "Q7587158",
         "upload" : false
       },
-      "Saint Johns County School District (Fla.)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Samuel Proctor Oral History Program" : {
         "Wikidata" : "Q16980590",
         "upload" : false
@@ -7870,10 +7034,6 @@
         "Wikidata" : "Q6765691",
         "upload" : false
       },
-      "Sounding Spirit (Project)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "South Carolina Digital Library" : {
         "Wikidata" : "",
         "upload" : false
@@ -7908,10 +7068,6 @@
       },
       "St. Augustine Historical Society" : {
         "Wikidata" : "Q54322406",
-        "upload" : false
-      },
-      "St. Johns County Sheriff's Office" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "St. Paul's Church (Augusta, Ga.)" : {
@@ -9162,10 +8318,6 @@
       },
       "Baltimore and Ohio Railroad Museum" : {
         "Wikidata" : "Q805753",
-        "upload" : false
-      },
-      "Baltimore-Washington Conference Archives, Lovely Lane United Methodist Church, Baltimore, Maryland" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Brunswick Public Library, Frederick County Public Libraries" : {
@@ -20668,10 +19820,6 @@
   "Harvard Library" : {
     "Wikidata" : "Q3232931",
     "institutions" : {
-      "Andover-Harvard Theological Library, Harvard Divinity School, Harvard University" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Arnold Arboretum Horticultural Library (Jamaica Plain), Harvard University" : {
         "Wikidata" : "",
         "upload" : false
@@ -20756,10 +19904,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Government Documents and Microforms Collection, Harvard Library, Harvard University" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Gray Herbarium Library, Botany Libraries, Harvard University" : {
         "Wikidata" : "",
         "upload" : false
@@ -20837,10 +19981,6 @@
         "upload" : false
       },
       "Master Microforms, Harvard University" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Microforms, Lamont Library, Harvard University" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -21045,22 +20185,6 @@
         "upload" : false
       },
       "Archive.Org through Missouri Digital Heritage" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Archives at the University of Missouri Columbia through Missouri Digital Heritage" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Archives at the University of Missouri-Columbia through Missouri Digital Heritage" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Archives of the University of Missouri Columbia through Missouri Digital Heritage" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Archives of the University of Missouri-Columbia through Missouri Digital Heritage" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -21908,10 +21032,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "St. Louis County Library through Missouri Digital Heritage" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "St. Louis Daily Globe-Democrat through Missouri Digital Heritage" : {
         "Wikidata" : "",
         "upload" : false
@@ -22350,10 +21470,6 @@
   "Illinois Digital Heritage Hub" : {
     "Wikidata" : "Q83878467",
     "institutions" : {
-      "0035_MCGSR_001.jpg" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Abraham Lincoln Presidential Library & Museum" : {
         "Wikidata" : "Q330237",
         "upload" : false
@@ -22506,10 +21622,6 @@
         "Wikidata" : "Q5290854",
         "upload" : false
       },
-      "Donald Horn" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Downers Grove Public Library" : {
         "Wikidata" : "",
         "upload" : false
@@ -22532,14 +21644,6 @@
       },
       "Elgin History Museum" : {
         "Wikidata" : "Q5360013",
-        "upload" : false
-      },
-      "Elgin History Museum http://elginhistory.org" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Elgin History Museum; https://elginhistory.org" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Ella Johnson Memorial Public Library District" : {
@@ -22588,14 +21692,6 @@
       },
       "Fountaindale Public Library District" : {
         "Wikidata" : "Q69473611",
-        "upload" : false
-      },
-      "Friends of the Pullman State Historic Site" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Gail Borden Public LIbrary District" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Gail Borden Public Library District" : {
@@ -22676,10 +21772,6 @@
       },
       "Huntley Area Public Library District" : {
         "Wikidata" : "Q69966199",
-        "upload" : false
-      },
-      "Illinois" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Illinois Center for the Book" : {
@@ -23852,10 +22944,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Henry County Historical Society (Ind.)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Herron Art Library" : {
         "Wikidata" : "Q97570005",
         "upload" : true
@@ -24100,10 +23188,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Indiana Room, Huntington City-Township Public Library, Huntington, Indiana" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Indiana School for the Deaf" : {
         "Wikidata" : "Q14688456",
         "upload" : false
@@ -24324,10 +23408,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Kane, Beverle Miller" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Knox County Public Library" : {
         "Wikidata" : "",
         "upload" : false
@@ -24341,14 +23421,6 @@
         "upload" : false
       },
       "Knox County Public Library; McGrady Brockman Archives" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Kraft, Gerald" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Kravig, Courtney" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -24369,10 +23441,6 @@
         "upload" : false
       },
       "Lemstra, Enid" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Levy, William" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -24436,10 +23504,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Mallah, Lee" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Manchester University (North Manchester, Ind.)" : {
         "Wikidata" : "",
         "upload" : false
@@ -24456,10 +23520,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Marshall, Sloan" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Mary Strome to Elizabeth Gardner to Clinton PL" : {
         "Wikidata" : "",
         "upload" : false
@@ -24469,10 +23529,6 @@
         "upload" : false
       },
       "Maurer School of Law" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Mayfield, Kim" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -24500,10 +23556,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Miller, Beatrice Pete" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Milton, Sadie" : {
         "Wikidata" : "",
         "upload" : false
@@ -24512,24 +23564,12 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Moore, Cleo" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Moore, Esther" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Moore, Normajo Ramsey" : {
         "Wikidata" : "",
         "upload" : false
       },
       "Moore, Robert" : {
         "Wikidata" : "Q19052980",
-        "upload" : false
-      },
-      "Mordoh, Alvin" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Multiple Institutions" : {
@@ -24548,24 +23588,12 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Murff, Anderson" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Murff, Robert" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "NCPL Weldon Collection" : {
         "Wikidata" : "",
         "upload" : false
       },
       "Nahmias" : {
         "Wikidata" : "Q37282389",
-        "upload" : false
-      },
-      "Nahmias, Esther" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Nappanee Public Library" : {
@@ -24584,18 +23612,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Nefouse, Lonnie" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Nejako, Emily" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Newsom, Jacqlynn" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Newspaper section, Indiana State Library" : {
         "Wikidata" : "Q14688462",
         "upload" : true
@@ -24606,10 +23622,6 @@
       },
       "Nisenbaum" : {
         "Wikidata" : "Q36970057",
-        "upload" : false
-      },
-      "Nisenbaum, Galdys Cohen" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Nissenbaum, Gladys Cohen" : {
@@ -24692,10 +23704,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Pendleton, Shelby" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Penzenik, Christopher" : {
         "Wikidata" : "",
         "upload" : false
@@ -24756,14 +23764,6 @@
         "Wikidata" : "Q120000385",
         "upload" : true
       },
-      "Rohde, Erin" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Ron Crain" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Rose-Hulman Institute of Technology Logan Library" : {
         "Wikidata" : "",
         "upload" : false
@@ -24785,18 +23785,6 @@
         "upload" : false
       },
       "Saoirse – Irish Freedom" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Sapper, Sema Goldstein" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Schneider, William (Keystone Lantern Slides)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Schwartz, Henrietta" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -24824,10 +23812,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Smith, Megan" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Smith, Michael" : {
         "Wikidata" : "Q19042743",
         "upload" : false
@@ -24841,10 +23825,6 @@
         "upload" : false
       },
       "Southport High School Alumni Association" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Speedway Public Schools, James A. Allison Elementary" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -24864,19 +23844,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Starke County Historical Society, Knox, Indiana" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Stephon, Helen" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Still Image; Photographs" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Stillerman, Dan" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -24917,10 +23885,6 @@
         "upload" : true
       },
       "The Maurer School of Law, Indiana University, Bloomington" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "The Passo Family" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -25008,10 +23972,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Ward, Terry Hazen" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Warren Central High School Media Complex" : {
         "Wikidata" : "",
         "upload" : false
@@ -25021,10 +23981,6 @@
         "upload" : false
       },
       "Wayne Branch, Indianapolis Public Libray" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Webb, Joan" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -25742,6 +24698,10 @@
         "Wikidata" : "",
         "upload" : false
       },
+      "Fr. Th Vischer" : {
+        "Wikidata" : "",
+        "upload" : false
+      },
       "Framingham Public Library" : {
         "Wikidata" : "Q69477643",
         "upload" : false
@@ -26342,6 +25302,10 @@
         "Wikidata" : "",
         "upload" : false
       },
+      "Monson Free Library" : {
+        "Wikidata" : "",
+        "upload" : false
+      },
       "Montachusett Regional Vocational Technical High School" : {
         "Wikidata" : "",
         "upload" : false
@@ -26358,8 +25322,16 @@
         "Wikidata" : "",
         "upload" : false
       },
+      "Montana Teachers' Retirement System" : {
+        "Wikidata" : "",
+        "upload" : false
+      },
       "Montana state Library" : {
         "Wikidata" : "Q30268156",
+        "upload" : false
+      },
+      "Montana. Department of Fish, Wildlife, and Parks" : {
+        "Wikidata" : "",
         "upload" : false
       },
       "Montana. Secretary of State" : {
@@ -27014,6 +25986,10 @@
         "Wikidata" : "",
         "upload" : false
       },
+      "Town of Orange" : {
+        "Wikidata" : "",
+        "upload" : false
+      },
       "Town of Sandisfield" : {
         "Wikidata" : "",
         "upload" : false
@@ -27338,6 +26314,10 @@
         "Wikidata" : "",
         "upload" : false
       },
+      "Whately Historical Society" : {
+        "Wikidata" : "",
+        "upload" : false
+      },
       "Wheaton College" : {
         "Wikidata" : "",
         "upload" : false
@@ -27524,10 +26504,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Library of Congress Geography and Map Division Washington, D.C. 20540-4650 duc." : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Library of Congress Manuscript Division Washington, D.C. 20540-4650 dcu" : {
         "Wikidata" : "",
         "upload" : false
@@ -27594,10 +26570,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "International Institute of Social History" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Lakeshore Museum Center" : {
         "Wikidata" : "",
         "upload" : false
@@ -27639,10 +26611,6 @@
         "upload" : false
       },
       "Western Michigan University. Libraries" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Yale University Library" : {
         "Wikidata" : "",
         "upload" : false
       }
@@ -27711,10 +26679,6 @@
       "Blue Earth County Historical Society" : {
         "Wikidata" : "Q108556264",
         "upload" : true
-      },
-      "Calhoun Yacht Club" : {
-        "Wikidata" : "",
-        "upload" : false
       },
       "Carleton College" : {
         "Wikidata" : "Q1041671",
@@ -27832,10 +26796,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Excelsior-Lake Minnetonka Historical Society" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Faribault County Historical Society" : {
         "Wikidata" : "",
         "upload" : false
@@ -27882,14 +26842,6 @@
       },
       "Hamline University" : {
         "Wikidata" : "Q1366519",
-        "upload" : false
-      },
-      "Hamline University School of Law" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Hamline University School of Law. Office of Alumni Relations" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Hazelden Foundation" : {
@@ -27968,10 +26920,6 @@
         "Wikidata" : "Q30258031",
         "upload" : false
       },
-      "Kautz Family YMCA Archives, University of Minnesota Libraries" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Lake County Historical Society" : {
         "Wikidata" : "",
         "upload" : false
@@ -28017,10 +26965,6 @@
         "upload" : false
       },
       "Mesabi Range College Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Midwestern School of Law" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -28144,10 +27088,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Museum of Lake Minnetonka" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "New Brighton Area Historical Society" : {
         "Wikidata" : "",
         "upload" : false
@@ -28208,10 +27148,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Northwestern College" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Northwestern Health Sciences University" : {
         "Wikidata" : "",
         "upload" : false
@@ -28249,10 +27185,6 @@
         "upload" : false
       },
       "Pipestone County Historical Society" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Plymouth Congregational Church" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -28392,10 +27324,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "St. Paul Public Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "St. Peter Regional Treatment Center" : {
         "Wikidata" : "",
         "upload" : false
@@ -28436,21 +27364,9 @@
         "Wikidata" : "Q7726780",
         "upload" : false
       },
-      "The English Department of Northwestern College" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "The English Department of the University of Northwestern–St. Paul" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "The History Center, Archives of Bethel University and Converge Worldwide - BGC" : {
         "Wikidata" : "Q3445045",
         "upload" : true
-      },
-      "The Public Relations Office of Northwestern College" : {
-        "Wikidata" : "",
-        "upload" : false
       },
       "Todd County Historical Society" : {
         "Wikidata" : "",
@@ -28552,10 +27468,6 @@
         "Wikidata" : "Q130236027",
         "upload" : true
       },
-      "Westonka Historical Society" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "White Bear Lake Area Historical Society" : {
         "Wikidata" : "",
         "upload" : false
@@ -28603,10 +27515,6 @@
         "upload" : false
       },
       "Bryner Pioneer Museum (Price, UT)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Buffalo Bill Center of the West, McCracken Research Library" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -28738,10 +27646,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Morgan County (UT) Historical Society and Morgan County (UT) Public Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Murray (UT) Museum" : {
         "Wikidata" : "",
         "upload" : false
@@ -28810,10 +27714,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Salt Lake Community College Libraries" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Snow College Libraries" : {
         "Wikidata" : "",
         "upload" : false
@@ -28831,10 +27731,6 @@
         "upload" : false
       },
       "Tremonton (UT) City Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Tremonton City (UT) Library" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -28882,10 +27778,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "University of Utah - College of Art" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "University of Utah - J. Willard Marriott Library" : {
         "Wikidata" : "",
         "upload" : false
@@ -28910,20 +27802,12 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Utah Department of Administrative Services - Division of Administrative Rules" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Utah Department of Cultural and Community Engagement" : {
         "Wikidata" : "",
         "upload" : false
       },
       "Utah Museum of Contemporary Art" : {
         "Wikidata" : "Q21016297",
-        "upload" : false
-      },
-      "Utah State Archives" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Utah State Library" : {
@@ -28947,10 +27831,6 @@
         "upload" : false
       },
       "Weber State University - Stewart Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Westminster College - Giovale Library" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -28997,10 +27877,6 @@
         "upload" : false
       },
       "Delaware City Public Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Delaware Collections" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -29158,6 +28034,10 @@
   "National Archives and Records Administration" : {
     "Wikidata" : "Q518155",
     "institutions" : {
+      "Archival Operations Division" : {
+        "Wikidata" : "",
+        "upload" : false
+      },
       "Barack Obama Presidential Library" : {
         "Wikidata" : "Q59661289",
         "upload" : false
@@ -30312,10 +29192,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Polk County Public Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Queens University of Charlotte" : {
         "Wikidata" : "Q7270829",
         "upload" : false
@@ -30696,10 +29572,6 @@
         "Wikidata" : "Q8025153",
         "upload" : false
       },
-      "Winston Salem African American Archive" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Winston-Salem African American Archive" : {
         "Wikidata" : "",
         "upload" : false
@@ -30814,10 +29686,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Canyon Birders" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Cathlamet Public Library" : {
         "Wikidata" : "",
         "upload" : false
@@ -30906,19 +29774,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Colville National Forest (Wash.)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Community Action" : {
         "Wikidata" : "",
         "upload" : false
       },
       "Connell Downtown Development Association" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Connell Heritage Museum" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -31430,10 +30290,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Oregon State University, Oregon Multicultural Archives" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Pacific Citizen" : {
         "Wikidata" : "",
         "upload" : false
@@ -31794,10 +30650,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Whatcom County Library System" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Whatcom County Library System, Deming Library" : {
         "Wikidata" : "",
         "upload" : false
@@ -31951,10 +30803,6 @@
         "upload" : false
       },
       "Bexley Public Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Bowling Green State University" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -32132,33 +30980,13 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "George Fox University Archives" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Lewis & Clark College, Special Collections and Archives" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Linfield College" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Oregon Institute of Technology Libraries, Shaw Historical Library" : {
         "Wikidata" : "",
         "upload" : false
       },
       "Oregon State Archives" : {
         "Wikidata" : "Q7101346",
         "upload" : true
-      },
-      "Oregon State University Libraries, Special Collections and Archives Research Center" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Reed College" : {
-        "Wikidata" : "",
-        "upload" : false
       },
       "Seattle Pacific University" : {
         "Wikidata" : "",
@@ -32168,32 +30996,8 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "University of Idaho Library, Special Collections and Archives" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "University of Oregon Libraries, Special Collections and University Archives" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "University of Portland" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "University of Puget Sound, Archives & Special Collections" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Washington State University Libraries, Manuscripts, Archives, and Special Collections" : {
         "Wikidata" : "Q27991313",
-        "upload" : false
-      },
-      "Western Oregon University Archives" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Willamette University Archives and Special Collections" : {
-        "Wikidata" : "",
         "upload" : false
       }
     },
@@ -32386,10 +31190,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Eastern State Penitentiary Historic Site" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Elizabethtown College" : {
         "Wikidata" : "Q5363873",
         "upload" : false
@@ -32562,10 +31362,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Milton Hershey School – Hershey Community Archives" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Mongomery County Community College" : {
         "Wikidata" : "",
         "upload" : false
@@ -32666,19 +31462,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Pittsburgh City Archives" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Pittsburgh History and Landmarks Foundation" : {
         "Wikidata" : "Q7199297",
         "upload" : false
       },
       "Pittsburgh Symphony Orchestra Archives" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Point Park University" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -32754,19 +31542,7 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "St. Marys Pubic Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "St. Marys Public LIbrary" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "St. Marys Public Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "St. Marys Public Liibrary" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -32838,10 +31614,6 @@
         "Wikidata" : "Q235034",
         "upload" : false
       },
-      "University of Pittsburgh, Global Studies Center" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "University of Scranton" : {
         "Wikidata" : "Q2495907",
         "upload" : false
@@ -32905,10 +31677,6 @@
       "Woodland Hills High School Library" : {
         "Wikidata" : "",
         "upload" : false
-      },
-      "iLead Pennsylvania" : {
-        "Wikidata" : "",
-        "upload" : false
       }
     },
     "upload" : false
@@ -32949,10 +31717,6 @@
         "upload" : false
       },
       "Black Citizens and Friends (Grand Junction, Colorado)" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Broomfield Depot Museum" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -33024,10 +31788,6 @@
         "Wikidata" : "Q110673471",
         "upload" : true
       },
-      "Colorado State University. Libraries; Colorado State University. Libraries" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Denver Museum of Nature and Science" : {
         "Wikidata" : "Q3330052",
         "upload" : false
@@ -33096,10 +31856,6 @@
         "Wikidata" : "Q5774674",
         "upload" : false
       },
-      "Hot Springs County Museum & Cultural Center" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Hotchkiss-Crawford Historical Society" : {
         "Wikidata" : "",
         "upload" : false
@@ -33113,10 +31869,6 @@
         "upload" : false
       },
       "Lafayette Miners Museum" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Lakewood Heritage Center" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -33578,10 +32330,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Monarch Library System" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Monticello Public Library" : {
         "Wikidata" : "",
         "upload" : false
@@ -33788,10 +32536,6 @@
       },
       "Viterbo University" : {
         "Wikidata" : "Q7937045",
-        "upload" : false
-      },
-      "Waldemar Ager Association" : {
-        "Wikidata" : "",
         "upload" : false
       },
       "Waunakee Public Library" : {
@@ -34362,6 +33106,10 @@
         "Wikidata" : "",
         "upload" : false
       },
+      "Chester County Historical Society. Chester County (S.C.)" : {
+        "Wikidata" : "",
+        "upload" : false
+      },
       "Chester Historical Society. Chester County (S.C.)" : {
         "Wikidata" : "",
         "upload" : false
@@ -34399,6 +33147,10 @@
         "upload" : false
       },
       "City of Columbia (S.C.)" : {
+        "Wikidata" : "",
+        "upload" : false
+      },
+      "City of Mullins, South Carolina" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -35734,11 +34486,19 @@
         "Wikidata" : "Q30268245",
         "upload" : false
       },
+      "South Carolina State Lirbary" : {
+        "Wikidata" : "",
+        "upload" : false
+      },
       "South Carolina State Museum" : {
         "Wikidata" : "Q7566640",
         "upload" : false
       },
       "South Carolina State Parks" : {
+        "Wikidata" : "",
+        "upload" : false
+      },
+      "South Carolina State Record" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -35763,10 +34523,6 @@
         "upload" : false
       },
       "Sparkle" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Spartanburg Counties Public Libraries" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -35815,10 +34571,6 @@
         "upload" : false
       },
       "Summerville Museum and Research Center" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Sumter County Museum" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -36554,10 +35306,6 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Stephen F. Austin State University" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Texas Woman's University Libraries" : {
         "Wikidata" : "",
         "upload" : false
@@ -36597,10 +35345,6 @@
         "upload" : false
       },
       "Dorot Jewish Division. The New York Public Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Dorothy and Lewis B. Cullman Center for Scholars & Writers. The New York Public Library" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -36652,6 +35396,10 @@
         "Wikidata" : "",
         "upload" : false
       },
+      "Reserve Film and Video Collection. The New York Public Library" : {
+        "Wikidata" : "",
+        "upload" : false
+      },
       "Rodgers and Hammerstein Archives of Recorded Sound. The New York Public Library" : {
         "Wikidata" : "",
         "upload" : false
@@ -36669,10 +35417,6 @@
         "upload" : false
       },
       "Schomburg Center for Research in Black Culture, Photographs and Prints Division. The New York Public Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
-      "Science, Industry and Business Library: General Collection. The New York Public Library" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -36882,10 +35626,6 @@
         "Wikidata" : "Q2759819",
         "upload" : false
       },
-      "Botanical Research Institute of Texas Library" : {
-        "Wikidata" : "",
-        "upload" : false
-      },
       "Bowie Public Library" : {
         "Wikidata" : "Q69492227",
         "upload" : false
@@ -37054,6 +35794,10 @@
         "Wikidata" : "Q21028309",
         "upload" : false
       },
+      "Clear Lake Shores Civic Club" : {
+        "Wikidata" : "",
+        "upload" : false
+      },
       "Cleng Peerson Research Library at the Bosque Museum" : {
         "Wikidata" : "",
         "upload" : false
@@ -37123,6 +35867,10 @@
         "upload" : false
       },
       "Czech Ex-Students Association of Texas" : {
+        "Wikidata" : "",
+        "upload" : false
+      },
+      "Czech Heritage Society of Texas" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -37526,6 +36274,10 @@
         "Wikidata" : "Q15223713",
         "upload" : false
       },
+      "Heritage Society at Sam Houston Park" : {
+        "Wikidata" : "",
+        "upload" : false
+      },
       "Higgins Public Library" : {
         "Wikidata" : "Q69492256",
         "upload" : false
@@ -37554,11 +36306,11 @@
         "Wikidata" : "",
         "upload" : false
       },
-      "Hoston History Research Center at Houston Public Library" : {
+      "Houston Earlier Texas Art Group" : {
         "Wikidata" : "",
         "upload" : false
       },
-      "Houston Earlier Texas Art Group" : {
+      "Houston History Research Center at Houston Public Library" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -37878,6 +36630,10 @@
         "Wikidata" : "Q6971981",
         "upload" : false
       },
+      "National Juneteenth Museum" : {
+        "Wikidata" : "",
+        "upload" : false
+      },
       "National Museum of the Pacific War/Admiral Nimitz Foundation" : {
         "Wikidata" : "Q6974516",
         "upload" : false
@@ -37966,6 +36722,10 @@
         "Wikidata" : "",
         "upload" : false
       },
+      "Panhandle Archeological Society" : {
+        "Wikidata" : "",
+        "upload" : false
+      },
       "Panhandle-Plains Historical Museum" : {
         "Wikidata" : "Q7131023",
         "upload" : false
@@ -37995,6 +36755,10 @@
         "upload" : false
       },
       "Pioneer City County Museum" : {
+        "Wikidata" : "",
+        "upload" : false
+      },
+      "Plano Public Library" : {
         "Wikidata" : "",
         "upload" : false
       },
@@ -38659,6 +37423,10 @@
         "upload" : false
       },
       "Tittle-Luther/Parkhill, Smith and Cooper, Inc" : {
+        "Wikidata" : "",
+        "upload" : false
+      },
+      "Tomball Museum Center" : {
         "Wikidata" : "",
         "upload" : false
       },

--- a/src/main/scala/dpla/ingestion3/entries/utils/UpdateInstitutions.scala
+++ b/src/main/scala/dpla/ingestion3/entries/utils/UpdateInstitutions.scala
@@ -256,20 +256,16 @@ object UpdateInstitutions {
       .toMap
 
     val oldContributors = prevHub.institutions.keys.flatMap(contributorName =>
-      if (!contributorNames.contains(contributorName)) {
+      if (
+        !contributorNames.contains(contributorName)
+          && prevHub.institutions(contributorName).Wikidata.exists(_.nonEmpty)
+      )
         // We explicitly drop contributors that are no longer in the hub's harvest
         // and have no Wikidata ID, since they have no chance to be uploaded, and
         // just create overhead for maintaining the institutions file.
-        val prevContributor = prevHub.institutions(contributorName)
-        if (
-          prevContributor.Wikidata.isDefined && prevContributor.Wikidata.get.nonEmpty
-        )
-          Some(contributorName -> prevHub.institutions(contributorName))
-        else
-          None
-      } else {
+        Some(contributorName -> prevHub.institutions(contributorName))
+      else
         None
-      }
     )
 
     prevHub.copy(institutions = newContributors ++ oldContributors)

--- a/src/main/scala/dpla/ingestion3/entries/utils/UpdateInstitutions.scala
+++ b/src/main/scala/dpla/ingestion3/entries/utils/UpdateInstitutions.scala
@@ -257,6 +257,9 @@ object UpdateInstitutions {
 
     val oldContributors = prevHub.institutions.keys.flatMap(contributorName =>
       if (!contributorNames.contains(contributorName)) {
+        // We explicitly drop contributors that are no longer in the hub's harvest
+        // and have no Wikidata ID, since they have no chance to be uploaded, and
+        // just create overhead for maintaining the institutions file.
         val prevContributor = prevHub.institutions(contributorName)
         if (
           prevContributor.Wikidata.isDefined && prevContributor.Wikidata.get.nonEmpty


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Pruned institutions without Wikidata IDs from `institutions_v2.json` and updated related logic in `UpdateInstitutions.scala`.
> 
>   - **Behavior**:
>     - Pruned institutions without a Wikidata ID from `institutions_v2.json`.
>     - Updated `noBacksliding` function to ensure only institutions with Wikidata IDs are retained.
>     - Modified `updatedHub` function to drop contributors without Wikidata IDs.
>   - **Code Changes**:
>     - Removed unused imports in `UpdateInstitutions.scala`.
>     - Refactored `noBacksliding` and `updatedHub` functions for clarity and efficiency.
>   - **Misc**:
>     - Updated `institutions_v2.json` to reflect changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for d0cc329b98a70a5a120da974b71b5ec7f51ba957. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->