### PR TITLE
Got rid of debug println

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/HarvardMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/HarvardMapping.scala
@@ -287,9 +287,6 @@ class HarvardMapping
 
     val setSpec = data.get \ "about" \ "request" \@ "set"
 
-    val record = data.get
-    println(record)
-
     val setName = (for {
       set <- data.get \ "metadata" \ "mods" \ "extension" \ "sets" \ "set"
       if (set \ "setSpec").text == setSpec


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removed a debug print statement from the `HarvardMapping` class.
> 
>   - **Debugging**:
>     - Removed `println(record)` from `HarvardMapping` class, which was used for debugging purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for 7393d1472ab0990bac04775eb37dd11ee1ec5f6c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->