### PR TITLE
Route njde harvest through Tailscale exit node for IP-whitelisted endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Some hubs restrict access to their OAI-PMH endpoint by IP address or VPN members
 
 Some partner endpoints are not publicly accessible — they whitelist a specific IP for OAI-PMH access. Rather than whitelisting the EC2's dynamic public IP (which changes on stop/start), we use a [Tailscale](https://tailscale.com) exit node to route harvest traffic through a stable whitelisted IP.
 
-`ingest.sh` handles the full lifecycle automatically when `tailscaleExitNode` is set in `i3.conf` for a hub: it starts `tailscaled`, waits for the daemon to connect, sets the exit node, runs the harvest, then clears the exit node and stops `tailscaled`. No manual Tailscale steps are needed to run these ingests.
+`ingest.sh` handles the full lifecycle automatically for hubs that require it (determined by a `TAILSCALE_EXIT_NODE` case block in `ingest.sh`): it starts `tailscaled`, waits for the daemon to connect, sets the exit node, runs the harvest, then clears the exit node and stops `tailscaled`. Only the **harvest step** is routed through the exit node — mapping, enrichment, JSONL export, and S3 sync use normal routing. No manual Tailscale steps are needed to run these ingests.
 
 **Tailscale auth on the EC2 is per-machine**, stored in `/var/lib/tailscale/` on EBS. It persists across stop/start cycles and is not tied to any individual operator — anyone with EC2 access can run these ingests.
 
@@ -278,7 +278,7 @@ Some partner endpoints are not publicly accessible — they whitelist a specific
 | Partner | Rutgers University / New Jersey State Library |
 | Endpoint | IP-whitelisted OAI-PMH |
 | Whitelisted IP | `100.82.233.38` (main-vpc Tailscale node) |
-| i3.conf key | `njde.harvest.tailscaleExitNode = "main-vpc"` |
+| Configured in | `scripts/ingest.sh` (`TAILSCALE_EXIT_NODE` case block) |
 | Handled by | `ingest.sh` automatically |
 
 Run exactly like any other hub — `ingest.sh njde` — no extra steps needed.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ DPLA's ingestion system is one of the core business systems and is the source of
     * [EC2 ingest instance](#ec2-ingest-box)
     * [Locally](#running-ingests-locally)
     * [Hub specific instructions](#exceptions-and-unusual-ingests)
-      * [Firewalled endpoints](#firewalled-endpoints) 
+      * [Firewalled endpoints](#firewalled-endpoints)
+      * [IP-whitelisted endpoints (Tailscale exit node)](#ip-whitelisted-endpoints-tailscale-exit-node)
+        * [NJ Digital Library (njde)](#nj-digital-library-njde)
       * [Internet Archive - Community Webs](#community-webs)
       * [Digital Virginias](#digital-virginias)
       * Digital Commonwealth
@@ -57,7 +59,8 @@ DPLA's ingestion system is one of the core business systems and is the source of
 - [Running ingests locally](#running-ingests-locally)
 - [Exceptions / Usual ingests](#exceptions-and-unusual-ingests)
       
-  - [Firewalled endpoints](#firewalled-endpoints) 
+  - [Firewalled endpoints](#firewalled-endpoints)
+  - [IP-whitelisted endpoints (Tailscale exit node)](#ip-whitelisted-endpoints-tailscale-exit-node)
   - [Internet Archive - Community Webs](#community-webs)
   - [Digital Virginias](#digital-virginias)
   - Digital Commonwealth
@@ -247,11 +250,38 @@ Bringing up the ingest EC2 instance is not always required. You can run a lot of
 Not all ingests are fire and forget, some require a bit of massaging before we can successfully harvest their data.
 
 ### Firewalled endpoints
-Some hubs have their feed endpoints behind a firewall so the harvests needs to be run while behind out VPN. I've been meaning to try and get the EC2 instance behind the VPN but that work is not a high priority right now because we have a workaround (run locally behind the VPN). Hubs that need to be harvested while connected to the VPN:
+
+Some hubs restrict access to their OAI-PMH endpoint by IP address or VPN membership. There are two patterns:
+
+**Run locally (VPN required):** The partner's firewall only allows connections from inside a specific institution's network. These must be harvested on a machine connected to that VPN — the EC2 instance cannot be placed behind an external institution's VPN.
 
 - Illinois
 - Indiana
 - MWDL
+
+**Tailscale exit node (automated):** The partner has whitelisted a specific stable IP address. Rather than exposing the EC2's dynamic public IP, we route harvest traffic through the `main-vpc` Tailscale node (`100.82.233.38`). `ingest.sh` handles this automatically — see [IP-whitelisted endpoints (Tailscale exit node)](#ip-whitelisted-endpoints-tailscale-exit-node) below.
+
+### IP-whitelisted endpoints (Tailscale exit node)
+
+Some partner endpoints are not publicly accessible — they whitelist a specific IP for OAI-PMH access. Rather than whitelisting the EC2's dynamic public IP (which changes on stop/start), we use a [Tailscale](https://tailscale.com) exit node to route harvest traffic through a stable whitelisted IP.
+
+`ingest.sh` handles the full lifecycle automatically when `tailscaleExitNode` is set in `i3.conf` for a hub: it starts `tailscaled`, waits for the daemon to connect, sets the exit node, runs the harvest, then clears the exit node and stops `tailscaled`. No manual Tailscale steps are needed to run these ingests.
+
+**Tailscale auth on the EC2 is per-machine**, stored in `/var/lib/tailscale/` on EBS. It persists across stop/start cycles and is not tied to any individual operator — anyone with EC2 access can run these ingests.
+
+**⚠️ Node key rotation:** Tailscale node keys expire approximately every 180 days. When the key expires, `ingest.sh` detects it immediately at harvest time and prints a clear error with re-authentication instructions. See `scripts/SCRIPTS.md` for the full recovery procedure.
+
+#### NJ Digital Library (njde)
+
+| Field | Value |
+|-------|-------|
+| Partner | Rutgers University / New Jersey State Library |
+| Endpoint | IP-whitelisted OAI-PMH |
+| Whitelisted IP | `100.82.233.38` (main-vpc Tailscale node) |
+| i3.conf key | `njde.harvest.tailscaleExitNode = "main-vpc"` |
+| Handled by | `ingest.sh` automatically |
+
+Run exactly like any other hub — `ingest.sh njde` — no extra steps needed.
 
 ### Community Webs
 

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -150,6 +150,23 @@ Runs the complete ingestion pipeline for a hub:
 ./scripts/ingest.sh maryland --harvest-only   # Only harvest
 ```
 
+#### IP-restricted hubs (TAILSCALE_EXIT_NODE)
+
+Some partners whitelist specific source IPs on their OAI endpoints. For those hubs, `ingest.sh` automatically routes harvest traffic through a Tailscale exit node that holds the whitelisted IP. The exit node is set before the harvest step and cleared (and tailscaled stopped) immediately after, so downstream steps (mapping, enrichment, S3 sync) use normal routing.
+
+The exit node is configured per-provider in a `case` block near the top of `ingest.sh`:
+
+```bash
+case "$PROVIDER" in
+    njde) TAILSCALE_EXIT_NODE="100.82.233.38" ;;  # main-vpc; IP whitelisted by Rutgers
+esac
+```
+
+**Prerequisites** for IP-restricted hubs:
+- Tailscale must be installed on the EC2 (`tailscale` command on PATH)
+- The exit node machine (e.g. `main-vpc` at `100.82.233.38`) must have exit node routes advertised and approved in the Tailscale admin console
+- `ec2-user` must have passwordless sudo for `systemctl` (standard on the ingest EC2)
+
 ### auto-ingest.sh - Automated Monthly Ingestion
 
 Processes hubs scheduled for the current month:

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -162,10 +162,34 @@ case "$PROVIDER" in
 esac
 ```
 
+**Current IP-restricted hubs:**
+
+| Hub | Partner | Whitelisted IP | Tailscale exit node |
+|-----|---------|---------------|---------------------|
+| `njde` | Rutgers (NJ Digital Library) | `100.82.233.38` | `main-vpc` |
+
 **Prerequisites** for IP-restricted hubs:
 - Tailscale must be installed on the EC2 (`tailscale` command on PATH)
-- The exit node machine (e.g. `main-vpc` at `100.82.233.38`) must have exit node routes advertised and approved in the Tailscale admin console
+- The exit node machine (`main-vpc` at `100.82.233.38`) must have exit node routes advertised (`tailscale set --advertise-exit-node` on main-vpc) and approved in the Tailscale admin console (tailscale.com/admin → Machines → main-vpc → Edit route settings)
 - `ec2-user` must have passwordless sudo for `systemctl` (standard on the ingest EC2)
+- Tailscale authentication is per-machine (stored in `/var/lib/tailscale/` on the EC2 EBS volume) — no per-operator credentials needed
+
+**Node key rotation (important — ~180 day maintenance task):**
+
+Tailscale node keys expire approximately every 180 days. When the ingest EC2's key expires, the njde harvest will fail immediately with a clear error message:
+
+```
+Tailscale node key has expired on this EC2. Re-authenticate with:
+  sudo tailscale up --auth-key=<key>
+```
+
+To fix: generate a reusable pre-auth key at tailscale.com/admin → Settings → Keys, then SSH or SSM into the EC2 and run:
+
+```bash
+sudo tailscale up --auth-key=<your-reusable-key>
+```
+
+This is a one-time re-authentication of the EC2 machine — not tied to any individual operator. After re-authenticating, re-run the njde ingest normally.
 
 ### auto-ingest.sh - Automated Monthly Ingestion
 

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -152,7 +152,7 @@ Runs the complete ingestion pipeline for a hub:
 
 #### IP-restricted hubs (TAILSCALE_EXIT_NODE)
 
-Some partners whitelist specific source IPs on their OAI endpoints. For those hubs, `ingest.sh` automatically routes harvest traffic through a Tailscale exit node that holds the whitelisted IP. The exit node is set before the harvest step and cleared (and tailscaled stopped) immediately after, so downstream steps (mapping, enrichment, S3 sync) use normal routing.
+Some partners whitelist specific source IPs on their OAI endpoints. For those hubs, `ingest.sh` automatically routes harvest traffic through a Tailscale exit node that holds the whitelisted IP. The exit node is set before the harvest step and cleared (and tailscaled stopped) immediately after, so downstream steps (mapping, enrichment, S3 sync) use normal routing. On failure, the same cleanup runs best-effort via an EXIT trap — it attempts to clear the exit node and stop `tailscaled` even when the harvest fails.
 
 The exit node is configured per-provider in a `case` block near the top of `ingest.sh`:
 

--- a/scripts/ingest.sh
+++ b/scripts/ingest.sh
@@ -172,10 +172,24 @@ if [ "$SKIP_HARVEST" = false ] && [[ -z "$RESUME_FROM" ]]; then
         log_info "Starting tailscaled for $PROVIDER harvest"
         sudo systemctl start tailscaled \
             || die "Failed to start tailscaled — required for $PROVIDER endpoint routing"
-        # Wait up to 30s for Tailscale to connect before setting exit node
-        for _i in $(seq 1 30); do tailscale status &>/dev/null && break; sleep 1; done
-        tailscale status &>/dev/null \
-            || die "Tailscale failed to connect within 30s"
+        # Wait up to 30s for Tailscale to connect; break early if key expired
+        for _i in $(seq 1 30); do
+            _ts_state=$(tailscale status --json 2>/dev/null \
+                | python3 -c "import json,sys; print(json.load(sys.stdin).get('BackendState',''))" 2>/dev/null || true)
+            [ "$_ts_state" = "Running" ] && break
+            [ "$_ts_state" = "NeedsLogin" ] && break
+            sleep 1
+        done
+        _ts_state=$(tailscale status --json 2>/dev/null \
+            | python3 -c "import json,sys; print(json.load(sys.stdin).get('BackendState',''))" 2>/dev/null || true)
+        if [ "$_ts_state" = "NeedsLogin" ]; then
+            die "Tailscale node key has expired on this EC2. Re-authenticate with:
+  sudo tailscale up --auth-key=<key>
+Generate a reusable key at tailscale.com/admin → Settings → Keys, then re-run the ingest.
+Node keys rotate every ~180 days; see scripts/SCRIPTS.md for details."
+        elif [ "$_ts_state" != "Running" ]; then
+            die "Tailscale failed to connect within 30s (state: ${_ts_state:-unknown})"
+        fi
         log_info "Setting Tailscale exit node $TAILSCALE_EXIT_NODE for $PROVIDER harvest"
         tailscale set --exit-node="$TAILSCALE_EXIT_NODE" \
             || die "Failed to set Tailscale exit node — $PROVIDER endpoint requires whitelisted IP"

--- a/scripts/ingest.sh
+++ b/scripts/ingest.sh
@@ -99,6 +99,15 @@ if [[ "$HARVEST_TYPE" == *"delta"* ]]; then
     die "Provider '$PROVIDER' uses delta harvesting ($HARVEST_TYPE) and cannot be run with ingest.sh. Use the dedicated script instead (e.g. scripts/harvest/nara-ingest.sh)."
 fi
 
+# Some partners whitelist specific source IPs on their OAI endpoints. For those
+# hubs, we route harvest traffic through a Tailscale exit node that holds the
+# whitelisted IP. The exit node is cleared after harvest so downstream pipeline
+# steps (mapping, enrichment, S3 sync) use normal routing.
+TAILSCALE_EXIT_NODE=""
+case "$PROVIDER" in
+    njde) TAILSCALE_EXIT_NODE="100.82.233.38" ;;  # main-vpc; IP whitelisted by Rutgers
+esac
+
 # Setup paths
 PROVIDER_DATA="$DPLA_DATA/$PROVIDER"
 HARVEST_DIR="$PROVIDER_DATA/harvest"
@@ -115,6 +124,7 @@ INGEST_PROVIDER="$PROVIDER"
 TRAP_HANDLED=false  # set to true when we handle notification+status explicitly before exit
 trap 'err=$?
      stop_heartbeat 2>/dev/null || true
+     [ -n "${TAILSCALE_EXIT_NODE:-}" ] && tailscale set --exit-node= 2>/dev/null || true
      if [[ $err -ne 0 && -n "${INGEST_PROVIDER:-}" && "$TRAP_HANDLED" != "true" ]]; then
          slack_notify ":x: *$INGEST_PROVIDER ingest FAILED* (exit $err)"
          write_hub_status "$INGEST_PROVIDER" failed --error="Exit $err" || true
@@ -156,6 +166,13 @@ if [ "$SKIP_HARVEST" = false ] && [[ -z "$RESUME_FROM" ]]; then
     mkdir -p "$I3_HOME/logs"
     start_heartbeat "$PROVIDER" "harvest" "$HARVEST_LOG"
 
+    if [ -n "$TAILSCALE_EXIT_NODE" ]; then
+        require_command tailscale "Tailscale is required for $PROVIDER (endpoint is IP-restricted) but not installed"
+        log_info "Setting Tailscale exit node $TAILSCALE_EXIT_NODE for $PROVIDER harvest"
+        tailscale set --exit-node="$TAILSCALE_EXIT_NODE" \
+            || die "Failed to set Tailscale exit node — $PROVIDER endpoint requires whitelisted IP"
+    fi
+
     SBT_OPTS="-Xmx15g"
     run_entry dpla.ingestion3.entries.ingest.HarvestEntry \
         --output="$DPLA_DATA" \
@@ -164,6 +181,11 @@ if [ "$SKIP_HARVEST" = false ] && [[ -z "$RESUME_FROM" ]]; then
         --sparkMaster="$SPARK_MASTER" 2>&1 | tee "$HARVEST_LOG"
 
     stop_heartbeat
+    if [ -n "$TAILSCALE_EXIT_NODE" ]; then
+        log_info "Clearing Tailscale exit node after $PROVIDER harvest"
+        tailscale set --exit-node= || log_warn "Failed to clear Tailscale exit node"
+    fi
+
     HARVEST_TS_DIR=$(find_latest_data "$PROVIDER" harvest)
     log_info "Harvest complete: $(basename "$HARVEST_TS_DIR")"
 

--- a/scripts/ingest.sh
+++ b/scripts/ingest.sh
@@ -123,8 +123,9 @@ fi
 INGEST_PROVIDER="$PROVIDER"
 TRAP_HANDLED=false  # set to true when we handle notification+status explicitly before exit
 trap 'err=$?
-     stop_heartbeat 2>/dev/null || true
      [ -n "${TAILSCALE_EXIT_NODE:-}" ] && tailscale set --exit-node= 2>/dev/null || true
+     [ -n "${TAILSCALE_EXIT_NODE:-}" ] && sudo systemctl stop tailscaled 2>/dev/null || true
+     stop_heartbeat 2>/dev/null || true
      if [[ $err -ne 0 && -n "${INGEST_PROVIDER:-}" && "$TRAP_HANDLED" != "true" ]]; then
          slack_notify ":x: *$INGEST_PROVIDER ingest FAILED* (exit $err)"
          write_hub_status "$INGEST_PROVIDER" failed --error="Exit $err" || true
@@ -168,6 +169,13 @@ if [ "$SKIP_HARVEST" = false ] && [[ -z "$RESUME_FROM" ]]; then
 
     if [ -n "$TAILSCALE_EXIT_NODE" ]; then
         require_command tailscale "Tailscale is required for $PROVIDER (endpoint is IP-restricted) but not installed"
+        log_info "Starting tailscaled for $PROVIDER harvest"
+        sudo systemctl start tailscaled \
+            || die "Failed to start tailscaled — required for $PROVIDER endpoint routing"
+        # Wait up to 30s for Tailscale to connect before setting exit node
+        for _i in $(seq 1 30); do tailscale status &>/dev/null && break; sleep 1; done
+        tailscale status &>/dev/null \
+            || die "Tailscale failed to connect within 30s"
         log_info "Setting Tailscale exit node $TAILSCALE_EXIT_NODE for $PROVIDER harvest"
         tailscale set --exit-node="$TAILSCALE_EXIT_NODE" \
             || die "Failed to set Tailscale exit node — $PROVIDER endpoint requires whitelisted IP"
@@ -180,11 +188,12 @@ if [ "$SKIP_HARVEST" = false ] && [[ -z "$RESUME_FROM" ]]; then
         --name="$PROVIDER" \
         --sparkMaster="$SPARK_MASTER" 2>&1 | tee "$HARVEST_LOG"
 
-    stop_heartbeat
     if [ -n "$TAILSCALE_EXIT_NODE" ]; then
-        log_info "Clearing Tailscale exit node after $PROVIDER harvest"
+        log_info "Clearing Tailscale exit node and stopping tailscaled after $PROVIDER harvest"
         tailscale set --exit-node= || log_warn "Failed to clear Tailscale exit node"
+        sudo systemctl stop tailscaled || log_warn "Failed to stop tailscaled"
     fi
+    stop_heartbeat
 
     HARVEST_TS_DIR=$(find_latest_data "$PROVIDER" harvest)
     log_info "Harvest complete: $(basename "$HARVEST_TS_DIR")"

--- a/scripts/tests/test-scripts.sh
+++ b/scripts/tests/test-scripts.sh
@@ -930,6 +930,80 @@ test_send_email_yes_flag() {
 }
 
 # =============================================================================
+# Test: Tailscale exit node configuration (static inspection of ingest.sh)
+# =============================================================================
+
+test_tailscale_exit_node() {
+    echo ""
+    echo "=========================================="
+    echo "  Testing Tailscale Exit Node Configuration"
+    echo "=========================================="
+
+    local ingest_sh="$SCRIPTS_DIR/ingest.sh"
+
+    if [[ ! -f "$ingest_sh" ]]; then
+        log_skip "ingest.sh not found - skipping Tailscale tests"
+        return
+    fi
+
+    local content
+    content=$(< "$ingest_sh")
+
+    # Test 1: njde maps to the expected Tailscale exit node IP
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if grep -q 'njde.*TAILSCALE_EXIT_NODE.*100\.82\.233\.38' <<< "$content"; then
+        log_pass "Tailscale: njde maps to exit node 100.82.233.38"
+    else
+        log_fail "Tailscale: njde exit node mapping not found in ingest.sh"
+    fi
+
+    # Test 2: require_command tailscale is called (install guard present)
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if grep -q 'require_command tailscale' <<< "$content"; then
+        log_pass "Tailscale: require_command guard present"
+    else
+        log_fail "Tailscale: require_command tailscale not found — missing install check"
+    fi
+
+    # Test 3: EXIT trap clears the exit node before stop_heartbeat
+    # Verify ordering within the trap body: Tailscale cleanup must precede stop_heartbeat.
+    TESTS_RUN=$((TESTS_RUN + 1))
+    local trap_block
+    trap_block=$(awk "/^trap '/{found=1} found{print} /EXIT$/{found=0}" <<< "$content")
+    if [[ -z "$trap_block" ]]; then
+        log_fail "Tailscale: could not extract EXIT trap body from ingest.sh"
+    else
+        local ts_line hb_line
+        ts_line=$(grep -n 'tailscale set --exit-node=' <<< "$trap_block" | head -1 | cut -d: -f1)
+        hb_line=$(grep -n 'stop_heartbeat' <<< "$trap_block" | head -1 | cut -d: -f1)
+        if [[ -n "$ts_line" && -n "$hb_line" && "$ts_line" -lt "$hb_line" ]]; then
+            log_pass "Tailscale: EXIT trap clears exit node before stop_heartbeat"
+        else
+            log_fail "Tailscale: EXIT trap ordering wrong — Tailscale cleanup should precede stop_heartbeat (ts_line=$ts_line, hb_line=$hb_line)"
+        fi
+    fi
+
+    # Test 4: NeedsLogin state triggers a die with re-auth instructions
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if grep -q 'NeedsLogin' <<< "$content" && grep -q 'tailscale up --auth-key' <<< "$content"; then
+        log_pass "Tailscale: NeedsLogin detection and re-auth instructions present"
+    else
+        log_fail "Tailscale: NeedsLogin handling or re-auth instructions missing"
+    fi
+
+    # Test 5: Post-harvest cleanup block clears exit node (not just the EXIT trap)
+    TESTS_RUN=$((TESTS_RUN + 1))
+    # Count occurrences of exit-node clear — trap + post-harvest = at least 2
+    local clear_count
+    clear_count=$(grep -c 'tailscale set --exit-node=' <<< "$content" || echo 0)
+    if [[ "$clear_count" -ge 2 ]]; then
+        log_pass "Tailscale: exit node cleared in both EXIT trap and post-harvest block"
+    else
+        log_fail "Tailscale: expected ≥2 exit node clear calls (trap + post-harvest), found $clear_count"
+    fi
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -960,6 +1034,7 @@ main() {
         test_nara_scripts_deleted
         test_community_webs_export
         test_send_email_yes_flag
+        test_tailscale_exit_node
     fi
 
     # Run deterministic alias tests (safe in both quick/full mode).


### PR DESCRIPTION
## Summary

- Adds a `TAILSCALE_EXIT_NODE` mechanism to `ingest.sh` that sets a Tailscale exit node immediately before the harvest step and clears it immediately after (and in the EXIT trap on failure)
- Only harvest traffic is routed through the exit node; mapping, enrichment, JSONL export, and S3 sync all use normal routing
- `njde` is the first hub using this: its OAI endpoint at Rutgers only accepts connections from a specific whitelisted IP (54.165.106.96, the `main-vpc` Tailscale node on the ingest VPC). The EC2's NAT IP (52.2.32.179) is not whitelisted
- Adding future IP-restricted hubs requires only a new `case` entry for `TAILSCALE_EXIT_NODE`

## Before this can be tested/merged

Two pre-requisites must be completed on the infrastructure side:

1. **Approve the Tailscale exit node routes in the admin console.** During the session that produced this PR, `tailscale set --advertise-exit-node` was run on the `main-vpc` node (100.82.233.38, EC2 `i-03013d6ac41edd3f0`), so it now offers an exit node. However, the route (`0.0.0.0/0`) still needs to be approved by a Tailscale admin at [tailscale.com/admin](https://tailscale.com/admin) → Machines → `main-vpc` → Edit route settings. Our OAuth client lacks the `devices:write` permission needed to approve routes via the API.

2. **Verify `tailscale set --exit-node=100.82.233.38` works on the ingest EC2 and that the njde endpoint responds 200.** With the exit node approved, run on the ingest EC2:
   ```bash
   tailscale set --exit-node=100.82.233.38
   curl -s --max-time 15 "http://prod-dpla.libraries.rutgers.edu/combine/oai/subset/dpla?verb=Identify" | head -5
   tailscale set --exit-node=
   ```
   A valid OAI XML `<Identify>` response confirms the whitelisted IP is routing correctly. Then run a full `ingest.sh njde` to validate end-to-end.

## Test plan

- [ ] Approve `main-vpc` exit node routes in Tailscale admin console
- [ ] Confirm `curl` to njde OAI endpoint returns 200 from ingest EC2 via exit node
- [ ] Run `ingest.sh njde` and confirm harvest completes without 403, exit node is cleared after harvest step, and downstream steps (mapping, enrichment, S3) complete normally
- [ ] Confirm `ingest.sh maryland` (or any non-njde hub) is unaffected (no Tailscale calls made)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-level summary

This PR adds per-provider Tailscale exit-node routing to scripts/ingest.sh so harvest traffic for IP-whitelisted OAI endpoints is routed via a designated Tailscale exit node and then restored to normal routing for downstream steps.

What changed
- Adds a provider-specific TAILSCALE_EXIT_NODE mapping in ingest.sh (njde → 100.82.233.38).
- When a provider has a mapping, ingest.sh will:
  - ensure tailscaled is started and connected before the harvest step,
  - fail fast with actionable re-auth instructions if the node key is expired (BackendState == NeedsLogin),
  - run `tailscale set --exit-node=<ip>` immediately before HarvestEntry,
  - clear the exit node (`tailscale set --exit-node=`) and stop `tailscaled` immediately after harvest,
  - perform best-effort cleanup in the EXIT trap (clear exit node and stop `tailscaled` before calling stop_heartbeat) to avoid leaving the ingest host under restricted routing on failure.
- Documentation updates: scripts/SCRIPTS.md and README.md add an IP-restricted hubs section, operational prerequisites, node-key rotation guidance (~180 days), and an example mapping (njde).
- Adds a static inspection test in scripts/tests/test-scripts.sh (test_tailscale_exit_node) which verifies:
  - njde → 100.82.233.38 mapping,
  - presence of require_command tailscale guard,
  - EXIT trap ordering (tailscale cleanup before stop_heartbeat),
  - NeedsLogin detection and re-auth instructions,
  - exit-node clearing occurs both in the trap and post-harvest (≥2 occurrences).

Providers affected
- njde is configured by this PR. Additional IP-restricted hubs must be added by adding entries to the provider case statement in ingest.sh (per-provider mapping).

Manual prerequisites / deploy notes
- No ECS redeployment, pipeline trigger, or service redeploy is required — the change is a shell-script update that takes effect when the updated script runs on the ingest EC2 host.
- Operational prerequisites before testing/merge:
  - Approve the advertised exit-node route (0.0.0.0/0) for the main-vpc device in the Tailscale admin console (cannot be approved via the current OAuth client API).
  - Confirm on the ingest EC2 that `tailscale set --exit-node=100.82.233.38` causes the njde OAI Identify endpoint to return HTTP 200, and that `tailscale set --exit-node=` clears the setting.
  - Ensure Tailscale is installed on the ingest EC2 and the ingest user has passwordless sudo for systemctl (standard on the ingest EC2).

Infrastructure, secrets, migrations, and API impact
- Does not add, remove, or rename environment variables or AWS Secrets Manager keys.
- No database migrations.
- No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task definitions, IAM policies).
- No modifications to public API response shapes or endpoints.

Security implications
- Harvest traffic for IP-restricted endpoints is routed through a trusted exit node with a whitelisted IP; only harvest is routed through that IP — mapping, enrichment, JSONL export, and S3 sync use normal routing after the harvest.
- The EXIT trap and post-harvest cleanup double-clear the exit node to avoid accidentally routing downstream traffic through the exit node.
- Operators must approve exit routes in the Tailscale admin console and ensure appropriate sudo privileges and Tailscale authentication on the EC2 host.
- The script includes explicit detection and operator instructions for expired Tailscale node keys to avoid silent failures.

Testing checklist
- Approve main-vpc exit-node route in the Tailscale admin console.
- Verify curl to the njde OAI Identify endpoint returns HTTP 200 from the ingest EC2 when using the exit node.
- Run `./scripts/ingest.sh njde` and confirm harvest completes without 403, the exit node is cleared after harvest, and downstream steps complete under normal routing.
- Confirm non-njde providers are unaffected (ingest.sh makes no Tailscale calls for them).

Public/exported interfaces
- No exported/public functions or API signatures were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->