### PR TITLE
fix: filter PREV_SNAP to timestamped snapshots only; log _MANIFEST fetch failures

### DIFF
--- a/scripts/ingest.sh
+++ b/scripts/ingest.sh
@@ -324,13 +324,24 @@ fi
 S3_PREFIX=$(resolve_s3_prefix "$PROVIDER")
 PREV_COUNT=0
 if _S3_LS=$(aws s3 ls "s3://dpla-master-dataset/${S3_PREFIX}/jsonl/" 2>&1); then
-    PREV_SNAP=$(echo "$_S3_LS" | awk '{print $NF}' | sed 's|/||g' | sort | tail -1)
+    # Filtering by pattern ensures stale non-snapshot objects (e.g. takedown CSVs,
+    # editor backups) never get picked as the "previous snapshot" and cause the
+    # _MANIFEST fetch to fail.
+    PREV_SNAP=$(echo "$_S3_LS" \
+        | awk '{print $NF}' | sed 's|/||g' \
+        | grep -E '^[0-9]{8}_[0-9]{6}-' \
+        | sort | tail -1)
     if [ -n "$PREV_SNAP" ]; then
-        PREV_COUNT=$(aws s3 cp "s3://dpla-master-dataset/${S3_PREFIX}/jsonl/${PREV_SNAP}/_MANIFEST" - 2>/dev/null \
-            | read_manifest_count /dev/stdin)
+        if _MANIFEST_CONTENT=$(aws s3 cp \
+                "s3://dpla-master-dataset/${S3_PREFIX}/jsonl/${PREV_SNAP}/_MANIFEST" - \
+                2>/dev/null); then
+            PREV_COUNT=$(echo "$_MANIFEST_CONTENT" | read_manifest_count /dev/stdin)
+        else
+            log_warn "Could not fetch _MANIFEST for previous snapshot '${PREV_SNAP}' — relative safety check will be skipped"
+        fi
     fi
 else
-    log_warn "Could not list S3 snapshots for $PROVIDER (aws s3 ls failed) — relative safety check will be skipped"
+    log_warn "Could not list S3 snapshots for ${PROVIDER} (aws s3 ls failed) — relative safety check will be skipped"
     log_warn "$_S3_LS"
 fi
 


### PR DESCRIPTION
## Summary

- Stale objects in the S3 \`jsonl/\` prefix (e.g. takedown CSVs left from a prior operation, editor backup files ending in \`~\`) were being picked as \`PREV_SNAP\` by \`sort | tail -1\`, since filenames like \`to-delete.csv~\` sort after \`20260...\` lexicographically.
- \`aws s3 cp .../to-delete.csv~/_MANIFEST\` then exits 1; under \`set -eo pipefail\` this killed the script silently — the only diagnostic was \`"error": "Exit 1"\` in the hub status file, with no log output explaining why.
- **Fix 1**: Filter the S3 listing to entries matching \`^[0-9]{8}_[0-9]{6}-\` (i.e. \`YYYYMMDD_HHMMSS-*\`) so non-snapshot objects are ignored regardless of their name or sort order.
- **Fix 2**: Separate the manifest fetch from \`read_manifest_count\` so fetch failures emit a \`log_warn\` and skip the safety check rather than crashing the run.

### What the logging looks like now

If \`aws s3 ls\` itself fails (permissions error, network issue):
```
[WARN] Could not list S3 snapshots for bpl (aws s3 ls failed) — relative safety check will be skipped
[WARN] <raw AWS error message>
```

If the \`_MANIFEST\` fetch fails — which is what happened in the original bug, where the stale file had no \`_MANIFEST\` subdirectory:
```
[WARN] Could not fetch _MANIFEST for previous snapshot 'to-delete.csv~' — relative safety check will be skipped
```

The snapshot name in that second message immediately identifies the stale object that caused the failure, which was completely missing from the original silent exit.

## Test plan

- [ ] Run an ingest for any hub whose S3 \`jsonl/\` prefix contains a previous valid snapshot — confirm \`PREV_COUNT\` is populated correctly and the safety check fires
- [ ] Manually place a stale file in the S3 \`jsonl/\` prefix and confirm it is silently ignored (and that \`PREV_SNAP\` resolves to the most recent real snapshot)
- [ ] Remove all valid snapshots from a test hub's S3 prefix — confirm \`PREV_SNAP\` is empty, no crash, \`PREV_COUNT\` stays 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)