### PR TITLE
Update institutions_v2.json

### DIFF
--- a/src/main/resources/wiki/institutions_v2.json
+++ b/src/main/resources/wiki/institutions_v2.json
@@ -30831,8 +30831,8 @@
         "upload" : false
       },
       "Columbus City Schools" : {
-        "Wikidata" : "",
-        "upload" : false
+        "Wikidata" : "Q5150021",
+        "upload" : true
       },
       "Columbus Metropolitan Library" : {
         "Wikidata" : "Q5150078",
@@ -30855,8 +30855,8 @@
         "upload" : false
       },
       "Kent Historical Society and Museum Digital Collection" : {
-        "Wikidata" : "",
-        "upload" : false
+        "Wikidata" : "Q118726937",
+        "upload" : true
       },
       "Kent State University" : {
         "Wikidata" : "Q1473615",


### PR DESCRIPTION
New participating ODN institutions
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `institutions_v2.json` to add new ODN institutions with `Wikidata` IDs and enable uploads.
> 
>   - **Institutions Update**:
>     - `Columbus City Schools`: Set `Wikidata` to `Q5150021` and `upload` to `true`.
>     - `Kent Historical Society and Museum Digital Collection`: Set `Wikidata` to `Q118726937` and `upload` to `true`.
>   - **Misc**:
>     - Add newline at end of `institutions_v2.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for 9d0f4e53abc8b940c4406c00f6fabcdb0d3965c5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->