### PR TITLE
Update si mapping

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ version := "0.0.1"
 scalaVersion := "2.13.15"
 fork  := true
 outputStrategy := Some(StdoutOutput)
-val SPARK_VERSION = "3.5.3"
+val SPARK_VERSION = "3.5.5"
 
 ThisBuild / Test / parallelExecution := false
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/SiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/SiMapping.scala
@@ -109,18 +109,18 @@ class SiMapping extends XmlMapping with XmlExtractor {
       textValue = guid.text
     } yield uriOnlyWebResource(URI(textValue))
 
-    if (guidDerived.nonEmpty) return guidDerived
-
-    getRecordId(data)
-      .map(id =>
-        uriOnlyWebResource(
-          URI(
-            s"http://collections.si.edu/search/results.htm?" +
-              s"q=record_ID=${id}" + s"&repo=DPLA"
+    if (guidDerived.nonEmpty) guidDerived
+    else
+      getRecordId(data)
+        .map(id =>
+          uriOnlyWebResource(
+            URI(
+              s"http://collections.si.edu/search/results.htm?" +
+                s"q=record_ID=${id}" + s"&repo=DPLA"
+            )
           )
         )
-      )
-      .toSeq
+        .toSeq
   }
 
   override def `object`(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =

--- a/src/main/scala/dpla/ingestion3/mappers/providers/SiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/SiMapping.scala
@@ -5,7 +5,6 @@ import dpla.ingestion3.mappers.utils._
 import dpla.ingestion3.model.DplaMapData._
 import dpla.ingestion3.model._
 import dpla.ingestion3.utils.Utils
-import org.apache.spark.sql.catalyst.expressions.SizeBasedWindowFunction.n
 import org.json4s.JsonAST
 import org.json4s.JsonDSL._
 
@@ -426,79 +425,4 @@ class SiMapping extends XmlMapping with XmlExtractor {
 
   private def getRecordId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "descriptiveNonRepeating" \ "record_ID")
-}
-
-object SiMapping {
-
-  def main(args: Array[String]): Unit = {
-    val siMapping = new SiMapping()
-    val document = Document(example ++ Text(""))
-    val result = siMapping.isShownAt(document)
-    println(result.head.uri)
-  }
-
-  private val example =
-    <doc>
-      <indexedStructured>
-        <date>1920s</date>
-        <geoLocation>
-          <L1 type="Continent">North America</L1>
-          <L2 type="Country">United States</L2>
-          <L3 type="State">Washington</L3>
-          <L4 type="County">Grant County</L4>
-          <L5 type="City">Wahluke Ferry</L5>
-        </geoLocation>
-        <object_type>Scrapers (finishing tools)</object_type>
-        <culture>Prehistoric</culture>
-        <name>Bureau Of American Ethnology</name>
-        <name>Herbert W. Krieger</name>
-        <topic>Archaeology</topic>
-        <topic>Anthropology</topic>
-        <place>Grant County</place>
-        <place>Wahluke Ferry</place>
-        <place>United States</place>
-        <place>North America</place>
-        <place>Washington</place>
-        <online_media_type>Images</online_media_type>
-      </indexedStructured>
-      <descriptiveNonRepeating>
-        <record_ID>nmnhanthropology_8089848</record_ID>
-        <online_media>
-          <media
-          thumbnail="https://ids.si.edu/ids/deliveryService/id/ark:/65665/m374ed5494007c43b5bc680956c7efdf7f/90"
-          altTextAccessibility=""
-          idsId="ark:/65665/m374ed5494007c43b5bc680956c7efdf7f"
-          guid="http://n2t.net/ark:/65665/m374ed5494-007c-43b5-bc68-0956c7efdf7f"
-          id="damsmdm:NMNH-anthro_mc_069_055_333851-333875" type="Images"><usage>
-            <access>Not determined</access>
-          </usage>
-            https://ids.si.edu/ids/deliveryService/id/ark:/65665/m374ed5494007c43b5bc680956c7efdf7f</media>
-        </online_media>
-        <guid>http://n2t.net/ark:/65665/306470d17-74d6-4694-8f29-24fc0033005a</guid>
-        <unit_code>NMNHANTHRO</unit_code>
-        <title_sort>SCRAPER AGATE AND CHALCEDONY</title_sort>
-        <record_link>https://collections.si.edu/search/detail/edanmdm:nmnhanthropology_8089848</record_link>
-        <title label="title">Scraper - Agate And Chalcedony</title>
-        <metadata_usage>
-          <access>CC0</access>
-        </metadata_usage>
-        <data_source>NMNH - Anthropology Dept.</data_source>
-      </descriptiveNonRepeating>
-      <freetext>
-        <date label="Accession Date">16 Oct 1926</date>
-        <setName label="See more items in">Anthropology</setName>
-        <identifier label="Accession Number">091522</identifier>
-        <identifier label="USNM Number">A333861-0</identifier>
-        <notes label="Record Last Modified">31 Jul 2020</notes>
-        <notes label="Specimen Count">1</notes>
-        <culture label="Culture">Prehistoric</culture>
-        <name label="Collector">Herbert W. Krieger</name>
-        <name label="Donor Name">Bureau Of American Ethnology</name>
-        <topic label="Topic">Archaeology</topic>
-        <place label="Place">Wahluke Ferry, Grant County, Washington, United States, North America</place>
-        <dataSource label="Data Source">NMNH - Anthropology Dept.</dataSource>
-        <objectType label="Object Type">Scraper</objectType>
-      </freetext>
-    </doc>
-
 }

--- a/src/test/scala/dpla/ingestion3/mappers/providers/SiMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/SiMappingTest.scala
@@ -16,6 +16,7 @@ class SiMappingTest extends AnyFlatSpec with BeforeAndAfter {
   val shortName = "si"
   val xmlString: String = new FlatFileIO().readFileAsString("/si.xml")
   val xml: Document[NodeSeq] = Document(XML.loadString(xmlString))
+
   val extractor = new SiMapping
 
   it should "use the provider shortname in minting IDs " in
@@ -58,6 +59,18 @@ class SiMappingTest extends AnyFlatSpec with BeforeAndAfter {
     val expected = Seq("http://collections.si.edu/search/results.htm?q=record_ID=acm_1991.0076.0102&repo=DPLA")
       .map(stringOnlyWebResource)
     assert(extractor.isShownAt(xml) === expected)
+  }
+
+  it should "build an isShownAt from the guid if it's available" in {
+    val xml =
+      <doc>
+        <descriptiveNonRepeating>
+          <guid>http://example.com/12345</guid>
+        </descriptiveNonRepeating>
+      </doc>
+
+    val expected = Seq("http://example.com/12345").map(stringOnlyWebResource)
+    assert(extractor.isShownAt(Document(xml)) === expected)
   }
 
   it should "extract the correct language" in {

--- a/src/test/scala/dpla/ingestion3/mappers/providers/SiMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/SiMappingTest.scala
@@ -244,10 +244,12 @@ class SiMappingTest extends AnyFlatSpec with BeforeAndAfter {
     </doc>
 
     val expected = Seq(
-      "https://ids.si.edu/ids/deliveryService/id/ark:/65665/m354db31afb0f64d4c8a06b75b1179e81b/90",
-      "https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3d9f23b1f4f1d4b1eb31fd6df431027aa/90"
+      "https://ids.si.edu/ids/deliveryService/id/ark:/65665/m354db31afb0f64d4c8a06b75b1179e81b",
+      "https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3d9f23b1f4f1d4b1eb31fd6df431027aa"
     ).map(stringOnlyWebResource)
 
-    assert(extractor.mediaMaster(Document(xml)) === expected)
+    val result = extractor.mediaMaster(Document(xml))
+
+    assert(result === expected)
   }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `SiMapping` to improve `isShownAt` and `mediaMaster` handling, update Spark version, and add relevant tests.
> 
>   - **Behavior**:
>     - Updates `isShownAt` in `SiMapping.scala` to derive from `guid` if available, otherwise uses `record_ID`.
>     - Updates `mediaMaster` in `SiMapping.scala` to extract non-empty text nodes from `online_media`.
>   - **Build**:
>     - Updates `SPARK_VERSION` in `build.sbt` from `3.5.3` to `3.5.5`.
>   - **Tests**:
>     - Adds test for `isShownAt` using `guid` in `SiMappingTest.scala`.
>     - Updates `mediaMaster` test in `SiMappingTest.scala` to check for non-thumbnail URLs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for 11f012ba55f65e9e18d523fa6976b832029479b7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->