### PR TITLE
feat: add Getty to Tailscale exit node routing; fix sudo for tailscale set

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,18 @@ Some partner endpoints are not publicly accessible — they whitelist a specific
 
 **⚠️ Node key rotation:** Tailscale node keys expire approximately every 180 days. When the key expires, `ingest.sh` detects it immediately at harvest time and prints a clear error with re-authentication instructions. See `scripts/SCRIPTS.md` for the full recovery procedure.
 
+#### J. Paul Getty Trust (getty)
+
+| Field | Value |
+|-------|-------|
+| Partner | J. Paul Getty Trust |
+| Endpoint | IP-whitelisted ExLibris Primo REST API |
+| Whitelisted IP | `100.82.233.38` (main-vpc Tailscale node) |
+| Configured in | `scripts/ingest.sh` (`TAILSCALE_EXIT_NODE` case block) |
+| Handled by | `ingest.sh` automatically |
+
+Run exactly like any other hub — `ingest.sh getty` — no extra steps needed.
+
 #### NJ Digital Library (njde)
 
 | Field | Value |

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ DPLA's ingestion system is one of the core business systems and is the source of
     * [Hub specific instructions](#exceptions-and-unusual-ingests)
       * [Firewalled endpoints](#firewalled-endpoints)
       * [IP-whitelisted endpoints (Tailscale exit node)](#ip-whitelisted-endpoints-tailscale-exit-node)
+        * [J. Paul Getty Trust (getty)](#j-paul-getty-trust-getty)
         * [NJ Digital Library (njde)](#nj-digital-library-njde)
       * [Internet Archive - Community Webs](#community-webs)
       * [Digital Virginias](#digital-virginias)

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -158,7 +158,7 @@ The exit node is configured per-provider in a `case` block near the top of `inge
 
 ```bash
 case "$PROVIDER" in
-    njde) TAILSCALE_EXIT_NODE="100.82.233.38" ;;  # main-vpc; IP whitelisted by Rutgers
+    getty|njde) TAILSCALE_EXIT_NODE="100.82.233.38" ;;  # main-vpc; whitelisted by Getty and Rutgers
 esac
 ```
 

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -166,6 +166,7 @@ esac
 
 | Hub | Partner | Whitelisted IP | Tailscale exit node |
 |-----|---------|---------------|---------------------|
+| `getty` | J. Paul Getty Trust (ExLibris Primo API) | `100.82.233.38` | `main-vpc` |
 | `njde` | Rutgers (NJ Digital Library) | `100.82.233.38` | `main-vpc` |
 
 **Prerequisites** for IP-restricted hubs:

--- a/scripts/ingest.sh
+++ b/scripts/ingest.sh
@@ -105,7 +105,7 @@ fi
 # steps (mapping, enrichment, S3 sync) use normal routing.
 TAILSCALE_EXIT_NODE=""
 case "$PROVIDER" in
-    njde) TAILSCALE_EXIT_NODE="100.82.233.38" ;;  # main-vpc; IP whitelisted by Rutgers
+    getty|njde) TAILSCALE_EXIT_NODE="100.82.233.38" ;;  # main-vpc; whitelisted by Getty and Rutgers
 esac
 
 # Setup paths
@@ -123,7 +123,7 @@ fi
 INGEST_PROVIDER="$PROVIDER"
 TRAP_HANDLED=false  # set to true when we handle notification+status explicitly before exit
 trap 'err=$?
-     [ -n "${TAILSCALE_EXIT_NODE:-}" ] && tailscale set --exit-node= 2>/dev/null || true
+     [ -n "${TAILSCALE_EXIT_NODE:-}" ] && sudo tailscale set --exit-node= 2>/dev/null || true
      [ -n "${TAILSCALE_EXIT_NODE:-}" ] && sudo systemctl stop tailscaled 2>/dev/null || true
      stop_heartbeat 2>/dev/null || true
      if [[ $err -ne 0 && -n "${INGEST_PROVIDER:-}" && "$TRAP_HANDLED" != "true" ]]; then
@@ -191,7 +191,7 @@ Node keys rotate every ~180 days; see scripts/SCRIPTS.md for details."
             die "Tailscale failed to connect within 30s (state: ${_ts_state:-unknown})"
         fi
         log_info "Setting Tailscale exit node $TAILSCALE_EXIT_NODE for $PROVIDER harvest"
-        tailscale set --exit-node="$TAILSCALE_EXIT_NODE" \
+        sudo tailscale set --exit-node="$TAILSCALE_EXIT_NODE" \
             || die "Failed to set Tailscale exit node — $PROVIDER endpoint requires whitelisted IP"
     fi
 
@@ -204,7 +204,7 @@ Node keys rotate every ~180 days; see scripts/SCRIPTS.md for details."
 
     if [ -n "$TAILSCALE_EXIT_NODE" ]; then
         log_info "Clearing Tailscale exit node and stopping tailscaled after $PROVIDER harvest"
-        tailscale set --exit-node= || log_warn "Failed to clear Tailscale exit node"
+        sudo tailscale set --exit-node= || log_warn "Failed to clear Tailscale exit node"
         sudo systemctl stop tailscaled || log_warn "Failed to stop tailscaled"
     fi
     stop_heartbeat

--- a/scripts/tests/test-scripts.sh
+++ b/scripts/tests/test-scripts.sh
@@ -957,6 +957,14 @@ test_tailscale_exit_node() {
         log_fail "Tailscale: njde exit node mapping not found in ingest.sh"
     fi
 
+    # Test 2: getty maps to the expected Tailscale exit node IP
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if grep -q 'getty.*TAILSCALE_EXIT_NODE.*100\.82\.233\.38' <<< "$content"; then
+        log_pass "Tailscale: getty maps to exit node 100.82.233.38"
+    else
+        log_fail "Tailscale: getty exit node mapping not found in ingest.sh"
+    fi
+
     # Test 2: require_command tailscale is called (install guard present)
     TESTS_RUN=$((TESTS_RUN + 1))
     if grep -q 'require_command tailscale' <<< "$content"; then
@@ -1000,6 +1008,17 @@ test_tailscale_exit_node() {
         log_pass "Tailscale: exit node cleared in both EXIT trap and post-harvest block"
     else
         log_fail "Tailscale: expected ≥2 exit node clear calls (trap + post-harvest), found $clear_count"
+    fi
+
+    # Test 6: All tailscale set calls use sudo (required — ec2-user lacks operator privilege)
+    TESTS_RUN=$((TESTS_RUN + 1))
+    local ts_set_total ts_set_with_sudo
+    ts_set_total=$(grep -c 'tailscale set' <<< "$content" || echo 0)
+    ts_set_with_sudo=$(grep -c 'sudo tailscale set' <<< "$content" || echo 0)
+    if [[ "$ts_set_total" -gt 0 && "$ts_set_total" -eq "$ts_set_with_sudo" ]]; then
+        log_pass "Tailscale: all tailscale set calls use sudo ($ts_set_with_sudo/$ts_set_total)"
+    else
+        log_fail "Tailscale: $((ts_set_total - ts_set_with_sudo)) of $ts_set_total tailscale set calls missing sudo"
     fi
 }
 


### PR DESCRIPTION
## Summary

- Getty's ExLibris Primo API is IP-restricted. Confirmed via testing that `main-vpc` (`100.82.233.38`) is already whitelisted — requests through the exit node return API validation errors rather than IP-block errors.
- Collapses `getty` and `njde` into one case arm since both use the same exit node.
- Fixes a latent bug: all three `tailscale set` calls were missing `sudo`. `ec2-user` requires it (no Tailscale operator privilege is configured), so without this fix any Tailscale-routed harvest — including `njde` — would die immediately at the exit node setup step.

## Test plan

- [ ] All Tailscale tests in `scripts/tests/test-scripts.sh` pass (7 assertions including new getty mapping and sudo-coverage checks)
- [ ] Run `ingest.sh getty` on EC2 to confirm harvest completes through the exit node
- [ ] Run `ingest.sh njde` on EC2 to confirm the sudo fix unblocks njde as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Getty Tailscale Exit Node Routing & sudo Fix

**Summary**
This PR adds Getty to the Tailscale exit-node routing exceptions so ingestion traffic to Getty’s IP-restricted ExLibris Primo REST API is routed through the whitelisted exit node, and fixes a latent privilege bug by prefixing all `tailscale set` calls with `sudo`.

**Changes**
- scripts/ingest.sh
  - Collapses `getty` and `njde` into a single case arm; both now use the same Tailscale exit node IP (100.82.233.38).
  - Adds `sudo` to all three `tailscale set` operations (harvest setup, teardown, and the global EXIT trap) so `ec2-user` can configure the exit node without requiring Tailscale operator privileges.
- README.md
  - Adds a “J. Paul Getty Trust (getty)” entry documenting the IP-whitelisted ExLibris Primo REST API, the whitelisted Tailscale node IP, where the configuration lives (scripts/ingest.sh TAILSCALE_EXIT_NODE case block), and the standard invocation `ingest.sh getty`.
- scripts/SCRIPTS.md
  - Updates the hub allowlist table and inline comments to show Getty uses the existing 100.82.233.38 exit node.
- scripts/tests/test-scripts.sh
  - Adds static assertions in `test_tailscale_exit_node` to (1) confirm `getty` maps to the same TAILSCALE_EXIT_NODE IP as `njde`, and (2) enforce that every `tailscale set` call in ingest.sh is prefixed with `sudo`.

**Security, Infrastructure & Deployment Notes**
- Security: The `sudo` additions are intentional and necessary to avoid failed exit-node setup on EC2 where `ec2-user` is not a Tailscale operator. No changes to authentication logic or credential handling are made.
- Infrastructure / Deployment: No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task definitions, IAM policies), no new or removed environment variables or AWS Secrets Manager keys, and no database migrations.
- Manual actions: No pipeline trigger or ECS redeployment is required for these script and documentation changes to take effect; however, the change should be validated on an EC2 instance (see test plan).
- Public API: No API response shapes or public endpoints are modified.

**Testing / Validation**
- Unit/static tests: All Tailscale-related tests in scripts/tests/test-scripts.sh (including the new getty mapping and sudo assertions) should pass.
- End-to-end: Run `ingest.sh getty` and `ingest.sh njde` on an EC2 instance to confirm end-to-end behavior (exit node is set via `sudo tailscale set` and requests succeed against Getty’s whitelisted API).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->