### PR TITLE
Mapping improvements.

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/SiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/SiMapping.scala
@@ -118,7 +118,7 @@ class SiMapping extends XmlMapping with XmlExtractor {
           uriOnlyWebResource(
             URI(
               s"http://collections.si.edu/search/results.htm?" +
-                s"q=record_ID=${id}" + s"&repo=DPLA"
+                s"q=record_ID=$id" + s"&repo=DPLA"
             )
           )
         )
@@ -442,86 +442,4 @@ class SiMapping extends XmlMapping with XmlExtractor {
 
   private def getRecordId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "descriptiveNonRepeating" \ "record_ID")
-}
-
-object SiMapping extends SiMapping {
-
-  def main(args: Array[String]): Unit = {
-    val data = Document(example ++ Text(""))
-    val thePreview = preview(data)
-    println(thePreview.head.uri)
-  }
-
-  val example =
-    <doc>
-      <indexedStructured>
-        <date>1890s</date>
-        <tax_family>Poaceae</tax_family>
-        <geoLocation>
-          <L1 type="Continent">North America</L1>
-          <L2 type="Country">United States</L2>
-          <L3 type="State">Wyoming</L3>
-          <Other type="Locality">Clear Creek. Town 6 mi. W of Buffalo.</Other>
-        </geoLocation>
-        <tax_class>Monocotyledonae</tax_class>
-        <tax_order>Poales</tax_order>
-        <name>Williams, --</name>
-        <name>Griffiths, --</name>
-        <topic>Monocotyledonae</topic>
-        <tax_kingdom>Plantae</tax_kingdom>
-        <scientific_name> Aristida purpurea var. longiseta (Steud.) Vasey </scientific_name>
-        <place>United States</place>
-        <place>Wyoming</place>
-        <place>North America</place>
-        <online_media_type>Images</online_media_type>
-      </indexedStructured>
-      <descriptiveNonRepeating>
-        <record_ID>nmnhbotany_15997259</record_ID>
-        <online_media>
-          <media thumbnail="https://collections.nmnh.si.edu/media/?irn=15839241&amp;thumb=yes"
-                 idsId="https://collections.nmnh.si.edu/media/?irn=15839241"
-                 guid="http://n2t.net/ark:/65665/m3d3fcb954-b3dc-42b9-89bf-10cdb4eaf9d3"
-                 type="Images">
-            <usage>
-              <access>Not determined</access>
-            </usage>
-            https://collections.nmnh.si.edu/media/?irn=15839241</media>
-          <media
-          thumbnail="https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3893e5b948b7a449cb5719e072fb4a3ad/90"
-          altTextAccessibility="" idsId="ark:/65665/m3893e5b948b7a449cb5719e072fb4a3ad"
-          guid="http://n2t.net/ark:/65665/m3893e5b94-8b7a-449c-b571-9e072fb4a3ad"
-          id="damsmdm:NMNH-04222265" type="Images">
-            <usage>
-              <access>CC0</access>
-            </usage>
-            https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3893e5b948b7a449cb5719e072fb4a3ad</media>
-        </online_media>
-        <guid>http://n2t.net/ark:/65665/35d269903-a6c1-45be-9f3c-756d212b4777</guid>
-        <unit_code>NMNHBOTANY</unit_code>
-        <title_sort>ARISTIDA PURPUREA VAR LONGISETA STEUD VASEY</title_sort>
-        <record_link> https://collections.si.edu/search/detail/edanmdm:nmnhbotany_15997259 </record_link>
-        <title label="title">Aristida purpurea var. longiseta (Steud.) Vasey</title>
-        <metadata_usage>
-          <access>CC0</access>
-        </metadata_usage>
-        <data_source>NMNH - Botany Dept.</data_source>
-      </descriptiveNonRepeating>
-      <freetext>
-        <date label="Collection Date">5 Aug 1898</date>
-        <setName label="See more items in">Botany</setName>
-        <setName label="See more items in">Flowering plants and ferns</setName>
-        <identifier label="Barcode">04222265</identifier>
-        <identifier label="USNM Number">991020</identifier>
-        <notes label="Record Last Modified">23 Mar 2022</notes>
-        <notes label="Specimen Count">1</notes>
-        <name label="Biogeographical Region">73 - Northwestern U.S.A.</name>
-        <name label="Collector">-- Williams</name>
-        <name label="Collector">-- Griffiths</name>
-        <name label="Min. Elevation">1981</name>
-        <publisher label="Published Name"> Aristida purpurea var. longiseta (Steud.) Vasey </publisher>
-        <place label="Place"> Clear Creek. Town 6 mi. W of Buffalo., Wyoming, United States, North America </place>
-        <dataSource label="Data Source">NMNH - Botany Dept.</dataSource>
-        <taxonomicName label="Taxonomy"> Plantae Monocotyledonae Poales Poaceae Aristidoideae </taxonomicName>
-      </freetext>
-    </doc>
 }

--- a/src/main/scala/dpla/ingestion3/mappers/providers/SiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/SiMapping.scala
@@ -8,12 +8,12 @@ import dpla.ingestion3.utils.Utils
 import org.json4s.JsonAST
 import org.json4s.JsonDSL._
 
-import scala.util.Try
 import scala.xml.{NodeSeq, Text}
 
 class SiMapping extends XmlMapping with XmlExtractor {
 
-  override val enforceRights: Boolean = false // allow records without rights
+  // allow records without rights
+  override val enforceRights: Boolean = false
 
   // ID minting functions
   override def useProviderName: Boolean = true
@@ -22,7 +22,7 @@ class SiMapping extends XmlMapping with XmlExtractor {
 
   override def originalId(implicit
       data: Document[NodeSeq]
-  ): ZeroToOne[String] = {
+  ): ZeroToOne[String] =
     // Hard code URL query for item as basis for DPLA identifier to maintain SI ids between ingestion1 and ingestion3
     // The URL is unnecessary and DPLA should ideally only rely upon the record_ID value. This does not exactly match
     // the itemUri value because it uses %3A instead of `=` in one place (again for consistency between ingestion1 and
@@ -32,7 +32,6 @@ class SiMapping extends XmlMapping with XmlExtractor {
         s"q=record_ID%%3A${getRecordId(data).getOrElse(throw MappingException("Missing required property `record_ID`"))}" +
         s"&repo=DPLA"
     )
-  }
 
   // OreAggregation
   override def dataProvider(data: Document[NodeSeq]): ZeroToMany[EdmAgent] =
@@ -42,52 +41,55 @@ class SiMapping extends XmlMapping with XmlExtractor {
   override def dplaUri(data: Document[NodeSeq]): ZeroToOne[URI] =
     mintDplaItemUri(data)
 
-  override def edmRights(data: Document[NodeSeq]): ZeroToMany[URI] = {
-    val edmRightsReadable = extractStrings(data \\ "objectRights")
-
-    edmRightsReadable.length match {
-      case 0 =>
+  override def edmRights(data: Document[NodeSeq]): ZeroToMany[URI] =
+    extractStrings(data \\ "objectRights") match {
+      case Seq() =>
         rightsFromMedia(extractStrings(data \\ "media" \ "usage" \ "access"))
-      case 1 => edmRightsReadable.map(lookupRightsUriFromText)
-      case _ => Seq()
-    }
-  }
-  private def lookupRightsUriFromText(str: String): URI =
-    str.toLowerCase.trim match {
-      case "cc0" => URI("http://creativecommons.org/publicdomain/zero/1.0/")
-      case "in copyright" => URI("http://rightsstatements.org/vocab/InC/1.0/")
-      case "in copyright - eu orphan work" =>
-        URI("http://rightsstatements.org/vocab/InC-EDU/1.0/")
-      case "in copyright - non-commercial use permitted" =>
-        URI("http://rightsstatements.org/vocab/InC-EDU/1.0/")
-      case "in copyright - educational use permitted" =>
-        URI("http://rightsstatements.org/vocab/InC-NC/1.0/")
-      case "in copyright - rights- holder(s) unlocatable or unidentifiable" =>
-        URI("http://rightsstatements.org/vocab/InC-RUU/1.0/")
-      case "no copyright - contractual restrictions" =>
-        URI("http://rightsstatements.org/vocab/NoC-CR/1.0/")
-      case "no copyright - non-commercial use only" =>
-        URI("http://rightsstatements.org/vocab/NoC-NC/1.0/")
-      case "no copyright - other known legal restrictions" =>
-        URI("http://rightsstatements.org/vocab/NoC-OKLR/1.0/")
-      case "no copyright - united states" =>
-        URI("http://rightsstatements.org/vocab/NoC-US/1.0/")
-      case "copyright not evaluated" =>
-        URI("http://rightsstatements.org/vocab/CNE/1.0/")
-      case "copyright undetermined" =>
-        URI("http://rightsstatements.org/vocab/UND/1.0/")
-      case "no known copyright" =>
-        URI("http://rightsstatements.org/vocab/NKC/1.0/")
-      case _ => URI("")
+
+      case x if x.length == 1 =>
+        x.flatMap(lookupRightsUriFromText)
+
+      case _ =>
+        Seq()
     }
 
-  private def rightsFromMedia(strs: Seq[String]): ZeroToMany[URI] = {
+  private def lookupRightsUriFromText(str: String): Option[URI] =
+    str.toLowerCase.trim match {
+      case "cc0" =>
+        Some(URI("http://creativecommons.org/publicdomain/zero/1.0/"))
+      case "in copyright" =>
+        Some(URI("http://rightsstatements.org/vocab/InC/1.0/"))
+      case "in copyright - eu orphan work" =>
+        Some(URI("http://rightsstatements.org/vocab/InC-EDU/1.0/"))
+      case "in copyright - non-commercial use permitted" =>
+        Some(URI("http://rightsstatements.org/vocab/InC-EDU/1.0/"))
+      case "in copyright - educational use permitted" =>
+        Some(URI("http://rightsstatements.org/vocab/InC-NC/1.0/"))
+      case "in copyright - rights- holder(s) unlocatable or unidentifiable" =>
+        Some(URI("http://rightsstatements.org/vocab/InC-RUU/1.0/"))
+      case "no copyright - contractual restrictions" =>
+        Some(URI("http://rightsstatements.org/vocab/NoC-CR/1.0/"))
+      case "no copyright - non-commercial use only" =>
+        Some(URI("http://rightsstatements.org/vocab/NoC-NC/1.0/"))
+      case "no copyright - other known legal restrictions" =>
+        Some(URI("http://rightsstatements.org/vocab/NoC-OKLR/1.0/"))
+      case "no copyright - united states" =>
+        Some(URI("http://rightsstatements.org/vocab/NoC-US/1.0/"))
+      case "copyright not evaluated" =>
+        Some(URI("http://rightsstatements.org/vocab/CNE/1.0/"))
+      case "copyright undetermined" =>
+        Some(URI("http://rightsstatements.org/vocab/UND/1.0/"))
+      case "no known copyright" =>
+        Some(URI("http://rightsstatements.org/vocab/NKC/1.0/"))
+      case _ => None
+    }
+
+  private def rightsFromMedia(strs: Seq[String]): ZeroToMany[URI] =
     strs.map(_.trim.toLowerCase).distinct match {
       case Seq("cc0") =>
         Seq(URI("http://creativecommons.org/publicdomain/zero/1.0/"))
       case _ => Seq()
     }
-  }
 
   override def mediaMaster(
       data: Document[NodeSeq]
@@ -123,17 +125,43 @@ class SiMapping extends XmlMapping with XmlExtractor {
         .toSeq
   }
 
-  override def `object`(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
-    extractPreview(data) // done
+  override def `object`(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] = {
+    val results = (data \ "descriptiveNonRepeating" \ "online_media" \ "media")
+      .flatMap(_.child)
+      .flatMap(_ match {
+        case Text(str) if str.trim.nonEmpty => Some(str)
+        case _                              => None
+      })
+      .map(stringOnlyWebResource)
+
+    results match {
+      case Seq()              => Seq()
+      case x if x.length == 1 => results
+      case x if x.length > 1  =>
+        // if there's more than one, prefer one from ids.si.edu
+        x.find(entry => entry.uri.toString.contains("ids.si.edu")) match {
+          case Some(entry) => Seq(entry)
+          case None        => Seq(results.head)
+        }
+    }
+  }
 
   override def originalRecord(data: Document[NodeSeq]): ExactlyOne[String] =
-    Utils.formatXml(data) // done
+    Utils.formatXml(data)
 
   override def provider(data: Document[NodeSeq]): ExactlyOne[EdmAgent] =
-    agent // done
+    EdmAgent(
+      name = Some("Smithsonian Institution"),
+      uri = Some(URI("http://dp.la/api/contributor/smithsonian"))
+    )
 
   override def preview(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
-    extractPreview(data) // done
+    (data \ "descriptiveNonRepeating" \ "online_media" \ "media")
+      .flatMap(node => node.attribute("thumbnail"))
+      .flatMap(node => extractStrings(node))
+      .map(stringOnlyWebResource)
+      .headOption
+      .toSeq
 
   override def sidecar(data: Document[NodeSeq]): JsonAST.JValue =
     ("prehashId", buildProviderBaseId()(data)) ~ ("dplaId", mintDplaId(data))
@@ -148,7 +176,8 @@ class SiMapping extends XmlMapping with XmlExtractor {
       .flatMap(extractStrings)
       .map(nameOnlyAgent)
 
-  override def creator(data: Document[NodeSeq]): Seq[EdmAgent] = {
+  override def creator(data: Document[NodeSeq]): Seq[EdmAgent] =
+    // might need to add this extensive set of label={value} filters to the mapping:
     //    val creatorAttr = Seq("Architect", "Artist", "Artists/Makers", "Attributed to", "Author", "Cabinet Maker",
     //      "Ceramist", "Circle of", "Co-Designer", "Creator", "Decorator", "Designer", "Draftsman", "Editor", "Embroiderer",
     //      "Engraver", "Etcher", "Executor", "Follower of", "Graphic Designer", "Instrumentiste", "Inventor",
@@ -173,15 +202,14 @@ class SiMapping extends XmlMapping with XmlExtractor {
       .flatMap(extractStrings)
       .map(
         nameOnlyAgent
-      ) // done but might need to add this extensive set of label={value} filters to the mapping
-  }
+      )
 
   override def date(data: Document[NodeSeq]): Seq[EdmTimeSpan] = extractDate(
     data
   )
 
   override def description(data: Document[NodeSeq]): ZeroToMany[String] =
-    extractStrings(data \ "freetext" \ "notes") // done
+    extractStrings(data \ "freetext" \ "notes")
 
   override def extent(data: Document[NodeSeq]): ZeroToMany[String] =
     (data \ "freetext" \ "physicalDescription")
@@ -205,12 +233,12 @@ class SiMapping extends XmlMapping with XmlExtractor {
       identifier <- extractStrings(identifierProp)
       attrValue <- identifierProp.attribute("label").flatMap(extractString(_))
       if attrValue.startsWith("Catalog") || attrValue.startsWith("Accession")
-    } yield identifier // done
+    } yield identifier
 
   override def language(data: Document[NodeSeq]): ZeroToMany[SkosConcept] =
     extractStrings(data \\ "indexedStructured" \ "language")
       .map(_.replaceAll(" language", "")) // removes ' language' from term
-      .map(nameOnlyConcept) // done
+      .map(nameOnlyConcept)
 
   override def place(data: Document[NodeSeq]): ZeroToMany[DplaPlace] = {
     // Get values from <indexedStructured> \ <geoLocation>
@@ -298,6 +326,7 @@ class SiMapping extends XmlMapping with XmlExtractor {
             )
           )
           .flatMap(extractStrings(_))
+
         val long = (node \ "points" \ "point" \ "longitude")
           .filter(node =>
             filterAttribute(node, "type", "decimal") | filterAttribute(
@@ -307,6 +336,7 @@ class SiMapping extends XmlMapping with XmlExtractor {
             )
           )
           .flatMap(extractStrings(_))
+
         val point =
           lat.zipAll(long, None, None).map(p => s"${p._1},${p._2}").mkString
 
@@ -321,8 +351,7 @@ class SiMapping extends XmlMapping with XmlExtractor {
       })
 
     // return structured DPLA Place if non-empty, otherwise use freetext spatial information
-    if (preciseGeoLocation.nonEmpty)
-      preciseGeoLocation
+    if (preciseGeoLocation.nonEmpty) preciseGeoLocation
     else
       (data \ "freetext" \ "place")
         .flatMap(extractStrings)
@@ -333,7 +362,7 @@ class SiMapping extends XmlMapping with XmlExtractor {
     (data \ "freetext" \ "publisher")
       .filter(node => filterAttribute(node, "label", "publisher"))
       .flatMap(extractStrings)
-      .map(nameOnlyAgent) // done
+      .map(nameOnlyAgent)
 
   override def rights(data: Document[NodeSeq]): AtLeastOne[String] = {
     val mediaRights =
@@ -350,7 +379,7 @@ class SiMapping extends XmlMapping with XmlExtractor {
           .flatMap(extractStrings(_))
     else
       mediaRights
-  } // done
+  }
 
   override def subject(data: Document[NodeSeq]): ZeroToMany[SkosConcept] = {
     val subjectProps = Seq(
@@ -383,7 +412,7 @@ class SiMapping extends XmlMapping with XmlExtractor {
       .flatMap(_.splitAtDelimiter("\\\\"))
       .flatMap(_.splitAtDelimiter(":"))
       .map(nameOnlyConcept)
-  } // done
+  }
 
   override def temporal(data: Document[NodeSeq]): ZeroToMany[EdmTimeSpan] =
     extractDate(data)
@@ -395,20 +424,14 @@ class SiMapping extends XmlMapping with XmlExtractor {
           filterAttribute(node, "label", "object name") ||
           filterAttribute(node, "label", "title (spanish)")
       )
-      .flatMap(node => extractStrings(node)) // done
+      .flatMap(node => extractStrings(node))
 
   override def `type`(data: Document[NodeSeq]): ZeroToMany[String] =
     (data \ "freetext" \ "objectType")
       .flatMap(node => getByAttribute(node, "label", "Type"))
       .flatMap(extractStrings(_)) ++
       extractStrings(data \ "freetext" \ "physicalDescription") ++
-      extractStrings(data \ "indexedStructure" \ "object_type") // done
-
-  // Helper methods
-  private def agent = EdmAgent(
-    name = Some("Smithsonian Institution"),
-    uri = Some(URI("http://dp.la/api/contributor/smithsonian"))
-  ) // done
+      extractStrings(data \ "indexedStructure" \ "object_type")
 
   // Helper methods
   private def extractDate(data: Document[NodeSeq]): Seq[EdmTimeSpan] =
@@ -417,12 +440,88 @@ class SiMapping extends XmlMapping with XmlExtractor {
       .flatMap(extractStrings(_))
       .map(stringOnlyTimeSpan) // done
 
-  private def extractPreview(data: Document[NodeSeq]): Seq[EdmWebResource] =
-    (data \ "descriptiveNonRepeating" \ "online_media" \ "media")
-      .flatMap(node => node.attribute("thumbnail"))
-      .flatMap(node => extractStrings(node))
-      .map(stringOnlyWebResource)
-
   private def getRecordId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
     extractString(data \ "descriptiveNonRepeating" \ "record_ID")
+}
+
+object SiMapping extends SiMapping {
+
+  def main(args: Array[String]): Unit = {
+    val data = Document(example ++ Text(""))
+    val thePreview = preview(data)
+    println(thePreview.head.uri)
+  }
+
+  val example =
+    <doc>
+      <indexedStructured>
+        <date>1890s</date>
+        <tax_family>Poaceae</tax_family>
+        <geoLocation>
+          <L1 type="Continent">North America</L1>
+          <L2 type="Country">United States</L2>
+          <L3 type="State">Wyoming</L3>
+          <Other type="Locality">Clear Creek. Town 6 mi. W of Buffalo.</Other>
+        </geoLocation>
+        <tax_class>Monocotyledonae</tax_class>
+        <tax_order>Poales</tax_order>
+        <name>Williams, --</name>
+        <name>Griffiths, --</name>
+        <topic>Monocotyledonae</topic>
+        <tax_kingdom>Plantae</tax_kingdom>
+        <scientific_name> Aristida purpurea var. longiseta (Steud.) Vasey </scientific_name>
+        <place>United States</place>
+        <place>Wyoming</place>
+        <place>North America</place>
+        <online_media_type>Images</online_media_type>
+      </indexedStructured>
+      <descriptiveNonRepeating>
+        <record_ID>nmnhbotany_15997259</record_ID>
+        <online_media>
+          <media thumbnail="https://collections.nmnh.si.edu/media/?irn=15839241&amp;thumb=yes"
+                 idsId="https://collections.nmnh.si.edu/media/?irn=15839241"
+                 guid="http://n2t.net/ark:/65665/m3d3fcb954-b3dc-42b9-89bf-10cdb4eaf9d3"
+                 type="Images">
+            <usage>
+              <access>Not determined</access>
+            </usage>
+            https://collections.nmnh.si.edu/media/?irn=15839241</media>
+          <media
+          thumbnail="https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3893e5b948b7a449cb5719e072fb4a3ad/90"
+          altTextAccessibility="" idsId="ark:/65665/m3893e5b948b7a449cb5719e072fb4a3ad"
+          guid="http://n2t.net/ark:/65665/m3893e5b94-8b7a-449c-b571-9e072fb4a3ad"
+          id="damsmdm:NMNH-04222265" type="Images">
+            <usage>
+              <access>CC0</access>
+            </usage>
+            https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3893e5b948b7a449cb5719e072fb4a3ad</media>
+        </online_media>
+        <guid>http://n2t.net/ark:/65665/35d269903-a6c1-45be-9f3c-756d212b4777</guid>
+        <unit_code>NMNHBOTANY</unit_code>
+        <title_sort>ARISTIDA PURPUREA VAR LONGISETA STEUD VASEY</title_sort>
+        <record_link> https://collections.si.edu/search/detail/edanmdm:nmnhbotany_15997259 </record_link>
+        <title label="title">Aristida purpurea var. longiseta (Steud.) Vasey</title>
+        <metadata_usage>
+          <access>CC0</access>
+        </metadata_usage>
+        <data_source>NMNH - Botany Dept.</data_source>
+      </descriptiveNonRepeating>
+      <freetext>
+        <date label="Collection Date">5 Aug 1898</date>
+        <setName label="See more items in">Botany</setName>
+        <setName label="See more items in">Flowering plants and ferns</setName>
+        <identifier label="Barcode">04222265</identifier>
+        <identifier label="USNM Number">991020</identifier>
+        <notes label="Record Last Modified">23 Mar 2022</notes>
+        <notes label="Specimen Count">1</notes>
+        <name label="Biogeographical Region">73 - Northwestern U.S.A.</name>
+        <name label="Collector">-- Williams</name>
+        <name label="Collector">-- Griffiths</name>
+        <name label="Min. Elevation">1981</name>
+        <publisher label="Published Name"> Aristida purpurea var. longiseta (Steud.) Vasey </publisher>
+        <place label="Place"> Clear Creek. Town 6 mi. W of Buffalo., Wyoming, United States, North America </place>
+        <dataSource label="Data Source">NMNH - Botany Dept.</dataSource>
+        <taxonomicName label="Taxonomy"> Plantae Monocotyledonae Poales Poaceae Aristidoideae </taxonomicName>
+      </freetext>
+    </doc>
 }

--- a/src/test/scala/dpla/ingestion3/mappers/providers/SiMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/SiMappingTest.scala
@@ -130,9 +130,10 @@ class SiMappingTest extends AnyFlatSpec with BeforeAndAfter {
     val expected = Seq(
       "http://ids.si.edu/ids/deliveryService?id=ACM-acmobj-199100760102-r2",
       "http://ids.si.edu/ids/deliveryService?id=ACM-acmobj-199100760102-r1-000002",
-      "http://ids.si.edu/ids/deliveryService?id=ACM-acmobj-199100760102-r3")
-      .map(stringOnlyWebResource)
-    assert(extractor.preview(xml) === expected)
+      "http://ids.si.edu/ids/deliveryService?id=ACM-acmobj-199100760102-r3"
+    ).map(URI(_))
+
+    assert(expected.contains(extractor.preview(xml).map(_.uri).head))
   }
 
   it should "extract the correct publisher" in {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refines `SiMapping` class to improve rights and media extraction logic, with corresponding test updates in `SiMappingTest`.
> 
>   - **Behavior**:
>     - Refines `edmRights` extraction in `SiMapping.scala` to handle multiple rights scenarios, including empty, single, and multiple rights entries.
>     - Updates `lookupRightsUriFromText` to return `Option[URI]` instead of `URI` to handle unknown rights cases.
>     - Enhances `object` method to prefer media from `ids.si.edu` when multiple entries exist.
>   - **Tests**:
>     - Adds test cases in `SiMappingTest.scala` for `edmRights` to cover scenarios with conflicting labels and multiple rights entries.
>     - Updates `preview` test to check for correct URI extraction from media entries.
>     - Adds tests for `isShownAt` to verify GUID-based URI extraction.
>   - **Misc**:
>     - Removes unused `extractPreview` method from `SiMapping.scala`.
>     - Minor formatting and comment adjustments in `SiMapping.scala`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for 720a680db1c6e54bec86c9f874908f7ad588547d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->