### PR TITLE
Increase size of contributers

### DIFF
--- a/scripts/generate_hub_stats.py
+++ b/scripts/generate_hub_stats.py
@@ -75,7 +75,7 @@ def contributor_counts(hub_name: str, bws: bool = False) -> dict:
         "query": {"term": {"provider.name.not_analyzed": hub_name}},
         "aggs": {
             "contributors": {
-                "terms": {"field": "dataProvider.name.not_analyzed", "size": 2000}
+                "terms": {"field": "dataProvider.name.not_analyzed", "size": 10000}
             }
         },
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR increases the Elasticsearch aggregation bucket size limit in the hub statistics generation script to accommodate larger contributor counts.

### Changes

**Modified:** `scripts/generate_hub_stats.py`
- Increases the `size` parameter of the `terms` aggregation in the `contributor_counts()` function from `2000` to `10000` buckets
- This change allows the script to return more contributor buckets before hitting the existing `sum_other_doc_count` truncation threshold

### Deployment Notes

This script change takes effect on the next execution of the hub statistics generation process. No manual pipeline trigger, ECS redeployment, environment variable changes, database migration, infrastructure configuration updates, API changes, or security implications are associated with this change.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingestion3/pull/737)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->