### PR TITLE
rework of edmRights mapping for Smithsonian

### DIFF
--- a/src/test/scala/dpla/ingestion3/mappers/providers/SiMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/SiMappingTest.scala
@@ -186,13 +186,13 @@ class SiMappingTest extends AnyFlatSpec with BeforeAndAfter {
           </media>
           <media>
             <usage>
-              <access>InC</access>
+              <access>usage conditions apply</access>
             </usage>
           </media>
         </descriptiveNonRepeating>
       </doc>
 
-    val expected = Seq()
+    val expected = Seq(URI("http://rightsstatements.org/vocab/InC/1.0/"))
     assert(extractor.edmRights(Document(xml)) === expected)
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `edmRights` in `SiMapping.scala` to prioritize object-level rights and update tests in `SiMappingTest.scala` for new logic.
> 
>   - **Behavior**:
>     - Refactor `edmRights` in `SiMapping.scala` to prioritize object-level rights over media-level rights.
>     - Update `rightsFromMedia` to handle specific keywords like "usage conditions apply" and "not determined".
>   - **Tests**:
>     - Update `SiMappingTest.scala` to reflect changes in `edmRights` logic, including tests for specific rights keywords and priority handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingestion3&utm_source=github&utm_medium=referral)<sup> for 85c5f324bc3a583ed9ced6aaa14eb9635a867b54. You can [customize](https://app.ellipsis.dev/dpla/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved handling of rights information to prioritize object-level rights and provide clearer fallback logic to media-level rights when necessary.
  * Enhanced detection of specific rights keywords for more accurate rights assignment.
* **Tests**
  * Updated rights extraction tests to reflect new handling of usage access terms and corresponding rights statements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->