### PR TITLE
Update workflow to use newest java version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/configure-pages@v5
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.0.0
         with:
           python-version: '3.x'
       - run: pip install zensical

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/configure-pages@v5
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.0.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
       - run: pip install zensical

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -8,9 +8,9 @@ jobs:
   build:
     runs-on: ubuntu-22.04 #temporary not latest because 24 is broken
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: 11


### PR DESCRIPTION
GitHub is deprecating Node.js 20 as the runner for Actions, and warnings are now appearing in CI. Both ingestion3 and sparkindexer have workflow files that need their action versions updated.

ingestion3
docs.yml

actions/checkout@v4 → actions/checkout@v6
actions/setup-python@v5 → actions/setup-python@v6
scala.yml

actions/checkout@v4 → actions/checkout@v6
(actions/setup-java@v4 is already current.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Updates GitHub Actions workflow versions to maintain compatibility with Node.js 24, which GitHub is now using as the default for its CI runners. This addresses deprecation warnings that have been appearing in the CI environment.

## Changes

### docs.yml
- `actions/checkout` pinned to v6.0.2 (commit SHA: de0fac2e4500dabe0009e67214ff5f5447ce83dd)
- `actions/setup-python` updated to v6.0.0 (commit SHA: a309ff8b426b58ec0e2a45f0f869d46889d02405)

### scala.yml
- `actions/checkout` pinned to v6.0.2 (commit SHA: de0fac2e4500dabe0009e67214ff5f5447ce83dd)
- `actions/setup-java` pinned to v4.8.0 (commit SHA: c1e323688fd81a25caa38c78aa6df2d33d3e20d9)

## Notes
The scala.yml workflow continues to use `ubuntu-22.04` runner (rather than `latest`) due to a known issue with Node.js 24. The changes pin actions to specific commit SHAs rather than floating version tags, which is the recommended practice for workflow stability.

These are CI/CD workflow updates only—no code changes, no infrastructure deployments, and no environment variable or secrets modifications are required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingestion3/pull/742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->