### PR TITLE
Add slack notifs to community webs

### DIFF
--- a/scripts/harvest/community-webs-ingest.sh
+++ b/scripts/harvest/community-webs-ingest.sh
@@ -8,6 +8,11 @@
 #   3. Harvest community-webs
 #   4. (Optional) Run full pipeline: mapping + enrichment + jsonl
 #
+# Posts milestone messages to Slack (#tech-alerts) at each step, matching the
+# notification pattern used by ingest.sh. Requires SLACK_WEBHOOK env var to
+# be set (see /home/ec2-user/ingestion3/.env). If SLACK_WEBHOOK is unset the
+# notifications are silently skipped — the script still runs end-to-end.
+#
 # Usage:
 #   ./scripts/community-webs-ingest.sh [options]
 #
@@ -37,6 +42,42 @@ SKIP_EXPORT=false
 FULL_PIPELINE=false
 UPDATE_CONF=false
 DB_PATH=""
+
+# Slack notifications -------------------------------------------------------
+# Mirrors the milestone format from ingest.sh (per §15 of the onboarding doc):
+#   :arrow_forward: community-webs ingest started
+#   :white_check_mark: community-webs harvest complete
+#   :x: community-webs ingest failed (exit N)
+#
+# If common.sh already defines a slack_notify function, prefer that one and
+# delete the local definition below — this is here so the script works even
+# if common.sh is missing the helper.
+HUB_NAME="community-webs"
+
+if ! declare -F slack_notify >/dev/null 2>&1; then
+    slack_notify() {
+        local emoji="$1"
+        local message="$2"
+        if [[ -z "${SLACK_WEBHOOK:-}" ]]; then
+            return 0  # No webhook configured — silently skip.
+        fi
+        # Use a 5s timeout so a slow/down Slack endpoint can't stall the ingest.
+        curl -s --max-time 5 -X POST \
+            -H 'Content-Type: application/json' \
+            --data "$(printf '{"text":"%s %s: %s"}' "$emoji" "$HUB_NAME" "$message")" \
+            "$SLACK_WEBHOOK" > /dev/null 2>&1 || true
+    }
+fi
+
+# Trap any failure (set -e propagates failed commands to ERR) and post to
+# Slack before letting the script exit. Without this, a failure would exit
+# silently from Slack's perspective.
+on_failure() {
+    local rc=$?
+    slack_notify ":x:" "ingest failed (exit $rc)"
+    exit $rc
+}
+trap on_failure ERR
 
 usage() {
     echo "Usage: $0 [options]"
@@ -83,6 +124,7 @@ for arg in "$@"; do
 done
 
 main() {
+    slack_notify ":arrow_forward:" "ingest started"
     setup_java "4g" || die "Failed to setup Java"
 
     if [[ "$SKIP_EXPORT" != "true" ]]; then
@@ -91,6 +133,7 @@ main() {
         [[ -n "$DB_PATH" ]] && export_args+=(--db="$DB_PATH")
         [[ "$UPDATE_CONF" == "true" ]] && export_args+=(--update-conf)
         "$SCRIPT_DIR/community-webs-export.sh" "${export_args[@]}" || die "Export failed"
+        slack_notify ":white_check_mark:" "export complete"
     else
         log_info "Skipping export (using existing ZIP)"
         if [[ -z "${I3_CONF:-}" ]] || [[ ! -f "$I3_CONF" ]]; then
@@ -101,10 +144,12 @@ main() {
 
     print_step "Harvesting community-webs..."
     "$SCRIPTS_ROOT/harvest.sh" community-webs || die "Harvest failed"
+    slack_notify ":white_check_mark:" "harvest complete"
 
     if [[ "$FULL_PIPELINE" == "true" ]]; then
         print_step "Running full pipeline (mapping + enrichment + jsonl)..."
         "$SCRIPTS_ROOT/ingest.sh" community-webs --skip-harvest || die "Pipeline failed"
+        slack_notify ":white_check_mark:" "ingest complete (full pipeline)"
         log_success "Community Webs ingest complete"
         echo ""
         echo "Output: $DPLA_DATA/community-webs/"


### PR DESCRIPTION
Adds slack notifications to the community-webs-ingest.sh file in the same methodology they exist in the ingest.sh file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds Slack milestone notifications to the `community-webs-ingest.sh` harvest script using the `SLACK_WEBHOOK` environment variable pattern. Implements a local `slack_notify()` function that only activates if not already provided by `common.sh`, ensuring compatibility without duplicating functionality.

## Changes

**scripts/harvest/community-webs-ingest.sh:**
- Defines a local `slack_notify()` function that POSTs emoji+message payloads to `SLACK_WEBHOOK` with a 5-second timeout, silently no-op when `SLACK_WEBHOOK` is unset
- Adds an ERR trap (`on_failure`) that posts a `:x:` failure notification with the exit code before re-exiting
- Emits `:arrow_forward:` at script start, `:white_check_mark:` after export, after harvest, and after the optional full pipeline
- Updates documentation to describe the notification behavior
- Fixes file's trailing newline

## Environment & Deployment

The implementation uses `SLACK_WEBHOOK` environment variable which is already documented in the existing codebase (see `/home/ec2-user/ingestion3/.env` referenced in `common.sh`). **No manual pipeline trigger, ECS redeployment, or environment variable changes required.** The `.env` file already defines this webhook URL for existing notification systems.

## Approach Notes

The implementation differs intentionally from the `slack_notify()` pattern in `common.sh` (which uses `SLACK_BOT_TOKEN` and Python JSON), maintaining backward compatibility by only defining the local function if `common.sh` hasn't already provided one. This defensive approach ensures the script works even if `common.sh` is missing the helper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->