### PR TITLE
Fix pipefail abort when aws s3 ls exits 1 on empty prefix (first-ever ingest)

### DIFF
--- a/scripts/ingest.sh
+++ b/scripts/ingest.sh
@@ -290,7 +290,7 @@ JSONL_RECORD_COUNT=$(read_manifest_count "$JSONL_TS_DIR/_MANIFEST")
 # before the partner email goes out. Skipped on first-ever ingest (no prev snapshot).
 S3_PREFIX=$(resolve_s3_prefix "$PROVIDER")
 PREV_SNAP=$(aws s3 ls "s3://dpla-master-dataset/${S3_PREFIX}/jsonl/" 2>/dev/null \
-    | awk '{print $NF}' | sed 's|/||g' | sort | tail -1)
+    | awk '{print $NF}' | sed 's|/||g' | sort | tail -1) || true
 PREV_COUNT=0
 if [ -n "$PREV_SNAP" ]; then
     PREV_COUNT=$(aws s3 cp "s3://dpla-master-dataset/${S3_PREFIX}/jsonl/${PREV_SNAP}/_MANIFEST" - 2>/dev/null \


### PR DESCRIPTION
## Summary
- `aws s3 ls` returns **exit code 1** when no objects exist at a prefix; with `set -eo pipefail` this silently killed the script before S3 sync on any hub's first-ever ingest
- The EXIT trap fired to Slack only — no log entry, making it hard to diagnose
- Fix: add `|| true` so `PREV_SNAP` stays empty and the safety check is skipped as documented ("Skipped on first-ever ingest")
- Also supersedes #690 (which only removed `grep -v "^$"`, also a pipefail risk on empty input, but `aws s3 ls` exit code was the deeper cause)

## Test plan
- [ ] Mississippi resumes from JSONL and completes S3 sync
- [ ] Safety check still runs correctly on subsequent ingests (non-empty S3 listing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)