### PR TITLE
Fix SiFileHarvester: streaming XML parser + --mapping-only flag

### DIFF
--- a/scripts/ingest-watchdog.sh
+++ b/scripts/ingest-watchdog.sh
@@ -4,7 +4,7 @@
 # Run every 5 minutes via crontab (as ec2-user). Detects ingests that were
 # killed without a clean exit (e.g. SIGKILL of the whole process group, which
 # bypasses bash EXIT traps) by checking for in-progress status files with no
-# corresponding running ingest.sh process.
+# corresponding running ingest process.
 #
 # On detecting a dead ingest:
 #   - Sends a Slack alert to #tech-alerts via SLACK_BOT_TOKEN
@@ -27,6 +27,14 @@ ACTIVE_STATUSES=(harvesting remapping enriching jsonl syncing)
 # for the brief gap between one JVM step completing and the next starting.
 MIN_AGE_SECS=300  # 5 minutes
 
+# Hubs that should get periodic "still running" progress updates while in an
+# active stage. These tend to be multi-hour jobs (smithsonian harvest is 3-4h)
+# where the operator benefits from a heartbeat rather than radio silence.
+HEARTBEAT_HUBS=(smithsonian)
+
+# How often to send a heartbeat for HEARTBEAT_HUBS while the ingest is alive.
+HEARTBEAT_INTERVAL_SECS=$((60 * 60))  # 1 hour
+
 [[ -d "$STATUS_DIR" ]] || exit 0
 
 # Load credentials (provides SLACK_BOT_TOKEN, SLACK_CHANNEL)
@@ -47,6 +55,40 @@ print(json.dumps({'channel': sys.argv[1], 'text': sys.argv[2]}))" \
         -H "Authorization: Bearer $token" \
         -H "Content-Type: application/json" \
         -d "$payload" > /dev/null || true
+}
+
+is_heartbeat_hub() {
+    local hub="$1"
+    for h in "${HEARTBEAT_HUBS[@]}"; do
+        [[ "$hub" == "$h" ]] && return 0
+    done
+    return 1
+}
+
+# Pull the most recent "Harvested X% (N / total) of records from FILE" line
+# from any of the candidate log files for this hub. Returns empty if no
+# progress line is found yet (e.g., harvest just started).
+latest_progress_line() {
+    local hub="$1"
+    local candidates=(
+        "$I3_HOME/data/${hub}-ingest.log"
+        "$I3_HOME/data/${hub}-harvest.log"
+        "$I3_HOME/data/si-harvest.log"          # smithsonian's bare-harvest log
+        "$I3_HOME/data/si-pipeline.log"
+    )
+    for log in "${candidates[@]}"; do
+        if [[ -f "$log" ]]; then
+            # Most recent "Harvested" line, stripped of timestamp+log noise.
+            local line
+            line=$(grep -E "Harvested [0-9]" "$log" 2>/dev/null \
+                   | tail -1 \
+                   | sed -E 's/^[0-9]{2}:[0-9]{2}:[0-9]{2} *INFO *\[[^]]*\] *//')
+            if [[ -n "$line" ]]; then
+                echo "$line"
+                return 0
+            fi
+        fi
+    done
 }
 
 for status_file in "$STATUS_DIR"/*.status; do
@@ -71,8 +113,34 @@ print(d.get('hub', ''), d.get('status', ''))" "$status_file" 2>/dev/null) || con
     age=$(( $(date +%s) - file_mtime ))
     (( age >= MIN_AGE_SECS )) || continue
 
-    # Skip if the ingest process is still running for this hub
-    if pgrep -f "ingest.sh $hub" > /dev/null 2>&1; then
+    # Skip if any process for this hub is still running. Different hubs use
+    # different launcher conventions:
+    #   - ingest.sh <hub>             — standard launcher
+    #   - <hub>-ingest.sh             — hub-specific scripts (community-webs)
+    #   - harvest.sh <hub>            — bare harvest invocations (smithsonian)
+    #   - java ... --name=<hub>       — the actual JVM, most reliable signal
+    proc_pattern="ingest\.sh $hub|${hub}-ingest\.sh|harvest\.sh $hub|java.*--name=$hub"
+    if pgrep -f "$proc_pattern" > /dev/null 2>&1; then
+        # Process is alive. For heartbeat-eligible hubs (long-running like
+        # smithsonian), send a periodic Slack progress update so the operator
+        # knows things are still moving instead of waiting hours in silence.
+        if is_heartbeat_hub "$hub"; then
+            heartbeat_sentinel="$STATUS_DIR/$hub.heartbeat"
+            last_heartbeat=0
+            [[ -f "$heartbeat_sentinel" ]] && \
+                last_heartbeat=$(stat -c '%Y' "$heartbeat_sentinel" 2>/dev/null || echo 0)
+            now=$(date +%s)
+            if (( now - last_heartbeat >= HEARTBEAT_INTERVAL_SECS )); then
+                progress=$(latest_progress_line "$hub" || true)
+                age_min=$(( age / 60 ))
+                msg=":hourglass: *$hub still running* — stage \`$status\`, last status update ${age_min}m ago"
+                if [[ -n "$progress" ]]; then
+                    msg+="\nLatest progress: $progress"
+                fi
+                slack_alert "$msg"
+                touch "$heartbeat_sentinel"
+            fi
+        fi
         continue
     fi
 
@@ -87,7 +155,7 @@ print(d.get('hub', ''), d.get('status', ''))" "$status_file" 2>/dev/null) || con
 
     # In-progress status with no running process and stale timestamp — alert.
     age_min=$(( age / 60 ))
-    slack_alert ":skull: *$hub ingest process was killed* | stage: \`$status\` | last updated: ${age_min}m ago\nNo ingest.sh process found — likely SIGKILL. Manual restart required."
+    slack_alert ":skull: *$hub ingest process was killed* | stage: \`$status\` | last updated: ${age_min}m ago\nNo ingest process found — likely SIGKILL. Manual restart required."
 
     # Touch sentinel so subsequent cron runs skip this death event.
     touch "$sentinel"

--- a/scripts/ingest.sh
+++ b/scripts/ingest.sh
@@ -20,6 +20,7 @@ usage() {
     echo "Options:"
     echo "  --skip-harvest          Skip harvest step (use existing harvest data)"
     echo "  --harvest-only          Only run harvest step"
+    echo "  --mapping-only          Only run mapping step (implies --skip-harvest)"
     echo "  --skip-s3-sync          Skip S3 sync step (pipeline stops at JSONL)"
     echo "  --resume-from <step>    Resume from a specific step, reusing existing outputs"
     echo "                          for all preceding steps. Valid steps: mapping,"
@@ -30,6 +31,7 @@ usage() {
     echo "  ./ingest.sh maryland                          # Full pipeline"
     echo "  ./ingest.sh maryland --skip-harvest           # Use existing harvest"
     echo "  ./ingest.sh maryland --harvest-only           # Only harvest"
+    echo "  ./ingest.sh maryland --mapping-only           # Only mapping (verify count)"
     echo "  ./ingest.sh maryland --skip-s3-sync           # Skip S3 upload"
     echo "  ./ingest.sh maryland --resume-from enrichment # Skip harvest+mapping, reuse"
     echo "                                                #   existing mapping output"
@@ -53,6 +55,7 @@ shift
 
 SKIP_HARVEST=false
 HARVEST_ONLY=false
+MAPPING_ONLY=false
 SKIP_S3_SYNC=false
 RESUME_FROM=""
 
@@ -69,6 +72,11 @@ while [[ $# -gt 0 ]]; do
             ;;
         --harvest-only)
             HARVEST_ONLY=true
+            shift
+            ;;
+        --mapping-only)
+            MAPPING_ONLY=true
+            SKIP_HARVEST=true
             shift
             ;;
         --skip-s3-sync)
@@ -142,6 +150,8 @@ cd "$I3_HOME"
 
 if [[ -n "$RESUME_FROM" ]]; then
     slack_notify ":arrow_forward: *$PROVIDER ingest resuming from $RESUME_FROM*"
+elif [[ "$MAPPING_ONLY" = true ]]; then
+    slack_notify ":arrow_forward: *$PROVIDER mapping-only run started*"
 else
     slack_notify ":arrow_forward: *$PROVIDER ingest started* | harvest → map → enrich → jsonl → s3"
 fi
@@ -227,6 +237,20 @@ else
     fi
 
     slack_notify ":white_check_mark: *$PROVIDER mapping complete* (${MAP_RECORD_COUNT} records) — starting enrichment"
+
+    if [ "$MAPPING_ONLY" = true ]; then
+        write_hub_status "$PROVIDER" complete
+        log_info "Mapping-only mode - stopping here"
+        END_TIME=$(date +%s)
+        DURATION=$((END_TIME - START_TIME))
+        echo ""
+        echo "=============================================="
+        echo "  Mapping completed in $((DURATION / 60))m $((DURATION % 60))s"
+        echo "  Records: $MAP_RECORD_COUNT"
+        echo "=============================================="
+        TRAP_HANDLED=true
+        exit 0
+    fi
 fi
 
 # Step 3: Enrichment

--- a/scripts/ingest.sh
+++ b/scripts/ingest.sh
@@ -194,6 +194,7 @@ fi
 
 if [ "$HARVEST_ONLY" = true ]; then
     write_hub_status "$PROVIDER" complete
+    slack_notify ":white_check_mark: *$PROVIDER harvest complete* (${HARVEST_RECORD_COUNT} records)"
     log_info "Harvest-only mode - stopping here"
     END_TIME=$(date +%s)
     DURATION=$((END_TIME - START_TIME))
@@ -201,6 +202,7 @@ if [ "$HARVEST_ONLY" = true ]; then
     echo "=============================================="
     echo "  Harvest completed in $((DURATION / 60))m $((DURATION % 60))s"
     echo "=============================================="
+    TRAP_HANDLED=true
     exit 0
 fi
 
@@ -236,10 +238,9 @@ else
         exit 1
     fi
 
-    slack_notify ":white_check_mark: *$PROVIDER mapping complete* (${MAP_RECORD_COUNT} records) — starting enrichment"
-
     if [ "$MAPPING_ONLY" = true ]; then
         write_hub_status "$PROVIDER" complete
+        slack_notify ":white_check_mark: *$PROVIDER mapping complete* (${MAP_RECORD_COUNT} records)"
         log_info "Mapping-only mode - stopping here"
         END_TIME=$(date +%s)
         DURATION=$((END_TIME - START_TIME))
@@ -251,6 +252,8 @@ else
         TRAP_HANDLED=true
         exit 0
     fi
+
+    slack_notify ":white_check_mark: *$PROVIDER mapping complete* (${MAP_RECORD_COUNT} records) — starting enrichment"
 fi
 
 # Step 3: Enrichment

--- a/scripts/ingest.sh
+++ b/scripts/ingest.sh
@@ -424,6 +424,7 @@ print(f'Records: {new:,} ({sign}{delta:,} vs prev) | Size: {size_mb:.1f} MB')
 ")
 
     slack_notify "*$PROVIDER ingest complete* :white_check_mark:\nNew snapshot: \`$JSONL_TS\`\n$SUMMARY\nS3: \`s3://dpla-master-dataset/${S3_PREFIX}/jsonl/${JSONL_TS}/\`${EMAIL_NOTE}"
+
 else
     print_step "Skipping S3 sync (--skip-s3-sync)"
     slack_notify "*$PROVIDER ingest complete* :white_check_mark: _(S3 sync skipped)_\nJSONL: \`$JSONL_TS\`${EMAIL_NOTE}"

--- a/src/main/scala/dpla/ingestion3/harvesters/file/SiFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/SiFileHarvester.scala
@@ -3,7 +3,6 @@ package dpla.ingestion3.harvesters.file
 import java.io.{File, FileInputStream}
 import java.util.zip.GZIPInputStream
 import javax.xml.stream.{XMLInputFactory, XMLStreamConstants}
-import org.apache.hadoop.shaded.com.ctc.wstx.api.WstxInputProperties   
 import dpla.ingestion3.confs.i3Conf
 import dpla.ingestion3.harvesters.{Harvester, LocalHarvester, ParsedResult}
 import dpla.ingestion3.harvesters.file.FileFilters.gzFilter
@@ -159,14 +158,10 @@ class SiFileHarvester(
     // so IS_NAMESPACE_AWARE=false is safe and avoids the overhead of namespace processing.
     // DTD and external entity resolution are disabled to prevent XXE attacks.
     val xmlInputFactory = XMLInputFactory.newInstance()
-        xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false)
-        xmlInputFactory.setProperty(XMLInputFactory.IS_COALESCING, true)
-        xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false)
-        xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false)
-        xmlInputFactory.setProperty(                                                  
-            WstxInputProperties.P_INPUT_PARSING_MODE,                                   
-            WstxInputProperties.PARSING_MODE_DOCUMENTS                                  
-            )                                                                               
+    xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false)
+    xmlInputFactory.setProperty(XMLInputFactory.IS_COALESCING, true)
+    xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false)
+    xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false)
 
     try {
       Option(inFiles.listFiles(gzFilter)).getOrElse(Array.empty).foreach { inFile =>

--- a/src/main/scala/dpla/ingestion3/harvesters/file/SiFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/SiFileHarvester.scala
@@ -3,6 +3,7 @@ package dpla.ingestion3.harvesters.file
 import java.io.{File, FileInputStream}
 import java.util.zip.GZIPInputStream
 import javax.xml.stream.{XMLInputFactory, XMLStreamConstants}
+import org.apache.hadoop.shaded.com.ctc.wstx.api.WstxInputProperties   
 import dpla.ingestion3.confs.i3Conf
 import dpla.ingestion3.harvesters.{Harvester, LocalHarvester, ParsedResult}
 import dpla.ingestion3.harvesters.file.FileFilters.gzFilter
@@ -158,10 +159,14 @@ class SiFileHarvester(
     // so IS_NAMESPACE_AWARE=false is safe and avoids the overhead of namespace processing.
     // DTD and external entity resolution are disabled to prevent XXE attacks.
     val xmlInputFactory = XMLInputFactory.newInstance()
-    xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false)
-    xmlInputFactory.setProperty(XMLInputFactory.IS_COALESCING, true)
-    xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false)
-    xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false)
+        xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false)
+        xmlInputFactory.setProperty(XMLInputFactory.IS_COALESCING, true)
+        xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false)
+        xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false)
+        xmlInputFactory.setProperty(                                                  
+            WstxInputProperties.P_INPUT_PARSING_MODE,                                   
+            WstxInputProperties.PARSING_MODE_DOCUMENTS                                  
+            )                                                                               
 
     try {
       Option(inFiles.listFiles(gzFilter)).getOrElse(Array.empty).foreach { inFile =>

--- a/src/main/scala/dpla/ingestion3/harvesters/file/SiFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/SiFileHarvester.scala
@@ -3,6 +3,7 @@ package dpla.ingestion3.harvesters.file
 import java.io.{File, FileInputStream}
 import java.util.zip.GZIPInputStream
 import javax.xml.stream.{XMLInputFactory, XMLStreamConstants}
+import org.apache.hadoop.shaded.com.ctc.wstx.api.WstxInputProperties
 import dpla.ingestion3.confs.i3Conf
 import dpla.ingestion3.harvesters.{Harvester, LocalHarvester, ParsedResult}
 import dpla.ingestion3.harvesters.file.FileFilters.gzFilter
@@ -157,11 +158,18 @@ class SiFileHarvester(
     // SI XML uses no namespace prefixes on elements or attributes inside <doc>,
     // so IS_NAMESPACE_AWARE=false is safe and avoids the overhead of namespace processing.
     // DTD and external entity resolution are disabled to prevent XXE attacks.
+    // PARSING_MODE_DOCUMENTS is required because xmll produces line-delimited XML
+    // (one <doc> per line, no root wrapper), which is treated as multiple concatenated
+    // XML documents by the StAX parser.
     val xmlInputFactory = XMLInputFactory.newInstance()
     xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false)
     xmlInputFactory.setProperty(XMLInputFactory.IS_COALESCING, true)
     xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false)
     xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false)
+    xmlInputFactory.setProperty(
+      WstxInputProperties.P_INPUT_PARSING_MODE,
+      WstxInputProperties.PARSING_MODE_DOCUMENTS
+    )
 
     try {
       Option(inFiles.listFiles(gzFilter)).getOrElse(Array.empty).foreach { inFile =>


### PR DESCRIPTION
## Summary

Two changes in this PR:

### 1. Fix SiFileHarvester multi-doc XML parsing

`SiFileHarvester` was producing only 1 record per file (26 total) instead of ~7.8M.

Root cause: `XMLInputFactory` was in default single-document mode. Woodstox treats input as one XML document — when it finishes the first `<doc>` and encounters the next one, it stops. `fix-si.sh` produces line-delimited XML (one `<doc>` per line, no root wrapper), so the parser needs `PARSING_MODE_DOCUMENTS` to read past the first document.

Fix: set `WstxInputProperties.P_INPUT_PARSING_MODE = PARSING_MODE_DOCUMENTS`. Also keeps existing safety properties: `IS_NAMESPACE_AWARE=false`, `IS_COALESCING=true`, `SUPPORT_DTD=false`, `IS_SUPPORTING_EXTERNAL_ENTITIES=false`.

### 2. Add `--mapping-only` flag to `ingest.sh`

Adds a `--mapping-only` mode that runs mapping and exits before enrichment/jsonl/S3. Useful for verifying record counts after harvest before committing to a full pipeline run. Sends a Slack notification on completion. Implies `--skip-harvest`.

Usage: ./scripts/ingest.sh smithsonian --mapping-only

## Testing
- Harvest: 7,845,472 records (100% per file, matches expected counts)
- Mapping: 7,845,472 records (1:1 with harvest, no duplication)