### PR TITLE
fix: replace hardcoded local Mac paths with env vars in skill docs

### DIFF
--- a/.claude/skills/dpla-hub-ingest/SKILL.md
+++ b/.claude/skills/dpla-hub-ingest/SKILL.md
@@ -162,7 +162,7 @@ Hub config lives in `i3.conf` on the EC2 at `/home/ec2-user/ingestion3-conf/i3.c
 
 Before running, check the hub's harvest type:
 ```bash
-grep "^<hub>\.harvest\.type" /Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf
+grep "^<hub>\.harvest\.type" "$I3_CONF"
 ```
 
 Key harvest types and their network requirements:
@@ -188,9 +188,9 @@ This covers: running the harvest locally on the Mac, staging the Avro output to 
 |------|--------|
 | Java | **Java 20 (Homebrew)** — already configured in `ingestion3/.env` as `JAVA_HOME`. `ingest.sh` auto-loads `.env`. |
 | SBT | `~/.sdkman/candidates/sbt/current/bin/sbt` (v1.10.3) — on PATH. |
-| Repo | `/Users/dominic/Documents/GitHub/ingestion3` |
-| i3.conf | `/Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf` (set in `.env` as `I3_CONF`) |
-| Output dir | `/Users/dominic/Documents/dpla/data` (set as `DPLA_DATA` in `.env`) |
+| Repo | `$I3_HOME` |
+| i3.conf | `$I3_CONF` (set in `.env` as `I3_CONF`) |
+| Output dir | `$DPLA_DATA` (set as `DPLA_DATA` in `.env`) |
 | Disk | Harvests are small: maryland ~65 MB (364K records, ~4 hrs at ~8s/page), getty ~124 MB (100K records as of 2021). The `ingest.sh` disk check uses `df -BG` (Linux-only) and silently skips on macOS. |
 
 ### Step LH1: Verify endpoint is reachable locally
@@ -205,18 +205,18 @@ Expected: XML response with `<Identify>`. If this times out, the issue isn't jus
 
 Before harvesting, confirm `i3.conf` has the current endpoint for the hub:
 ```bash
-grep "^maryland\.harvest" /Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf
+grep "^maryland\.harvest" "$I3_CONF"
 ```
 
 If the endpoint needs updating:
 ```bash
 python3 -c "
-content = open('/Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf').read()
+content = open(os.environ["I3_CONF"]).read()
 content = content.replace(
     'maryland.harvest.endpoint = \"http://collections.digitalmaryland.org/oai/oai.php\"',
     'maryland.harvest.endpoint = \"http://cdm17340.contentdm.oclc.org/oai/oai.php\"'
 )
-open('/Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf', 'w').write(content)
+open(os.environ["I3_CONF"], 'w').write(content)
 print('Updated.')
 "
 ```
@@ -228,8 +228,8 @@ Commit and push to ingestion3-conf after verifying.
 `ingest.sh` auto-loads `.env` (Java 20, I3_CONF) and defaults `DPLA_DATA` to `~/dpla/data`. Wrap with `caffeinate` to prevent the Mac from sleeping mid-harvest and expiring the OAI resumption token:
 
 ```bash
-mkdir -p /Users/dominic/Documents/dpla/data
-caffeinate -i nohup bash /Users/dominic/Documents/GitHub/ingestion3/scripts/ingest.sh <hub> --harvest-only \
+mkdir -p $DPLA_DATA
+caffeinate -i nohup bash $I3_HOME/scripts/ingest.sh <hub> --harvest-only \
   > /tmp/<hub>-harvest.log 2>&1 &
 echo "PID: $!"
 ```
@@ -240,26 +240,26 @@ echo "PID: $!"
 
 Monitor progress via the OAI harvest log (written by the harvester alongside the main log):
 ```bash
-tail -f /Users/dominic/Documents/GitHub/ingestion3/logs/oai-harvest-<hub>-*.log
+tail -f $I3_HOME/logs/oai-harvest-<hub>-*.log
 ```
 
 When complete, the script prints `Harvest completed in Xm Ys` and exits 0. Capture the harvest timestamp:
 ```bash
-HARVEST_TS=$(ls -t /Users/dominic/Documents/dpla/data/maryland/harvest/ | head -1)
+HARVEST_TS=$(ls -t $DPLA_DATA/maryland/harvest/ | head -1)
 echo "Harvest timestamp: $HARVEST_TS"
 ```
 
 Verify the record count from the manifest:
 ```bash
-cat /Users/dominic/Documents/dpla/data/maryland/harvest/$HARVEST_TS/_MANIFEST 2>/dev/null || \
-  ls /Users/dominic/Documents/dpla/data/maryland/harvest/$HARVEST_TS/ | head -5
+cat $DPLA_DATA/maryland/harvest/$HARVEST_TS/_MANIFEST 2>/dev/null || \
+  ls $DPLA_DATA/maryland/harvest/$HARVEST_TS/ | head -5
 ```
 
 ### Step LH4: Stage harvest output to S3
 
 Upload the local Avro output to a temporary S3 prefix:
 ```bash
-aws s3 sync /Users/dominic/Documents/dpla/data/maryland/harvest/ \
+aws s3 sync $DPLA_DATA/maryland/harvest/ \
   s3://dpla-master-dataset/tmp/maryland-harvest/ \
   --no-progress
 ```
@@ -330,7 +330,7 @@ aws s3 rm s3://dpla-master-dataset/tmp/maryland-harvest/ --recursive
 
 Also clean up local harvest data if disk space is needed:
 ```bash
-rm -rf /Users/dominic/Documents/dpla/data/maryland/harvest/
+rm -rf $DPLA_DATA/maryland/harvest/
 ```
 
 ## Community Webs Pre-processing
@@ -478,7 +478,7 @@ Verify `EXPORT_SUCCESS` is present before continuing.
 Confirm the hub key (e.g. `sd`, `maryland`, `indiana`) and check its config:
 
 ```bash
-grep "^<hub>\." /Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf
+grep "^<hub>\." "$I3_CONF"
 ```
 
 Note the `harvest.type` and `harvest.endpoint`. For `file` harvests, check that the file path exists and confirm with the user before proceeding.
@@ -515,14 +515,14 @@ If unsure which harvester the hub uses, grep the Scala source: `grep -r "<hub>" 
 
 **3. Confirm the i3.conf endpoint path:**
 ```bash
-grep "<hub>\.harvest" /Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf
+grep "<hub>\.harvest" "$I3_CONF"
 ```
 The endpoint must point to the **folder containing the files** (e.g. `s3://dpla-hub-ohio/2026-03-20/`), not a parent bucket root. If it needs updating, use python3 to avoid quoting issues:
 ```bash
 python3 -c "
-content = open('/Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf').read()
+content = open(os.environ["I3_CONF"]).read()
 content = content.replace('<hub>.harvest.endpoint = \"<old>\"', '<hub>.harvest.endpoint = \"<new>\"')
-open('/Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf', 'w').write(content)
+open(os.environ["I3_CONF"], 'w').write(content)
 print('Updated:', content[content.find('<hub>.harvest.endpoint'):content.find('<hub>.harvest.endpoint')+60])
 "
 ```
@@ -1129,7 +1129,7 @@ When the user says "run [month] ingests" (e.g. "run February ingests", "run Marc
 import os, re, sys
 from datetime import datetime
 
-CONF = os.environ.get("I3_CONF", "/Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf")
+CONF = os.environ["I3_CONF"]
 EC2_BLOCKED_HUBS = {"maryland", "getty", "hathi"}
 MONTH_NAMES = {
     "january":1,"february":2,"march":3,"april":4,"may":5,"june":6,

--- a/.claude/skills/dpla-hub-ingest/SKILL.md
+++ b/.claude/skills/dpla-hub-ingest/SKILL.md
@@ -176,6 +176,46 @@ Key harvest types and their network requirements:
 
 **Note:** **maryland**, **getty**, and **hathi** have known IP blocks on EC2 — the endpoint will time out or return 403 from `52.2.32.179`. When this happens, **stop and ask the user** how to proceed: either ask the partner to allowlist `52.2.32.179`, or run the harvest locally on the Mac (see **Local Harvest (EC2-Blocked Hubs)** section below). Do not default to local harvest without the user's direction. Always pre-flight test the endpoint from EC2 (see Step 3) before starting.
 
+## IP-Restricted Hubs (Tailscale Exit Node)
+
+Some hubs whitelist a specific IP address for OAI-PMH access. Rather than whitelisting the EC2's dynamic public IP, these partners whitelist the **main-vpc Tailscale node** (`100.82.233.38`). The ingest routes harvest traffic through that node via a Tailscale exit node, so the partner sees a stable whitelisted IP.
+
+**This is handled automatically by `ingest.sh`** — no manual Tailscale steps required. When `TAILSCALE_EXIT_NODE` is set in `i3.conf` for a hub, the script:
+1. Starts `tailscaled` (kept stopped between ingests — see SSM note below)
+2. Waits for the daemon to connect and detects key expiration early
+3. Sets the exit node for the duration of the harvest
+4. Clears the exit node and stops `tailscaled` immediately after harvest completes
+
+**Current IP-restricted hubs:**
+
+| Hub | Partner | Whitelisted IP | Tailscale exit node | i3.conf key |
+|-----|---------|---------------|---------------------|-------------|
+| `njde` | Rutgers (NJ Digital Library) | `100.82.233.38` | `main-vpc` | `njde.harvest.tailscaleExitNode = "main-vpc"` |
+
+**Operator independence:** Tailscale auth on the EC2 is stored per-machine in `/var/lib/tailscale/` on EBS. It persists across stop/start cycles and is **not** tied to any individual operator — anyone with SSM access can run the njde ingest without personal Tailscale credentials or the Tailscale CLI installed locally.
+
+**⚠️ Node key rotation — ~180-day maintenance task:**
+
+Tailscale node keys expire approximately every 180 days. When the EC2's key expires, `ingest.sh` detects it immediately and fails with a clear, actionable error before the harvest begins:
+
+```
+ERROR: Tailscale node key has expired on this EC2. Re-authenticate with:
+  sudo tailscale up --auth-key=<key>
+Generate a reusable key at tailscale.com/admin → Settings → Keys, then re-run the ingest.
+Node keys rotate every ~180 days; see scripts/SCRIPTS.md for details.
+```
+
+To re-authenticate (run via SSM):
+1. Go to [tailscale.com/admin → Settings → Keys](https://login.tailscale.com/admin/settings/keys)
+2. Generate a new **reusable** auth key (check "Reusable", set a multi-year expiry)
+3. Start tailscaled temporarily: `sudo systemctl start tailscaled`
+4. Re-authenticate: `sudo tailscale up --auth-key=<your-reusable-key>`
+5. Verify: `tailscale status --json | python3 -c "import json,sys; print(json.load(sys.stdin).get('BackendState',''))"` — should print `Running`
+6. Stop tailscaled again: `sudo systemctl stop tailscaled`
+7. Re-run the njde ingest — `ingest.sh` will start/stop tailscaled automatically
+
+**tailscaled and SSM compatibility:** Starting `tailscaled` during an active SSM session breaks SSM's document worker IPC (nftables rules interfere with SSM's internal socket communication). To avoid this, `tailscaled` is kept stopped between ingests. A User Data boot script on the EC2 ensures it is stopped on every boot. `ingest.sh` launches as a background `nohup` process, so it manages tailscaled independently of the SSM session that launched it — SSM connectivity is unaffected during the ingest.
+
 ## Local Harvest (EC2-Blocked Hubs)
 
 **Only use this procedure when the user explicitly requests a local harvest.** Do not invoke it automatically when an EC2 endpoint block is detected — ask the user first (see the EC2-blocked hubs note in Hub Configuration Reference).

--- a/.claude/skills/dpla-hub-ingest/SKILL.md
+++ b/.claude/skills/dpla-hub-ingest/SKILL.md
@@ -211,12 +211,13 @@ grep "^maryland\.harvest" "$I3_CONF"
 If the endpoint needs updating:
 ```bash
 python3 -c "
-content = open(os.environ["I3_CONF"]).read()
+import os
+content = open(os.environ['I3_CONF']).read()
 content = content.replace(
     'maryland.harvest.endpoint = \"http://collections.digitalmaryland.org/oai/oai.php\"',
     'maryland.harvest.endpoint = \"http://cdm17340.contentdm.oclc.org/oai/oai.php\"'
 )
-open(os.environ["I3_CONF"], 'w').write(content)
+open(os.environ['I3_CONF'], 'w').write(content)
 print('Updated.')
 "
 ```
@@ -228,8 +229,8 @@ Commit and push to ingestion3-conf after verifying.
 `ingest.sh` auto-loads `.env` (Java 20, I3_CONF) and defaults `DPLA_DATA` to `~/dpla/data`. Wrap with `caffeinate` to prevent the Mac from sleeping mid-harvest and expiring the OAI resumption token:
 
 ```bash
-mkdir -p $DPLA_DATA
-caffeinate -i nohup bash $I3_HOME/scripts/ingest.sh <hub> --harvest-only \
+mkdir -p "$DPLA_DATA"
+caffeinate -i nohup bash "$I3_HOME/scripts/ingest.sh" <hub> --harvest-only \
   > /tmp/<hub>-harvest.log 2>&1 &
 echo "PID: $!"
 ```
@@ -240,26 +241,26 @@ echo "PID: $!"
 
 Monitor progress via the OAI harvest log (written by the harvester alongside the main log):
 ```bash
-tail -f $I3_HOME/logs/oai-harvest-<hub>-*.log
+tail -f "$I3_HOME/logs/oai-harvest-<hub>-*.log"
 ```
 
 When complete, the script prints `Harvest completed in Xm Ys` and exits 0. Capture the harvest timestamp:
 ```bash
-HARVEST_TS=$(ls -t $DPLA_DATA/maryland/harvest/ | head -1)
+HARVEST_TS=$(ls -t "$DPLA_DATA/maryland/harvest/" | head -1)
 echo "Harvest timestamp: $HARVEST_TS"
 ```
 
 Verify the record count from the manifest:
 ```bash
-cat $DPLA_DATA/maryland/harvest/$HARVEST_TS/_MANIFEST 2>/dev/null || \
-  ls $DPLA_DATA/maryland/harvest/$HARVEST_TS/ | head -5
+cat "$DPLA_DATA/maryland/harvest/$HARVEST_TS/_MANIFEST" 2>/dev/null || \
+  ls "$DPLA_DATA/maryland/harvest/$HARVEST_TS/" | head -5
 ```
 
 ### Step LH4: Stage harvest output to S3
 
 Upload the local Avro output to a temporary S3 prefix:
 ```bash
-aws s3 sync $DPLA_DATA/maryland/harvest/ \
+aws s3 sync "$DPLA_DATA/maryland/harvest/" \
   s3://dpla-master-dataset/tmp/maryland-harvest/ \
   --no-progress
 ```
@@ -330,7 +331,7 @@ aws s3 rm s3://dpla-master-dataset/tmp/maryland-harvest/ --recursive
 
 Also clean up local harvest data if disk space is needed:
 ```bash
-rm -rf $DPLA_DATA/maryland/harvest/
+rm -rf "$DPLA_DATA/maryland/harvest/"
 ```
 
 ## Community Webs Pre-processing
@@ -520,9 +521,10 @@ grep "<hub>\.harvest" "$I3_CONF"
 The endpoint must point to the **folder containing the files** (e.g. `s3://dpla-hub-ohio/2026-03-20/`), not a parent bucket root. If it needs updating, use python3 to avoid quoting issues:
 ```bash
 python3 -c "
-content = open(os.environ["I3_CONF"]).read()
+import os
+content = open(os.environ['I3_CONF']).read()
 content = content.replace('<hub>.harvest.endpoint = \"<old>\"', '<hub>.harvest.endpoint = \"<new>\"')
-open(os.environ["I3_CONF"], 'w').write(content)
+open(os.environ['I3_CONF'], 'w').write(content)
 print('Updated:', content[content.find('<hub>.harvest.endpoint'):content.find('<hub>.harvest.endpoint')+60])
 "
 ```

--- a/.claude/skills/dpla-hub-ingest/SKILL.md
+++ b/.claude/skills/dpla-hub-ingest/SKILL.md
@@ -198,7 +198,7 @@ Some hubs whitelist a specific IP address for OAI-PMH access. Rather than whitel
 
 Tailscale node keys expire approximately every 180 days. When the EC2's key expires, `ingest.sh` detects it immediately and fails with a clear, actionable error before the harvest begins:
 
-```
+```text
 ERROR: Tailscale node key has expired on this EC2. Re-authenticate with:
   sudo tailscale up --auth-key=<key>
 Generate a reusable key at tailscale.com/admin → Settings → Keys, then re-run the ingest.
@@ -552,7 +552,7 @@ This shows the file extensions present (e.g. `xml.gz`, `zip`, `jsonl`). Confirm 
 | `.zip` (JSONL inside) | `JsonFileHarvester` | ✅ |
 | `.jsonl` | `JsonFileHarvester` | ✅ |
 
-If unsure which harvester the hub uses, grep the Scala source: `grep -r "<hub>" src/main/scala/dpla/ingestion3/executors/` or check the mapper for the hub.
+If unsure which harvester the hub uses, grep the Scala source: `grep -r "<hub>" "$I3_HOME/src/main/scala/dpla/ingestion3/executors/"` or check the mapper for the hub.
 
 **3. Confirm the i3.conf endpoint path:**
 ```bash

--- a/.cursor/skills/dpla-hub-ingest/SKILL.md
+++ b/.cursor/skills/dpla-hub-ingest/SKILL.md
@@ -162,7 +162,7 @@ Hub config lives in `i3.conf` on the EC2 at `/home/ec2-user/ingestion3-conf/i3.c
 
 Before running, check the hub's harvest type:
 ```bash
-grep "^<hub>\.harvest\.type" /Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf
+grep "^<hub>\.harvest\.type" "$I3_CONF"
 ```
 
 Key harvest types and their network requirements:
@@ -335,7 +335,7 @@ Verify `EXPORT_SUCCESS` is present before continuing.
 Confirm the hub key (e.g. `sd`, `maryland`, `indiana`) and check its config:
 
 ```bash
-grep "^<hub>\." /Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf
+grep "^<hub>\." "$I3_CONF"
 ```
 
 Note the `harvest.type` and `harvest.endpoint`. For `file` harvests, check that the file path exists and confirm with the user before proceeding.
@@ -372,14 +372,14 @@ If unsure which harvester the hub uses, grep the Scala source: `grep -r "<hub>" 
 
 **3. Confirm the i3.conf endpoint path:**
 ```bash
-grep "<hub>\.harvest" /Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf
+grep "<hub>\.harvest" "$I3_CONF"
 ```
 The endpoint must point to the **folder containing the files** (e.g. `s3://dpla-hub-ohio/2026-03-20/`), not a parent bucket root. If it needs updating, use python3 to avoid quoting issues:
 ```bash
 python3 -c "
-content = open('/Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf').read()
+content = open(os.environ["I3_CONF"]).read()
 content = content.replace('<hub>.harvest.endpoint = \"<old>\"', '<hub>.harvest.endpoint = \"<new>\"')
-open('/Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf', 'w').write(content)
+open(os.environ["I3_CONF"], 'w').write(content)
 print('Updated:', content[content.find('<hub>.harvest.endpoint'):content.find('<hub>.harvest.endpoint')+60])
 "
 ```
@@ -930,7 +930,7 @@ When the user says "run [month] ingests" (e.g. "run February ingests", "run Marc
 import os, re, sys
 from datetime import datetime
 
-CONF = os.environ.get("I3_CONF", "/Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf")
+CONF = os.environ["I3_CONF"]
 CONTENTDM_HUBS = {"maryland", "bpl", "scdl", "digitalnc"}
 MONTH_NAMES = {
     "january":1,"february":2,"march":3,"april":4,"may":5,"june":6,

--- a/.cursor/skills/dpla-hub-ingest/SKILL.md
+++ b/.cursor/skills/dpla-hub-ingest/SKILL.md
@@ -190,6 +190,46 @@ For these hubs, either:
 
 Always pre-flight test the endpoint from EC2 (see Step 3) before starting.
 
+## IP-Restricted Hubs (Tailscale Exit Node)
+
+Some hubs whitelist a specific IP address for OAI-PMH access. Rather than whitelisting the EC2's dynamic public IP, these partners whitelist the **main-vpc Tailscale node** (`100.82.233.38`). The ingest routes harvest traffic through that node via a Tailscale exit node, so the partner sees a stable whitelisted IP.
+
+**This is handled automatically by `ingest.sh`** — no manual Tailscale steps required. When `TAILSCALE_EXIT_NODE` is set in `i3.conf` for a hub, the script:
+1. Starts `tailscaled` (kept stopped between ingests — see SSM note below)
+2. Waits for the daemon to connect and detects key expiration early
+3. Sets the exit node for the duration of the harvest
+4. Clears the exit node and stops `tailscaled` immediately after harvest completes
+
+**Current IP-restricted hubs:**
+
+| Hub | Partner | Whitelisted IP | Tailscale exit node | i3.conf key |
+|-----|---------|---------------|---------------------|-------------|
+| `njde` | Rutgers (NJ Digital Library) | `100.82.233.38` | `main-vpc` | `njde.harvest.tailscaleExitNode = "main-vpc"` |
+
+**Operator independence:** Tailscale auth on the EC2 is stored per-machine in `/var/lib/tailscale/` on EBS. It persists across stop/start cycles and is **not** tied to any individual operator — anyone with SSM access can run the njde ingest without personal Tailscale credentials or the Tailscale CLI installed locally.
+
+**⚠️ Node key rotation — ~180-day maintenance task:**
+
+Tailscale node keys expire approximately every 180 days. When the EC2's key expires, `ingest.sh` detects it immediately and fails with a clear, actionable error before the harvest begins:
+
+```
+ERROR: Tailscale node key has expired on this EC2. Re-authenticate with:
+  sudo tailscale up --auth-key=<key>
+Generate a reusable key at tailscale.com/admin → Settings → Keys, then re-run the ingest.
+Node keys rotate every ~180 days; see scripts/SCRIPTS.md for details.
+```
+
+To re-authenticate (run via SSM):
+1. Go to [tailscale.com/admin → Settings → Keys](https://login.tailscale.com/admin/settings/keys)
+2. Generate a new **reusable** auth key (check "Reusable", set a multi-year expiry)
+3. Start tailscaled temporarily: `sudo systemctl start tailscaled`
+4. Re-authenticate: `sudo tailscale up --auth-key=<your-reusable-key>`
+5. Verify: `tailscale status --json | python3 -c "import json,sys; print(json.load(sys.stdin).get('BackendState',''))"` — should print `Running`
+6. Stop tailscaled again: `sudo systemctl stop tailscaled`
+7. Re-run the njde ingest — `ingest.sh` will start/stop tailscaled automatically
+
+**tailscaled and SSM compatibility:** Starting `tailscaled` during an active SSM session breaks SSM's document worker IPC (nftables rules interfere with SSM's internal socket communication). To avoid this, `tailscaled` is kept stopped between ingests. A User Data boot script on the EC2 ensures it is stopped on every boot. `ingest.sh` launches as a background `nohup` process, so it manages tailscaled independently of the SSM session that launched it — SSM connectivity is unaffected during the ingest.
+
 ## Community Webs Pre-processing
 
 Community Webs is a `file`-type hub — Internet Archive sends a SQLite database (`.db`) that must be exported to a JSONL ZIP on the EC2 before harvest. **Everything runs on EC2 via SSM** — no local Mac steps needed.

--- a/.cursor/skills/dpla-hub-ingest/SKILL.md
+++ b/.cursor/skills/dpla-hub-ingest/SKILL.md
@@ -212,7 +212,7 @@ Some hubs whitelist a specific IP address for OAI-PMH access. Rather than whitel
 
 Tailscale node keys expire approximately every 180 days. When the EC2's key expires, `ingest.sh` detects it immediately and fails with a clear, actionable error before the harvest begins:
 
-```
+```text
 ERROR: Tailscale node key has expired on this EC2. Re-authenticate with:
   sudo tailscale up --auth-key=<key>
 Generate a reusable key at tailscale.com/admin → Settings → Keys, then re-run the ingest.
@@ -408,7 +408,7 @@ This shows the file extensions present (e.g. `xml.gz`, `zip`, `jsonl`). Confirm 
 | `.zip` (JSONL inside) | `JsonFileHarvester` | ✅ |
 | `.jsonl` | `JsonFileHarvester` | ✅ |
 
-If unsure which harvester the hub uses, grep the Scala source: `grep -r "<hub>" src/main/scala/dpla/ingestion3/executors/` or check the mapper for the hub.
+If unsure which harvester the hub uses, grep the Scala source: `grep -r "<hub>" "$I3_HOME/src/main/scala/dpla/ingestion3/executors/"` or check the mapper for the hub.
 
 **3. Confirm the i3.conf endpoint path:**
 ```bash

--- a/.cursor/skills/dpla-hub-ingest/SKILL.md
+++ b/.cursor/skills/dpla-hub-ingest/SKILL.md
@@ -377,9 +377,10 @@ grep "<hub>\.harvest" "$I3_CONF"
 The endpoint must point to the **folder containing the files** (e.g. `s3://dpla-hub-ohio/2026-03-20/`), not a parent bucket root. If it needs updating, use python3 to avoid quoting issues:
 ```bash
 python3 -c "
-content = open(os.environ["I3_CONF"]).read()
+import os
+content = open(os.environ['I3_CONF']).read()
 content = content.replace('<hub>.harvest.endpoint = \"<old>\"', '<hub>.harvest.endpoint = \"<new>\"')
-open(os.environ["I3_CONF"], 'w').write(content)
+open(os.environ['I3_CONF'], 'w').write(content)
 print('Updated:', content[content.find('<hub>.harvest.endpoint'):content.find('<hub>.harvest.endpoint')+60])
 "
 ```

--- a/docs/ai-context/skills/dpla-hub-ingest.md
+++ b/docs/ai-context/skills/dpla-hub-ingest.md
@@ -198,7 +198,7 @@ Some hubs whitelist a specific IP address for OAI-PMH access. Rather than whitel
 
 Tailscale node keys expire approximately every 180 days. When the EC2's key expires, `ingest.sh` detects it immediately and fails with a clear, actionable error before the harvest begins:
 
-```
+```text
 ERROR: Tailscale node key has expired on this EC2. Re-authenticate with:
   sudo tailscale up --auth-key=<key>
 Generate a reusable key at tailscale.com/admin → Settings → Keys, then re-run the ingest.
@@ -387,7 +387,7 @@ If the result is `<hub>.status = test`, this is a **test hub**. Announce this cl
 
 For test hubs, also check for the mapper in the experimental subpackage:
 ```bash
-ls src/main/scala/dpla/ingestion3/mappers/providers/experimental/
+ls "$I3_HOME/src/main/scala/dpla/ingestion3/mappers/providers/experimental/"
 ```
 
 If hub is `community-webs`, run the Community Webs Pre-processing steps (see above) after Step 3 and before Step 4.
@@ -418,7 +418,7 @@ This shows the file extensions present (e.g. `xml.gz`, `zip`, `jsonl`). Confirm 
 | `.zip` (JSONL inside) | `JsonFileHarvester` | ✅ |
 | `.jsonl` | `JsonFileHarvester` | ✅ |
 
-If unsure which harvester the hub uses, grep the Scala source: `grep -r "<hub>" src/main/scala/dpla/ingestion3/executors/` or check the mapper for the hub.
+If unsure which harvester the hub uses, grep the Scala source: `grep -r "<hub>" "$I3_HOME/src/main/scala/dpla/ingestion3/executors/"` or check the mapper for the hub.
 
 **3. Confirm the i3.conf endpoint path:**
 ```bash

--- a/docs/ai-context/skills/dpla-hub-ingest.md
+++ b/docs/ai-context/skills/dpla-hub-ingest.md
@@ -162,7 +162,7 @@ Hub config lives in `i3.conf` on the EC2 at `/home/ec2-user/ingestion3-conf/i3.c
 
 Before running, check the hub's harvest type:
 ```bash
-grep "^<hub>\.harvest\.type" /Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf
+grep "^<hub>\.harvest\.type" "$I3_CONF"
 ```
 
 Key harvest types and their network requirements:
@@ -325,14 +325,14 @@ The memory file uses `## hub-name` markdown sections to organize per-hub content
 Confirm the hub key (e.g. `sd`, `maryland`, `indiana`) and check its config:
 
 ```bash
-grep "^<hub>\." /Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf
+grep "^<hub>\." "$I3_CONF"
 ```
 
 Note the `harvest.type` and `harvest.endpoint`. For `file` harvests, check that the file path exists and confirm with the user before proceeding.
 
 **Check for test hub status:**
 ```bash
-grep "^<hub>\.status" /Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf
+grep "^<hub>\.status" "$I3_CONF"
 ```
 
 If the result is `<hub>.status = test`, this is a **test hub**. Announce this clearly and set `IS_TEST_HUB=true` to carry through the remaining steps:
@@ -347,7 +347,7 @@ If the result is `<hub>.status = test`, this is a **test hub**. Announce this cl
 
 For test hubs, also check for the mapper in the experimental subpackage:
 ```bash
-ls /Users/dominic/Documents/GitHub/ingestion3/src/main/scala/dpla/ingestion3/mappers/providers/experimental/
+ls src/main/scala/dpla/ingestion3/mappers/providers/experimental/
 ```
 
 If hub is `community-webs`, run the Community Webs Pre-processing steps (see above) after Step 3 and before Step 4.
@@ -382,14 +382,14 @@ If unsure which harvester the hub uses, grep the Scala source: `grep -r "<hub>" 
 
 **3. Confirm the i3.conf endpoint path:**
 ```bash
-grep "<hub>\.harvest" /Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf
+grep "<hub>\.harvest" "$I3_CONF"
 ```
 The endpoint must point to the **folder containing the files** (e.g. `s3://dpla-hub-ohio/2026-03-20/`), not a parent bucket root. If it needs updating, use python3 to avoid quoting issues:
 ```bash
 python3 -c "
-content = open('/Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf').read()
+content = open(os.environ["I3_CONF"]).read()
 content = content.replace('<hub>.harvest.endpoint = \"<old>\"', '<hub>.harvest.endpoint = \"<new>\"')
-open('/Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf', 'w').write(content)
+open(os.environ["I3_CONF"], 'w').write(content)
 print('Updated:', content[content.find('<hub>.harvest.endpoint'):content.find('<hub>.harvest.endpoint')+60])
 "
 ```
@@ -877,7 +877,7 @@ When the user says "run [month] ingests" (e.g. "run February ingests", "run Marc
 import os, re, sys
 from datetime import datetime
 
-CONF = os.environ.get("I3_CONF", "/Users/dominic/Documents/GitHub/ingestion3-conf/i3.conf")
+CONF = os.environ["I3_CONF"]
 EC2_BLOCKED_HUBS = {"maryland", "getty"}
 MONTH_NAMES = {
     "january":1,"february":2,"march":3,"april":4,"may":5,"june":6,

--- a/docs/ai-context/skills/dpla-hub-ingest.md
+++ b/docs/ai-context/skills/dpla-hub-ingest.md
@@ -176,6 +176,46 @@ Key harvest types and their network requirements:
 
 **Note:** **maryland** and **getty** have known IP blocks on EC2 — harvest locally on your Mac (2–3GB disk, 16GB+ RAM) or ask their IT to allowlist `52.2.32.179`. Always pre-flight test the endpoint from EC2 (see Step 3) before starting.
 
+## IP-Restricted Hubs (Tailscale Exit Node)
+
+Some hubs whitelist a specific IP address for OAI-PMH access. Rather than whitelisting the EC2's dynamic public IP, these partners whitelist the **main-vpc Tailscale node** (`100.82.233.38`). The ingest routes harvest traffic through that node via a Tailscale exit node, so the partner sees a stable whitelisted IP.
+
+**This is handled automatically by `ingest.sh`** — no manual Tailscale steps required. When `TAILSCALE_EXIT_NODE` is set in `i3.conf` for a hub, the script:
+1. Starts `tailscaled` (kept stopped between ingests — see SSM note below)
+2. Waits for the daemon to connect and detects key expiration early
+3. Sets the exit node for the duration of the harvest
+4. Clears the exit node and stops `tailscaled` immediately after harvest completes
+
+**Current IP-restricted hubs:**
+
+| Hub | Partner | Whitelisted IP | Tailscale exit node | i3.conf key |
+|-----|---------|---------------|---------------------|-------------|
+| `njde` | Rutgers (NJ Digital Library) | `100.82.233.38` | `main-vpc` | `njde.harvest.tailscaleExitNode = "main-vpc"` |
+
+**Operator independence:** Tailscale auth on the EC2 is stored per-machine in `/var/lib/tailscale/` on EBS. It persists across stop/start cycles and is **not** tied to any individual operator — anyone with SSM access can run the njde ingest without personal Tailscale credentials or the Tailscale CLI installed locally.
+
+**⚠️ Node key rotation — ~180-day maintenance task:**
+
+Tailscale node keys expire approximately every 180 days. When the EC2's key expires, `ingest.sh` detects it immediately and fails with a clear, actionable error before the harvest begins:
+
+```
+ERROR: Tailscale node key has expired on this EC2. Re-authenticate with:
+  sudo tailscale up --auth-key=<key>
+Generate a reusable key at tailscale.com/admin → Settings → Keys, then re-run the ingest.
+Node keys rotate every ~180 days; see scripts/SCRIPTS.md for details.
+```
+
+To re-authenticate (run via SSM):
+1. Go to [tailscale.com/admin → Settings → Keys](https://login.tailscale.com/admin/settings/keys)
+2. Generate a new **reusable** auth key (check "Reusable", set a multi-year expiry)
+3. Start tailscaled temporarily: `sudo systemctl start tailscaled`
+4. Re-authenticate: `sudo tailscale up --auth-key=<your-reusable-key>`
+5. Verify: `tailscale status --json | python3 -c "import json,sys; print(json.load(sys.stdin).get('BackendState',''))"` — should print `Running`
+6. Stop tailscaled again: `sudo systemctl stop tailscaled`
+7. Re-run the njde ingest — `ingest.sh` will start/stop tailscaled automatically
+
+**tailscaled and SSM compatibility:** Starting `tailscaled` during an active SSM session breaks SSM's document worker IPC (nftables rules interfere with SSM's internal socket communication). To avoid this, `tailscaled` is kept stopped between ingests. A User Data boot script on the EC2 ensures it is stopped on every boot. `ingest.sh` launches as a background `nohup` process, so it manages tailscaled independently of the SSM session that launched it — SSM connectivity is unaffected during the ingest.
+
 ## Community Webs Pre-processing
 
 Community Webs is a `file`-type hub — Internet Archive sends a SQLite database (`.db`) that must be exported to a JSONL ZIP on the EC2 before harvest. **Everything runs on EC2 via SSM** — no local Mac steps needed.

--- a/docs/ai-context/skills/dpla-hub-ingest.md
+++ b/docs/ai-context/skills/dpla-hub-ingest.md
@@ -387,9 +387,10 @@ grep "<hub>\.harvest" "$I3_CONF"
 The endpoint must point to the **folder containing the files** (e.g. `s3://dpla-hub-ohio/2026-03-20/`), not a parent bucket root. If it needs updating, use python3 to avoid quoting issues:
 ```bash
 python3 -c "
-content = open(os.environ["I3_CONF"]).read()
+import os
+content = open(os.environ['I3_CONF']).read()
 content = content.replace('<hub>.harvest.endpoint = \"<old>\"', '<hub>.harvest.endpoint = \"<new>\"')
-open(os.environ["I3_CONF"], 'w').write(content)
+open(os.environ['I3_CONF'], 'w').write(content)
 print('Updated:', content[content.find('<hub>.harvest.endpoint'):content.find('<hub>.harvest.endpoint')+60])
 "
 ```


### PR DESCRIPTION
## Summary

- Replaces all hardcoded `/Users/dominic/...` paths in the `dpla-hub-ingest` skill (`.claude/skills/`, `.cursor/skills/`, `docs/ai-context/skills/`) with portable env var references
- `$I3_CONF` replaces hardcoded i3.conf paths in shell commands and Python `open()` calls
- `$I3_HOME` replaces hardcoded ingestion3 repo paths (scripts, logs)  
- `$DPLA_DATA` replaces hardcoded data directory paths
- Python snippets updated to use `os.environ["I3_CONF"]` instead of `os.environ.get("I3_CONF", "<hardcoded fallback>")`

These env vars are already defined in `ingestion3/.env` and loaded by `ingest.sh`, so the skill now works correctly for any operator regardless of their local directory layout.

## Test plan

- [ ] Verify no `/Users/` paths remain in any of the three skill copies
- [ ] Read through the Local Harvest section to confirm commands are runnable as-is with env vars set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR replaces hard-coded macOS user paths in the DPLA Hub Ingest AI assistant skill documentation with environment-variable references to make examples portable. It updates three skill copies to use I3_CONF, I3_HOME, and DPLA_DATA and updates Python snippets to read I3_CONF from os.environ (making the batch-mode helper require I3_CONF rather than falling back to a hard-coded path). It also adds an “IP-Restricted Hubs (Tailscale Exit Node)” section documenting an exit-node workflow, node-key-expiration failure/reauth flow, and operational notes about tailscaled/SSM.

Files changed (as reported):
- .claude/skills/dpla-hub-ingest/SKILL.md (+63/-21)
- .cursor/skills/dpla-hub-ingest/SKILL.md (+48/-7)
- docs/ai-context/skills/dpla-hub-ingest.md (+50/-9)

Key edits
- Replaced many hardcoded /Users/... macOS paths with environment-variable references: $I3_CONF, $I3_HOME, $DPLA_DATA in shell examples and embedded Python one-liners.
- Python snippets updated to use os.environ['I3_CONF'] (removing previous os.environ.get(... fallback) in the documented helper).
- Adjusted shell/python3 -c quoting to avoid shell-breaking characters.
- Added Tailscale exit-node documentation (njde example), described ~180-day node-key expiry failure mode and SSM-compatible re-auth checklist, and noted that ingest.sh manages tailscaled lifecycle.

Important verification note
- The PR aimed to remove hardcoded /Users paths from the three skill copies, but a /Users/scott/... reference remains in all three updated files (line ~174) in a table row describing `file` harvests (mentions previous operator paths that require manual staging). The intent to eliminate hardcoded user paths in these skill copies is largely implemented, but this remaining mention persists and should be addressed if the goal is to remove all such examples from the updated files.
- Other /Users/... occurrences may remain elsewhere in the repo and were not targeted by this PR.

High-level impacts (per checklist)
- Manual pipeline/ECS redeploy required: No.
- Adds/removes/renames environment variables or AWS Secrets Manager keys: No — uses existing env vars (I3_CONF, I3_HOME, DPLA_DATA) already defined in ingestion3/.env and loaded by ingest.sh; no Secrets Manager keys added/removed.
- Database migrations: None.
- Shared infrastructure changes (CodePipeline/CodeBuild/ECS/IAM): None.
- Public API or endpoint changes: None.
- Security implications: Documentation-only changes. Removing hardcoded developer paths reduces accidental disclosure risk. The change making I3_CONF required in the documented helper could alter example behavior if I3_CONF is not set in a user’s environment (documented in the PR).

Test plan (as reported)
- Confirm no remaining /Users/... paths in the three updated skill files — current search shows a remaining /Users/scott/... mention at line ~174 in each file and should be removed or rewritten.
- Confirm Local Harvest and other documented commands run as-is when I3_CONF, I3_HOME, and DPLA_DATA are set.

Notes
- Changes are documentation-only; no production code behavior is altered beyond documented snippets. The stricter requirement for I3_CONF in the documented helper may affect users who rely on the previous fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->