### PR TITLE
Remove duplicate Slack webhook from harvest failure notifier

### DIFF
--- a/.claude/skills/dpla-maryland-ingest/SKILL.md
+++ b/.claude/skills/dpla-maryland-ingest/SKILL.md
@@ -135,7 +135,6 @@ If .env is missing, create it:
 DPLA_DATA=/home/ec2-user/data/
 I3_CONF=/home/ec2-user/ingestion3-conf/i3.conf
 SLACK_WEBHOOK=<webhook from local ~/.claude/secrets or ingestion3/.env>
-SLACK_ALERT_USER_ID=UQYFCAVEC
 JAVA_HOME=/home/ec2-user/.local/share/mise/installs/java/temurin-11.0.29+7
 ```
 

--- a/.cursor/skills/dpla-maryland-ingest/SKILL.md
+++ b/.cursor/skills/dpla-maryland-ingest/SKILL.md
@@ -135,7 +135,6 @@ If .env is missing, create it:
 DPLA_DATA=/home/ec2-user/data/
 I3_CONF=/home/ec2-user/ingestion3-conf/i3.conf
 SLACK_WEBHOOK=<webhook from local ~/.claude/secrets or ingestion3/.env>
-SLACK_ALERT_USER_ID=UQYFCAVEC
 JAVA_HOME=/home/ec2-user/.local/share/mise/installs/java/temurin-11.0.29+7
 ```
 

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ SLACK_WEBHOOK=your_webhook_url_here
 # If not set, hub-complete messages fall back to SLACK_WEBHOOK.
 SLACK_TECH_WEBHOOK=your_tech_channel_webhook_url_here
 
-# Slack User ID to @mention on harvest failures (e.g. U01234ABCD).
+# Slack User ID to @mention in orchestrator escalation alerts (e.g. U01234ABCD).
 # Find via Slack: Profile → More → Copy member ID.
 SLACK_ALERT_USER_ID=
 

--- a/docs/ai-context/skills/dpla-maryland-ingest.md
+++ b/docs/ai-context/skills/dpla-maryland-ingest.md
@@ -135,7 +135,6 @@ If .env is missing, create it:
 DPLA_DATA=/home/ec2-user/data/
 I3_CONF=/home/ec2-user/ingestion3-conf/i3.conf
 SLACK_WEBHOOK=<webhook from local ~/.claude/secrets or ingestion3/.env>
-SLACK_ALERT_USER_ID=UQYFCAVEC
 JAVA_HOME=/home/ec2-user/.local/share/mise/installs/java/temurin-11.0.29+7
 ```
 

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -412,11 +412,9 @@ One summary email to all contacts of hubs scheduled for a given month. Sent at t
 
 ### notify-harvest-failure.sh and send-harvest-failure-email.py - Harvest Failure Alerts
 
-Invoked by `HarvestExecutor` when an OAI (or other) harvest fails. Sends **both** Slack and email so tech is notified even if one channel is unavailable.
+Invoked by `HarvestExecutor` when an OAI (or other) harvest fails. Sends email to tech@dp.la. Slack alerts are handled separately by the Tech Reports bot.
 
 **Email body is built in Scala:** `OaiHarvestException.buildEmailBody` (in `OaiResponse.scala`) produces the complete email body (hub name, human-readable error details, footer). `HarvestExecutor` passes this body as a third argument to `notify-harvest-failure.sh`, which forwards it to `send-harvest-failure-email.py`. The Python script sends the body as-is — no template wrapping. This makes Scala the single source of truth for notification content.
-
-**Slack:** If `SLACK_WEBHOOK` is set, posts to #tech-alerts with hub name and error snippet (from `OaiHarvestException.getMessage`). Optional `SLACK_ALERT_USER_ID` adds an @mention.
 
 **Email:** Always attempts to send to **tech@dp.la** via AWS SES using `scripts/communication/send-harvest-failure-email.py` (requires project venv and boto3; uses `AWS_PROFILE`, default `dpla`). Best-effort: if email fails (e.g. no credentials), a warning is printed and the script still exits 0.
 
@@ -429,7 +427,7 @@ Invoked by `HarvestExecutor` when an OAI (or other) harvest fails. Sends **both*
 ./scripts/communication/notify-harvest-failure.sh indiana "OAI Error: badArgument ..."
 ```
 
-**Environment:** `SLACK_WEBHOOK`, `SLACK_ALERT_USER_ID`, `AWS_PROFILE` (for email), `I3_HOME` (default: derived from script path).
+**Environment:** `AWS_PROFILE` (for email, default `dpla`), `I3_HOME` (default: derived from script path).
 
 ## Workflow Diagrams
 

--- a/scripts/communication/notify-harvest-failure.sh
+++ b/scripts/communication/notify-harvest-failure.sh
@@ -1,21 +1,20 @@
 #!/usr/bin/env bash
-# notify-harvest-failure.sh - Send Slack and email notification on harvest failure
+# notify-harvest-failure.sh - Send email notification on harvest failure
 #
 # Usage: ./scripts/notify-harvest-failure.sh <hub> "<error message>" ["<email body>"]
 #
 # Args:
 #   $1  Hub short name (required)
-#   $2  Error summary for Slack code block (required)
+#   $2  Error summary (required)
 #   $3  Complete email body built by the Scala pipeline (optional; when omitted
 #       the Python emailer wraps $2 in a default template)
 #
-# Sends to both Slack (#tech-alerts) and tech@dp.la (email via AWS SES).
+# Sends to tech@dp.la via AWS SES. Slack alerts are handled by the Tech Reports
+# bot and do not need to be sent here.
 #
 # Environment:
-#   SLACK_WEBHOOK        - Slack webhook URL for #tech-alerts (required for Slack)
-#   SLACK_ALERT_USER_ID  - Slack user ID to mention, e.g. U01234ABCD (optional)
-#   AWS_PROFILE          - AWS profile for SES email (default: dpla)
-#   I3_HOME              - Repo root (default: derived from script location)
+#   AWS_PROFILE  - AWS profile for SES email (default: dpla)
+#   I3_HOME      - Repo root (default: derived from script location)
 
 set -e
 
@@ -28,56 +27,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 I3_HOME="${I3_HOME:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
 export I3_HOME
 
-# Truncate very long error messages for Slack
-MAX_LEN=1500
-if [ "${#ERROR_MSG}" -gt "$MAX_LEN" ]; then
-    ERROR_MSG_SLACK="${ERROR_MSG:0:$MAX_LEN}..."
-else
-    ERROR_MSG_SLACK="$ERROR_MSG"
-fi
-
-# Build the mention string
-MENTION=""
-if [ -n "${SLACK_ALERT_USER_ID:-}" ]; then
-    MENTION="<@${SLACK_ALERT_USER_ID}> "
-fi
-
-# 1. Send to Slack when webhook is set
-if [ -n "${SLACK_WEBHOOK:-}" ]; then
-    PAYLOAD=$(cat <<EOJSON
-{
-  "text": ":x: *Harvest Failure: ${HUB}*\n${MENTION}OAI harvest failure needs attention\n\n\`\`\`\n${ERROR_MSG_SLACK}\n\`\`\`"
-}
-EOJSON
-)
-
-    if curl -s -o /dev/null -w "%{http_code}" \
-        -X POST -H 'Content-Type: application/json' \
-        -d "$PAYLOAD" "$SLACK_WEBHOOK" | grep -q "200"; then
-        echo "Harvest failure notification sent to Slack for ${HUB}"
-    else
-        echo "Warning: Failed to send Slack notification for ${HUB}" >&2
-    fi
-else
-    echo "SLACK_WEBHOOK not set. Harvest failure for ${HUB}:" >&2
-    echo "$ERROR_MSG" >&2
-    echo "" >&2
-fi
-
-# 2. Always send email to tech@dp.la (best-effort)
+# Send email to tech@dp.la (best-effort)
 # When EMAIL_BODY is provided (from Scala), pass it as arg 3 so the Python
 # script uses it as-is. Otherwise the Python script wraps ERROR_MSG in a
 # default template.
 SEND_EMAIL_SCRIPT="$I3_HOME/scripts/communication/send-harvest-failure-email.py"
 PYTHON="${I3_HOME}/venv/bin/python"
 if [ -x "$PYTHON" ] && [ -f "$SEND_EMAIL_SCRIPT" ]; then
-    if [ -n "$EMAIL_BODY" ]; then
-        "$PYTHON" "$SEND_EMAIL_SCRIPT" "$HUB" "$ERROR_MSG" "$EMAIL_BODY" 2>/dev/null || \
-            echo "Warning: Failed to send harvest failure email to tech@dp.la" >&2
-    else
-        "$PYTHON" "$SEND_EMAIL_SCRIPT" "$HUB" "$ERROR_MSG" 2>/dev/null || \
-            echo "Warning: Failed to send harvest failure email to tech@dp.la" >&2
-    fi
+    ARGS=("$HUB" "$ERROR_MSG")
+    [ -n "$EMAIL_BODY" ] && ARGS+=("$EMAIL_BODY")
+    "$PYTHON" "$SEND_EMAIL_SCRIPT" "${ARGS[@]}" 2>/dev/null || \
+        echo "Warning: Failed to send harvest failure email to tech@dp.la" >&2
 else
     echo "Could not run send-harvest-failure-email.py (missing venv or script). Notify tech@dp.la manually." >&2
 fi


### PR DESCRIPTION
## Summary

- `notify-harvest-failure.sh` was firing a second Slack alert via the `incoming-webhook` app on every OAI harvest failure, duplicating the alert already posted by the Tech Reports bot
- Removes the `SLACK_WEBHOOK` send entirely from the script — email to tech@dp.la is unaffected
- Collapses the duplicated Python invocation branches into a single call with a conditional args array
- Removes the hardcoded `SLACK_ALERT_USER_ID=UQYFCAVEC` from the Maryland ingest skill's `.env` template (the var remains valid for orchestrator escalation alerts; `.env.example` comment updated accordingly)
- Docs (`SCRIPTS.md`) updated to reflect email-only behaviour

## Test plan

- [ ] Trigger or simulate an OAI harvest failure and confirm only one Slack alert fires (from the Tech Reports bot)
- [ ] Confirm `notify-harvest-failure.sh` still attempts the SES email path as before
- [ ] Remove `SLACK_ALERT_USER_ID` from EC2's `/home/ec2-user/ingestion3/.env` (no longer used by the Scala pipeline path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR removes duplicate Slack webhook notifications from the harvest failure notifier while retaining email notifications to `tech@dp.la`.

### Changes

**Script refactoring:**
- `scripts/communication/notify-harvest-failure.sh` no longer sends a second Slack alert via the `incoming-webhook` app (the Tech Reports bot already handles Slack notifications for OAI harvest failures)
- Removed all Slack-specific logic: error truncation, formatting, webhook POST, and user mention handling
- Refactored Python invocation to use a single conditional argument array instead of duplicated branches
- Email notification path via `send-harvest-failure-email.py` remains unchanged and best-effort

**Environment variable updates:**
- Removed `SLACK_ALERT_USER_ID=UQYFCAVEC` hardcoded value from Maryland ingest skill's `.env` template (`.claude/` and `.cursor/` skill variants)
- Updated `.env.example` comment to clarify `SLACK_ALERT_USER_ID` is for orchestrator escalation alerts, not harvest failures
- Note: `SLACK_ALERT_USER_ID` remains valid and in use by `scheduler/orchestrator/config.py` for orchestrator alerts; only the Maryland skill's template documentation was updated

**Documentation:**
- `scripts/SCRIPTS.md` updated to indicate `notify-harvest-failure.sh` now sends email-only alerts for harvest failures
- Removed references to Slack environment variables (`SLACK_WEBHOOK`, `SLACK_ALERT_USER_ID`) from harvest failure notifier documentation
- Updated AI skill context documents to reflect the removed environment variable from Maryland ingest setup

### Deployment Notes

- **No manual trigger required**: Changes take effect with normal code deployment; the script is automatically invoked by `HarvestExecutor` when OAI harvests fail
- **No infrastructure changes**: No database migrations, ECS task definition updates, IAM policy changes, or CodePipeline modifications
- **Backward compatible**: Email notification path unchanged; only redundant Slack alert removed
- **No security implications**: Simplifies notification flow without affecting credential handling or external integrations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->