### PR TITLE
Add generate_hub_stats.py: write hub item counts to S3 after rebuild

### DIFF
--- a/scripts/generate_hub_stats.py
+++ b/scripts/generate_hub_stats.py
@@ -39,7 +39,13 @@ def es_query(query: dict) -> dict:
         url, data=data, headers={"Content-Type": "application/json"}
     )
     with urllib.request.urlopen(req, timeout=30) as resp:
-        return json.loads(resp.read())
+        data = json.loads(resp.read())
+    if data.get("timed_out"):
+        raise RuntimeError(f"Elasticsearch query timed out: {query}")
+    shards = data.get("_shards", {})
+    if shards.get("failed", 0) > 0:
+        raise RuntimeError(f"Elasticsearch shard failures: {shards}")
+    return data
 
 
 def hub_totals(bws: bool = False) -> dict:

--- a/scripts/generate_hub_stats.py
+++ b/scripts/generate_hub_stats.py
@@ -11,7 +11,7 @@ then one per-hub query for contributor counts. A single nested aggregation
 across all hubs exceeds ES's search.max_buckets limit.
 
 Usage:
-    python3 scripts/generate_hub_stats.py
+    ./venv/bin/python scripts/generate_hub_stats.py
 
 Environment:
     ES_HOST  - Elasticsearch hostname (default: search-prod1.internal.dp.la)
@@ -53,7 +53,13 @@ def hub_totals(bws: bool = False) -> dict:
     if bws:
         query["query"] = {"term": {"tags": "blackwomensuffrage"}}
     result = es_query(query)
-    return {b["key"]: b["doc_count"] for b in result["aggregations"]["hubs"]["buckets"]}
+    hubs_agg = result["aggregations"]["hubs"]
+    if hubs_agg.get("sum_other_doc_count", 0) > 0:
+        raise RuntimeError(
+            f"Hub aggregation truncated (sum_other_doc_count="
+            f"{hubs_agg['sum_other_doc_count']}); increase size."
+        )
+    return {b["key"]: b["doc_count"] for b in hubs_agg["buckets"]}
 
 
 def contributor_counts(hub_name: str, bws: bool = False) -> dict:
@@ -77,10 +83,14 @@ def contributor_counts(hub_name: str, bws: bool = False) -> dict:
             }
         }
     result = es_query(query)
-    return {
-        b["key"]: b["doc_count"]
-        for b in result["aggregations"]["contributors"]["buckets"]
-    }
+    contributors_agg = result["aggregations"]["contributors"]
+    if contributors_agg.get("sum_other_doc_count", 0) > 0:
+        raise RuntimeError(
+            f"Contributor aggregation truncated for hub '{hub_name}' "
+            f"(sum_other_doc_count={contributors_agg['sum_other_doc_count']}); "
+            f"increase size."
+        )
+    return {b["key"]: b["doc_count"] for b in contributors_agg["buckets"]}
 
 
 def build_stats(bws: bool = False) -> dict:

--- a/scripts/generate_hub_stats.py
+++ b/scripts/generate_hub_stats.py
@@ -106,7 +106,10 @@ def build_stats(bws: bool = False) -> dict:
 
 
 def upload(data: dict, key: str) -> None:
-    boto3.client("s3", region_name="us-east-1").put_object(
+    # Use AWS_PROFILE if set (local dev); on EC2 profile_name=None falls back
+    # to the instance metadata credential chain.
+    session = boto3.Session(profile_name=os.environ.get("AWS_PROFILE"))
+    session.client("s3", region_name="us-east-1").put_object(
         Bucket=BUCKET,
         Key=key,
         Body=json.dumps(data, indent=2).encode(),

--- a/scripts/generate_hub_stats.py
+++ b/scripts/generate_hub_stats.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Generate hub_stats.json and hub_stats_bws.json from the live ES index
+and upload to s3://dashboard-analytics/hub-stats/.
+
+Run on the ingest EC2 after each monthly index rebuild completes,
+before final verification. Requires boto3 and network access to ES.
+
+Usage:
+    python3 scripts/generate_hub_stats.py
+
+Environment:
+    ES_HOST  - Elasticsearch hostname (default: search-prod1.internal.dp.la)
+    ES_PORT  - Elasticsearch port (default: 9200)
+"""
+
+import json
+import os
+import urllib.request
+from datetime import datetime, timezone
+
+import boto3
+
+ES_HOST = os.environ.get("ES_HOST", "search-prod1.internal.dp.la")
+ES_PORT = int(os.environ.get("ES_PORT", "9200"))
+BUCKET = "dashboard-analytics"
+HUB_KEY = "hub-stats/hub_stats.json"
+BWS_KEY = "hub-stats/hub_stats_bws.json"
+
+
+def es_query(query: dict) -> dict:
+    url = f"http://{ES_HOST}:{ES_PORT}/dpla_alias/_search"
+    data = json.dumps(query).encode()
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        return json.loads(resp.read())
+
+
+def build_stats(bws: bool = False) -> dict:
+    query: dict = {
+        "size": 0,
+        "aggs": {
+            "hubs": {
+                "terms": {"field": "provider.name.not_analyzed", "size": 200},
+                "aggs": {
+                    "contributors": {
+                        "terms": {
+                            "field": "dataProvider.name.not_analyzed",
+                            "size": 2000,
+                        }
+                    }
+                },
+            }
+        },
+    }
+    if bws:
+        query["query"] = {"term": {"tags": "blackwomensuffrage"}}
+
+    result = es_query(query)
+
+    hubs = {}
+    for hub_bucket in result["aggregations"]["hubs"]["buckets"]:
+        hub_name = hub_bucket["key"]
+        contributors = {
+            c["key"]: c["doc_count"] for c in hub_bucket["contributors"]["buckets"]
+        }
+        hubs[hub_name] = {
+            "item_count": hub_bucket["doc_count"],
+            "contributors": contributors,
+        }
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "hubs": hubs,
+    }
+
+
+def upload(data: dict, key: str) -> None:
+    boto3.client("s3", region_name="us-east-1").put_object(
+        Bucket=BUCKET,
+        Key=key,
+        Body=json.dumps(data, indent=2).encode(),
+        ContentType="application/json",
+    )
+    print(f"  Uploaded s3://{BUCKET}/{key}", flush=True)
+
+
+def main() -> None:
+    print("Generating hub stats from ES...", flush=True)
+
+    hub_stats = build_stats(bws=False)
+    hub_count = len(hub_stats["hubs"])
+    print(f"  {hub_count} hubs", flush=True)
+
+    bws_stats = build_stats(bws=True)
+    bws_hub_count = sum(1 for h in bws_stats["hubs"].values() if h["item_count"] > 0)
+    print(f"  {bws_hub_count} hubs with BWS items", flush=True)
+
+    upload(hub_stats, HUB_KEY)
+    upload(bws_stats, BWS_KEY)
+
+    print(
+        f"Done. {hub_count} hubs, generated_at={hub_stats['generated_at']}",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_hub_stats.py
+++ b/scripts/generate_hub_stats.py
@@ -123,7 +123,7 @@ def main() -> None:
     print(f"  {hub_count} hubs", flush=True)
 
     bws_stats = build_stats(bws=True)
-    bws_hub_count = sum(1 for h in bws_stats["hubs"].values() if h["item_count"] > 0)
+    bws_hub_count = len(bws_stats["hubs"])
     print(f"  {bws_hub_count} hubs with BWS items", flush=True)
 
     upload(hub_stats, HUB_KEY)

--- a/scripts/generate_hub_stats.py
+++ b/scripts/generate_hub_stats.py
@@ -6,6 +6,10 @@ and upload to s3://dashboard-analytics/hub-stats/.
 Run on the ingest EC2 after each monthly index rebuild completes,
 before final verification. Requires boto3 and network access to ES.
 
+Uses two passes per stats file: first a hub-level totals aggregation,
+then one per-hub query for contributor counts. A single nested aggregation
+across all hubs exceeds ES's search.max_buckets limit.
+
 Usage:
     python3 scripts/generate_hub_stats.py
 
@@ -34,43 +38,57 @@ def es_query(query: dict) -> dict:
     req = urllib.request.Request(
         url, data=data, headers={"Content-Type": "application/json"}
     )
-    with urllib.request.urlopen(req, timeout=120) as resp:
+    with urllib.request.urlopen(req, timeout=30) as resp:
         return json.loads(resp.read())
 
 
-def build_stats(bws: bool = False) -> dict:
+def hub_totals(bws: bool = False) -> dict:
+    """Return {hub_name: item_count} for all hubs (or BWS-filtered hubs)."""
     query: dict = {
         "size": 0,
         "aggs": {
-            "hubs": {
-                "terms": {"field": "provider.name.not_analyzed", "size": 200},
-                "aggs": {
-                    "contributors": {
-                        "terms": {
-                            "field": "dataProvider.name.not_analyzed",
-                            "size": 2000,
-                        }
-                    }
-                },
-            }
+            "hubs": {"terms": {"field": "provider.name.not_analyzed", "size": 200}}
         },
     }
     if bws:
         query["query"] = {"term": {"tags": "blackwomensuffrage"}}
-
     result = es_query(query)
+    return {b["key"]: b["doc_count"] for b in result["aggregations"]["hubs"]["buckets"]}
 
+
+def contributor_counts(hub_name: str, bws: bool = False) -> dict:
+    """Return {contributor_name: item_count} for all contributors in a hub."""
+    query: dict = {
+        "size": 0,
+        "query": {"term": {"provider.name.not_analyzed": hub_name}},
+        "aggs": {
+            "contributors": {
+                "terms": {"field": "dataProvider.name.not_analyzed", "size": 2000}
+            }
+        },
+    }
+    if bws:
+        query["query"] = {
+            "bool": {
+                "filter": [
+                    {"term": {"provider.name.not_analyzed": hub_name}},
+                    {"term": {"tags": "blackwomensuffrage"}},
+                ]
+            }
+        }
+    result = es_query(query)
+    return {
+        b["key"]: b["doc_count"]
+        for b in result["aggregations"]["contributors"]["buckets"]
+    }
+
+
+def build_stats(bws: bool = False) -> dict:
+    totals = hub_totals(bws)
     hubs = {}
-    for hub_bucket in result["aggregations"]["hubs"]["buckets"]:
-        hub_name = hub_bucket["key"]
-        contributors = {
-            c["key"]: c["doc_count"] for c in hub_bucket["contributors"]["buckets"]
-        }
-        hubs[hub_name] = {
-            "item_count": hub_bucket["doc_count"],
-            "contributors": contributors,
-        }
-
+    for hub_name, item_count in totals.items():
+        contributors = contributor_counts(hub_name, bws)
+        hubs[hub_name] = {"item_count": item_count, "contributors": contributors}
     return {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "hubs": hubs,


### PR DESCRIPTION
## Summary
- Adds `scripts/generate_hub_stats.py` — queries the live ES index via two aggregations (all items + BWS-tagged) and writes `hub_stats.json` and `hub_stats_bws.json` to `s3://dashboard-analytics/hub-stats/`
- Run on the ingest EC2 after each monthly index rebuild (new Step 7.5 in the dpla-index-rebuild skill)

## Motivation
Part of decoupling the analytics dashboard from the live DPLA API. See companion PR dpla/dashboard-analytics#261.

The script queries ES directly (not Parquet) because `ParquetDump` drops the `tags` field, which is needed for BWS counts. The ingest EC2 has direct access to `search-prod1.internal.dp.la:9200`.

## Test plan
- [ ] Start ingest EC2, run `python3 scripts/generate_hub_stats.py` manually
- [ ] Confirm both S3 files exist: `aws s3 ls s3://dashboard-analytics/hub-stats/`
- [ ] Confirm JSON shape matches expected: `{"generated_at": "...", "hubs": {"Hub Name": {"item_count": N, "contributors": {...}}}}`
- [ ] Confirm BWS file has `blackwomensuffrage`-tagged items only (spot-check a known BWS hub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated hub statistics generation producing JSON reports with per-hub item counts and contributor breakdowns.
  * Produces two variants: overall and collection-filtered reports.
  * Reports include UTC generation timestamps and validation to detect incomplete aggregations.
  * Generated reports are uploaded to analytics storage and progress is logged to stdout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->