### PR TITLE
Fix Maryland thumbnail URLs

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/MarylandMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MarylandMapping.scala
@@ -1,6 +1,5 @@
 package dpla.ingestion3.mappers.providers
 
-import com.typesafe.scalalogging.LazyLogging
 import dpla.ingestion3.enrichments.normalizations.StringNormalizationUtils._
 import dpla.ingestion3.mappers.utils.{Document, XmlExtractor, XmlMapping}
 import dpla.ingestion3.model.DplaMapData._
@@ -22,7 +21,9 @@ object MarylandMapping {
   val ccByNd30Uri = "https://creativecommons.org/licenses/by-nd/3.0/"
 }
 
-class MarylandMapping extends XmlMapping with XmlExtractor with LazyLogging {
+class MarylandMapping extends XmlMapping with XmlExtractor {
+
+  private val logger = org.slf4j.LoggerFactory.getLogger(getClass)
 
   import MarylandMapping._
 

--- a/src/main/scala/dpla/ingestion3/mappers/providers/MarylandMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/MarylandMapping.scala
@@ -1,5 +1,6 @@
 package dpla.ingestion3.mappers.providers
 
+import com.typesafe.scalalogging.LazyLogging
 import dpla.ingestion3.enrichments.normalizations.StringNormalizationUtils._
 import dpla.ingestion3.mappers.utils.{Document, XmlExtractor, XmlMapping}
 import dpla.ingestion3.model.DplaMapData._
@@ -21,7 +22,7 @@ object MarylandMapping {
   val ccByNd30Uri = "https://creativecommons.org/licenses/by-nd/3.0/"
 }
 
-class MarylandMapping extends XmlMapping with XmlExtractor {
+class MarylandMapping extends XmlMapping with XmlExtractor with LazyLogging {
 
   import MarylandMapping._
 
@@ -129,21 +130,18 @@ class MarylandMapping extends XmlMapping with XmlExtractor {
       .filter(Utils.isUrl)
       .headOption
 
-    val parts: Seq[String] = url.getOrElse("").stripSuffix("/").split("/")
-
-    val collection: Option[String] =
-      parts.reverse.lift(2) // get third to last element
-    val item: Option[String] = parts.lastOption // get last element
-
-    if (collection.isDefined && item.isDefined) {
-      val url: String =
-        "http://webconfig.digitalmaryland.org/utils/getthumbnail/collection/" +
-          collection.get +
-          "/id/" +
-          item.get
-
-      Seq(stringOnlyWebResource(url))
-    } else Seq()
+    url.flatMap { u =>
+      val uri = new java.net.URI(u)
+      val base = s"${uri.getScheme}://${uri.getHost}"
+      val thumbnailPath = uri.getPath
+        .replaceFirst("/cdm/ref/collection/", "/utils/getthumbnail/collection/")
+      if (thumbnailPath.contains("getthumbnail"))
+        Some(stringOnlyWebResource(base + thumbnailPath))
+      else {
+        logger.warn(s"MarylandMapping.preview: identifier URL did not match expected CONTENTdm path pattern, no thumbnail generated. URL: $u")
+        None
+      }
+    }.toSeq
   }
 
   override def provider(data: Document[NodeSeq]): ExactlyOne[EdmAgent] = agent

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MarylandMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MarylandMappingTest.scala
@@ -128,8 +128,7 @@ class MarylandMappingTest extends AnyFlatSpec with BeforeAndAfter {
   }
 
   it should "extract the correct preview" in {
-    val expected = Seq(stringOnlyWebResource("http://webconfig.digitalmaryland.org/utils/getthumbnail/collection/mamo/id/29817"))
-    assert(extractor.preview(xml) === expected)
+    val expected = Seq(stringOnlyWebResource("http://collections.digitalmaryland.org/utils/getthumbnail/collection/mamo/id/29817"))    assert(extractor.preview(xml) === expected)
   }
 
   it should "create the correct DPLA URI" in {

--- a/src/test/scala/dpla/ingestion3/mappers/providers/MarylandMappingTest.scala
+++ b/src/test/scala/dpla/ingestion3/mappers/providers/MarylandMappingTest.scala
@@ -128,7 +128,8 @@ class MarylandMappingTest extends AnyFlatSpec with BeforeAndAfter {
   }
 
   it should "extract the correct preview" in {
-    val expected = Seq(stringOnlyWebResource("http://collections.digitalmaryland.org/utils/getthumbnail/collection/mamo/id/29817"))    assert(extractor.preview(xml) === expected)
+    val expected = Seq(stringOnlyWebResource("http://collections.digitalmaryland.org/utils/getthumbnail/collection/mamo/id/29817"))
+    assert(extractor.preview(xml) === expected)
   }
 
   it should "create the correct DPLA URI" in {


### PR DESCRIPTION
The preview field for Maryland records was hardcoded to webconfig.digitalmaryland.org, which has been dead for a while. This meant every Maryland item in DPLA was showing a broken thumbnail.

The fix: instead of hardcoding the domain, we now derive the thumbnail URL directly from the isShownAt identifier by swapping the CONTENTdm item path (/cdm/ref/collection/) for the thumbnail path (/utils/getthumbnail/collection/). Same domain, same collection, same ID — just the right endpoint.

Tested locally against a Maryland harvest: 23k records mapped, thumbnail URLs verified live (200 OK, image/jpeg). Added a logger warning for any identifiers that don't match the expected CONTENTdm pattern so we'll know if something changes upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixed broken thumbnail URLs for Maryland records by refactoring the `preview` field generation in the MarylandMapping. Instead of hardcoding `webconfig.digitalmaryland.org` and manually constructing thumbnail endpoints, the mapper now derives thumbnail URLs dynamically from the `isShownAt` identifier by:

1. Parsing the identifier URL using `java.net.URI` to extract the scheme, host, and path
2. Rewriting the CONTENTdm path from `/cdm/ref/collection/` to `/utils/getthumbnail/collection/`
3. Reconstructing the thumbnail URL with the preserved domain and rewritten path
4. Returning a thumbnail WebResource only if the path rewrite succeeded (contains `getthumbnail`)

When identifiers do not match the expected CONTENTdm pattern, the mapper now logs a warning and returns no thumbnail instead of attempting a potentially incorrect URL construction. This approach ensures thumbnails dynamically adapt to the actual CONTENTdm endpoint in the identifier, preventing broken links if the domain or path structure changes upstream.

**Testing**: Locally validated against a 23,000-record Maryland harvest with thumbnail URLs verified live (HTTP 200 OK, image/jpeg).

**Changes**: 14 lines added, 15 lines removed in `src/main/scala/dpla/ingestion3/mappers/providers/MarylandMapping.scala` — a mapper-only modification with no impact on pipelines, configuration, or deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->