### PR TITLE
Fix to remove incorrect "edmRights ends with /" warning

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/Mapper.scala
@@ -117,6 +117,7 @@ trait Mapper[T, +E] extends IngestMessageTemplates {
             }
             // trailing punctuation
             if (
+              !uri.getPath.endsWith("/") &&
               !uri.getPath
                 .equalsIgnoreCase(uri.getPath.cleanupEndingPunctuation)
             ) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes incorrect warning in `normalizeEdmRights` in `Mapper.scala` by checking if URI path ends with "/" before logging a trailing punctuation warning.
> 
>   - **Behavior**:
>     - Fixes incorrect warning in `normalizeEdmRights` in `Mapper.scala` by adding a condition to check if `uri.getPath` ends with "/" before logging a trailing punctuation warning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for 7dcbf559335b26e92aa2c026c9c9fbe802a6bed6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->