### PR TITLE
Issue 738 Post rebuild jobs for supporting the analytics dashboard.

### DIFF
--- a/scripts/export_item_attribution.py
+++ b/scripts/export_item_attribution.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+One-time export: item → hub/contributor attribution from the live ES index.
+Produces s3://dashboard-analytics/hub-stats/item_attribution.json.gz
+
+Run ONCE on the ingest EC2 after the regular monthly rebuild. The output
+is stable because item IDs in DPLA are permanently bound to a single hub
+and contributor. Re-run only if a full re-index changes item→hub assignments.
+
+Dashboard-side counterpart: dpla/dashboard-analytics#284
+
+Usage:
+    ./venv/bin/python scripts/export_item_attribution.py
+
+Environment:
+    ES_HOST      - Elasticsearch hostname (default: search-prod1.internal.dp.la)
+    ES_PORT      - Elasticsearch port (default: 9200)
+    AWS_PROFILE  - AWS profile name (optional; omit on EC2 to use instance role)
+    BATCH_SIZE   - Records per ES page (default: 10000)
+"""
+
+import gzip
+import json
+import os
+import sys
+import tempfile
+import urllib.request
+from datetime import datetime, timezone
+
+import boto3
+
+ES_HOST = os.environ.get("ES_HOST", "search-prod1.internal.dp.la")
+ES_PORT = int(os.environ.get("ES_PORT", "9200"))
+BATCH_SIZE = int(os.environ.get("BATCH_SIZE", "10000"))
+BUCKET = "dashboard-analytics"
+ATTR_KEY = "hub-stats/item_attribution.json.gz"
+
+
+def es_search(query: dict) -> dict:
+    url = f"http://{ES_HOST}:{ES_PORT}/dpla_alias/_search"
+    data = json.dumps(query).encode()
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        result = json.loads(resp.read())
+    if result.get("timed_out"):
+        raise RuntimeError("Elasticsearch query timed out")
+    shards = result.get("_shards", {})
+    if shards.get("failed", 0) > 0:
+        raise RuntimeError(f"Elasticsearch shard failures: {shards}")
+    return result
+
+
+def export_attribution(out_path: str) -> int:
+    """Stream all ES records to a gzipped JSONL file. Returns record count.
+
+    Uses search_after pagination on _id to avoid deep-pagination penalties.
+    Each output line is a JSON object:
+        {"id": "<dpla_id>", "hub": "<provider.name>", "contributor": "<dataProvider.name>"}
+    """
+    query: dict = {
+        "_source": ["provider.name", "dataProvider.name"],
+        "query": {"match_all": {}},
+        "sort": [{"_id": "asc"}],
+        "size": BATCH_SIZE,
+    }
+
+    total_written = 0
+    last_sort = None
+    batch_num = 0
+
+    with gzip.open(out_path, "wt", encoding="utf-8") as fout:
+        while True:
+            if last_sort is not None:
+                query["search_after"] = last_sort
+
+            result = es_search(query)
+            hits = result["hits"]["hits"]
+
+            if not hits:
+                break
+
+            for hit in hits:
+                src = hit.get("_source", {})
+                provider = src.get("provider", {})
+                data_provider = src.get("dataProvider", {})
+                fout.write(
+                    json.dumps(
+                        {
+                            "id": hit["_id"],
+                            "hub": provider.get("name", "") if isinstance(provider, dict) else "",
+                            "contributor": data_provider.get("name", "") if isinstance(data_provider, dict) else "",
+                        }
+                    )
+                    + "\n"
+                )
+                total_written += 1
+
+            last_sort = hits[-1]["sort"]
+            batch_num += 1
+
+            if batch_num % 100 == 0:
+                print(f"  {total_written:,} records exported...", flush=True)
+
+    return total_written
+
+
+def upload_to_s3(local_path: str) -> None:
+    session = boto3.Session(profile_name=os.environ.get("AWS_PROFILE"))
+    s3 = session.client("s3", region_name="us-east-1")
+    file_size = os.path.getsize(local_path)
+    print(
+        f"  Uploading {file_size / 1024 / 1024:.1f} MB to s3://{BUCKET}/{ATTR_KEY}...",
+        flush=True,
+    )
+    s3.upload_file(
+        local_path,
+        BUCKET,
+        ATTR_KEY,
+        ExtraArgs={"ContentType": "application/gzip"},
+    )
+    print(f"  Uploaded s3://{BUCKET}/{ATTR_KEY}", flush=True)
+
+
+def main() -> None:
+    print("Exporting item attribution from ES...", flush=True)
+    print(f"  ES:         {ES_HOST}:{ES_PORT}", flush=True)
+    print(f"  Batch size: {BATCH_SIZE:,}", flush=True)
+    print(f"  Output:     s3://{BUCKET}/{ATTR_KEY}", flush=True)
+    print(f"  Started:    {datetime.now(timezone.utc).isoformat()}", flush=True)
+
+    with tempfile.NamedTemporaryFile(
+        suffix=".json.gz", prefix="item_attribution_", delete=False
+    ) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        count = export_attribution(tmp_path)
+        print(f"  {count:,} records written", flush=True)
+        upload_to_s3(tmp_path)
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+    print(
+        f"Done. {count:,} records exported at {datetime.now(timezone.utc).isoformat()}",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_hub_stats.py
+++ b/scripts/generate_hub_stats.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """
-Generate hub_stats.json and hub_stats_bws.json from the live ES index
-and upload to s3://dashboard-analytics/hub-stats/.
+Generate hub_stats.json, hub_stats_bws.json, and item_data_providers.json
+from the live ES index and GA4, then upload to s3://dashboard-analytics/hub-stats/.
 
 Run on the ingest EC2 after each monthly index rebuild completes,
-before final verification. Requires boto3 and network access to ES.
+before final verification. Requires boto3, google-analytics-data, and
+network access to ES.
 
 Uses two passes per stats file: first a hub-level totals aggregation,
 then one per-hub query for contributor counts. A single nested aggregation
@@ -14,31 +15,44 @@ Usage:
     ./venv/bin/python scripts/generate_hub_stats.py
 
 Environment:
-    ES_HOST  - Elasticsearch hostname (default: search-prod1.internal.dp.la)
-    ES_PORT  - Elasticsearch port (default: 9200)
+    ES_HOST             - Elasticsearch hostname (default: search-prod1.internal.dp.la)
+    ES_PORT             - Elasticsearch port (default: 9200)
+    AWS_PROFILE         - AWS profile name (optional; omit on EC2 to use instance role)
+    GA4_PROPERTY_ID     - GA4 numeric property ID (required for item_data_providers)
+    GA4_SECRET_NAME     - Secrets Manager secret name for GA4 service account JSON
+                          (default: dpla/ga4-service-account)
+    GA4_CLICK_EVENT     - GA4 event name for item click-throughs (default: click_item)
+    GA4_HISTORY_START   - Earliest date for first-run backfill (default: 2018-01-01)
 """
 
+import calendar
 import json
 import os
 import urllib.request
 from datetime import datetime, timezone
 
 import boto3
+import botocore.exceptions
 
 ES_HOST = os.environ.get("ES_HOST", "search-prod1.internal.dp.la")
 ES_PORT = int(os.environ.get("ES_PORT", "9200"))
 BUCKET = "dashboard-analytics"
 HUB_KEY = "hub-stats/hub_stats.json"
 BWS_KEY = "hub-stats/hub_stats_bws.json"
+IDP_KEY = "hub-stats/item_data_providers.json"
+GA4_PROPERTY_ID = os.environ.get("GA4_PROPERTY_ID", "")
+GA4_SECRET_NAME = os.environ.get("GA4_SECRET_NAME", "dpla/ga4-service-account")
+GA4_CLICK_EVENT = os.environ.get("GA4_CLICK_EVENT", "click_item")
+GA4_HISTORY_START = os.environ.get("GA4_HISTORY_START", "2018-01-01")
 
 
-def es_query(query: dict) -> dict:
+def es_query(query: dict, timeout: int = 30) -> dict:
     url = f"http://{ES_HOST}:{ES_PORT}/dpla_alias/_search"
     data = json.dumps(query).encode()
     req = urllib.request.Request(
         url, data=data, headers={"Content-Type": "application/json"}
     )
-    with urllib.request.urlopen(req, timeout=30) as resp:
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
         data = json.loads(resp.read())
     if data.get("timed_out"):
         raise RuntimeError(f"Elasticsearch query timed out: {query}")
@@ -99,14 +113,16 @@ def contributor_counts(hub_name: str, bws: bool = False) -> dict:
     return {b["key"]: b["doc_count"] for b in contributors_agg["buckets"]}
 
 
-def build_stats(bws: bool = False) -> dict:
+def build_stats(bws: bool = False, generated_at: str | None = None) -> dict:
+    if generated_at is None:
+        generated_at = datetime.now(timezone.utc).isoformat()
     totals = hub_totals(bws)
     hubs = {}
     for hub_name, item_count in totals.items():
         contributors = contributor_counts(hub_name, bws)
         hubs[hub_name] = {"item_count": item_count, "contributors": contributors}
     return {
-        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_at": generated_at,
         "hubs": hubs,
     }
 
@@ -124,22 +140,195 @@ def upload(data: dict, key: str) -> None:
     print(f"  Uploaded s3://{BUCKET}/{key}", flush=True)
 
 
-def main() -> None:
-    print("Generating hub stats from ES...", flush=True)
+# ---------------------------------------------------------------------------
+# item_data_providers.json
+# ---------------------------------------------------------------------------
 
-    hub_stats = build_stats(bws=False)
+
+def prev_month_range() -> tuple[str, str]:
+    """Return (start_date, end_date) ISO strings for the previous calendar month."""
+    now = datetime.now(timezone.utc)
+    year, month = (now.year, now.month - 1) if now.month > 1 else (now.year - 1, 12)
+    last_day = calendar.monthrange(year, month)[1]
+    return f"{year:04d}-{month:02d}-01", f"{year:04d}-{month:02d}-{last_day:02d}"
+
+
+def fetch_ga4_credentials() -> dict:
+    """Fetch GA4 service account JSON from AWS Secrets Manager."""
+    session = boto3.Session(profile_name=os.environ.get("AWS_PROFILE"))
+    sm = session.client("secretsmanager", region_name="us-east-1")
+    secret = sm.get_secret_value(SecretId=GA4_SECRET_NAME)
+    return json.loads(secret["SecretString"])
+
+
+def ga4_item_ids(credentials: dict, start_date: str, end_date: str) -> set:
+    """Return set of item IDs from GA4 click-through events in [start_date, end_date].
+
+    Item IDs are the first segment of the eventLabel dimension value,
+    which has the format "{item_id} : {item_title}".
+    """
+    from google.analytics.data_v1beta import BetaAnalyticsDataClient
+    from google.analytics.data_v1beta.types import (
+        DateRange,
+        Dimension,
+        Filter,
+        FilterExpression,
+        Metric,
+        RunReportRequest,
+    )
+    from google.oauth2.service_account import Credentials
+
+    creds = Credentials.from_service_account_info(
+        credentials,
+        scopes=["https://www.googleapis.com/auth/analytics.readonly"],
+    )
+    client = BetaAnalyticsDataClient(credentials=creds)
+
+    item_ids: set = set()
+    offset = 0
+    page_size = 10000
+
+    while True:
+        request = RunReportRequest(
+            property=f"properties/{GA4_PROPERTY_ID}",
+            dimensions=[Dimension(name="eventLabel")],
+            metrics=[Metric(name="eventCount")],
+            date_ranges=[DateRange(start_date=start_date, end_date=end_date)],
+            dimension_filter=FilterExpression(
+                filter=Filter(
+                    field_name="eventName",
+                    string_filter=Filter.StringFilter(
+                        value=GA4_CLICK_EVENT,
+                        match_type=Filter.StringFilter.MatchType.EXACT,
+                    ),
+                )
+            ),
+            offset=offset,
+            limit=page_size,
+        )
+        response = client.run_report(request)
+        if not response.rows:
+            break
+        for row in response.rows:
+            label = row.dimension_values[0].value
+            item_id = label.split(" : ")[0].strip()
+            if item_id:
+                item_ids.add(item_id)
+        if len(response.rows) < page_size:
+            break
+        offset += page_size
+
+    return item_ids
+
+
+def fetch_existing_idp() -> dict:
+    """Fetch existing item_data_providers.json from S3, or return empty structure."""
+    session = boto3.Session(profile_name=os.environ.get("AWS_PROFILE"))
+    s3 = session.client("s3", region_name="us-east-1")
+    try:
+        obj = s3.get_object(Bucket=BUCKET, Key=IDP_KEY)
+        return json.loads(obj["Body"].read())
+    except botocore.exceptions.ClientError as e:
+        if e.response["Error"]["Code"] == "NoSuchKey":
+            print("  No existing item_data_providers.json; starting fresh.", flush=True)
+            return {"items": {}}
+        raise
+
+
+def resolve_ids_from_es(ids: list) -> dict:
+    """Batch-resolve DPLA item IDs → dataProvider names via ES ids query."""
+    resolved = {}
+    batch_size = 1000
+    for i in range(0, len(ids), batch_size):
+        batch = ids[i : i + batch_size]
+        result = es_query(
+            {
+                "query": {"ids": {"values": batch}},
+                "_source": ["dataProvider.name"],
+                "size": batch_size,
+            },
+            timeout=60,
+        )
+        for hit in result["hits"]["hits"]:
+            dp = hit.get("_source", {}).get("dataProvider", {})
+            name = dp.get("name", "") if isinstance(dp, dict) else ""
+            if name:
+                resolved[hit["_id"]] = name
+    return resolved
+
+
+def build_item_data_providers(generated_at: str) -> dict:
+    """Build the cumulative item_data_providers.json.
+
+    Fetches the existing mapping from S3, queries GA4 for new item IDs
+    (previous calendar month, or full history on first run), resolves
+    them against ES, and returns the merged mapping.
+    """
+    if not GA4_PROPERTY_ID:
+        print(
+            "  WARNING: GA4_PROPERTY_ID not set; skipping item_data_providers.",
+            flush=True,
+        )
+        return {"generated_at": generated_at, "items": {}}
+
+    existing = fetch_existing_idp()
+    current_items: dict = existing.get("items", {})
+
+    # First run (empty mapping): backfill all available GA4 history.
+    # Subsequent runs: previous calendar month only.
+    if current_items:
+        start_date, end_date = prev_month_range()
+    else:
+        _, end_date = prev_month_range()
+        start_date = GA4_HISTORY_START
+
+    print(
+        f"  Querying GA4 ({GA4_CLICK_EVENT}) {start_date} → {end_date}...", flush=True
+    )
+    credentials = fetch_ga4_credentials()
+    seen_ids = ga4_item_ids(credentials, start_date, end_date)
+    print(f"  {len(seen_ids):,} item IDs from GA4", flush=True)
+
+    new_ids = [i for i in seen_ids if i not in current_items]
+    print(f"  {len(new_ids):,} new IDs to resolve from ES", flush=True)
+
+    if new_ids:
+        resolved = resolve_ids_from_es(new_ids)
+        current_items.update(resolved)
+        print(f"  {len(resolved):,} IDs resolved", flush=True)
+
+    return {"generated_at": generated_at, "items": current_items}
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    generated_at = datetime.now(timezone.utc).isoformat()
+
+    print("Generating hub stats from ES...", flush=True)
+    hub_stats = build_stats(bws=False, generated_at=generated_at)
     hub_count = len(hub_stats["hubs"])
     print(f"  {hub_count} hubs", flush=True)
 
-    bws_stats = build_stats(bws=True)
+    bws_stats = build_stats(bws=True, generated_at=generated_at)
     bws_hub_count = len(bws_stats["hubs"])
     print(f"  {bws_hub_count} hubs with BWS items", flush=True)
 
+    print("Generating item_data_providers.json...", flush=True)
+    idp = build_item_data_providers(generated_at)
+    idp_count = len(idp.get("items", {}))
+    print(f"  {idp_count:,} items in mapping", flush=True)
+
     upload(hub_stats, HUB_KEY)
     upload(bws_stats, BWS_KEY)
+    upload(idp, IDP_KEY)
 
     print(
-        f"Done. {hub_count} hubs, generated_at={hub_stats['generated_at']}",
+        f"Done. {hub_count} hubs, {idp_count:,} item mappings, "
+        f"generated_at={generated_at}",
         flush=True,
     )
 


### PR DESCRIPTION
scripts/generate_hub_stats.py

Extracted generated_at timestamp into main() and passed it through to build_stats() so all three output files (hub_stats.json, hub_stats_bws.json, item_data_providers.json) share a single consistent timestamp. The dashboard derives max_date from this field; previously hub_stats and hub_stats_bws could drift by a few milliseconds.
Added recurring monthly step: build_item_data_providers() produces and uploads s3://dashboard-analytics/hub-stats/item_data_providers.json — a cumulative {item_id: dataProvider_name} lookup table. On first run it backfills all available GA4 history from GA4_HISTORY_START; on subsequent runs it queries only the previous calendar month and merges new IDs into the existing mapping. New IDs are resolved against ES in batches of 1000 using an ids query. GA4 credentials are fetched from AWS Secrets Manager.
If GA4_PROPERTY_ID is not set, the IDP step is skipped with a warning so existing runs are not broken during rollout.

scripts/export_item_attribution.py (new, one-time)

Exports {id, hub, contributor} for every item in the ES index (~50M rows) to s3://dashboard-analytics/hub-stats/item_attribution.json.gz. Uses search_after pagination on _id and streams directly to a gzipped JSONL temp file to avoid holding the full dataset in memory. Run once after the next monthly rebuild; skip on all subsequent rebuilds.

Environment variables (all optional with sensible defaults):

GA4_PROPERTY_ID — required to enable the IDP step
GA4_SECRET_NAME — Secrets Manager secret name (default: dpla/ga4-service-account)
GA4_CLICK_EVENT — GA4 event name (default: click_item)
GA4_HISTORY_START — earliest backfill date (default: 2018-01-01)
BATCH_SIZE — ES page size for attribution export (default: 10000)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## High-Level Summary

This PR adds two new post-rebuild analytics scripts and enhances the existing hub stats generation to support a GA4-backed analytics dashboard revamp.

### Key Infrastructure and Deployment Notes

**Manual Pipeline Trigger Required**: Both `scripts/export_item_attribution.py` and the enhanced `scripts/generate_hub_stats.py` are designed as post-rebuild jobs that must be manually triggered on the ingest EC2 after each monthly index rebuild completes. Per `scripts/SCRIPTS.md`, these are separate utilities outside the main automated pipeline and do not integrate with CodePipeline or other infrastructure automation. They must be run by hand:

```bash
./venv/bin/python scripts/export_item_attribution.py
./venv/bin/python scripts/generate_hub_stats.py
```

**New Environment Variables**:
- `GA4_PROPERTY_ID` - GA4 numeric property ID (required for `item_data_providers.json` generation; no default)
- `GA4_SECRET_NAME` - AWS Secrets Manager secret name for GA4 service account (default: `dpla/ga4-service-account`)
- `GA4_CLICK_EVENT` - GA4 event name for item click-throughs (default: `click_item`)
- `GA4_HISTORY_START` - Earliest date for first-run GA4 history backfill (default: `2018-01-01`)
- `BATCH_SIZE` - Elasticsearch pagination batch size for item export (default: `10000`)

**New AWS Secrets Manager Key**:
- `dpla/ga4-service-account` - Must contain GA4 service account JSON credentials with `analytics.readonly` scope for Google Analytics API access

**New S3 Output Artifact**:
- `s3://dashboard-analytics/hub-stats/item_data_providers.json` - New cumulative JSON file mapping item IDs to data provider names, built from GA4 click-through events merged with Elasticsearch data

### Security Implications

The PR introduces credential handling for Google Analytics API:
- GA4 service account credentials are fetched from AWS Secrets Manager and used to authenticate with Google Analytics Data API
- Scripts require network access to Elasticsearch (internal) and Google Analytics API (external)
- The `item_data_providers.json` builder implements incremental backfilling: first run backfills all GA4 history from configured `GA4_HISTORY_START` date, subsequent runs only process the previous calendar month
- All boto3 sessions respect `AWS_PROFILE` environment variable or fall back to EC2 instance role credentials

### Summary of Changes

**`scripts/export_item_attribution.py`** (new, 153 lines):
- One-time export utility streaming all item records from the Elasticsearch `dpla_alias` index
- Exports gzipped JSONL file mapping each item ID to its hub (`provider.name`) and contributor (`dataProvider.name`)
- Paginates using `search_after` on `_id`, includes progress tracking, uploads result to S3
- Accepts `ES_HOST`, `ES_PORT`, `AWS_PROFILE`, and `BATCH_SIZE` environment variables
- Cleans up temporary local gzip file after upload or on failure

**`scripts/generate_hub_stats.py`** (enhanced, +202/-13 lines):
- Now generates three S3 JSON outputs instead of two: `hub_stats.json`, `hub_stats_bws.json`, and `item_data_providers.json`
- Elasticsearch queries now accept configurable per-request timeout (default 30s, raised to 60s for batch ID resolution)
- Core `build_stats()` function accepts optional `generated_at` timestamp so all produced JSON files share consistent generation time
- New GA4-backed item data pipeline:
  - Fetches GA4 service account credentials from Secrets Manager
  - Queries GA4 for click-through events over computed date range
  - Resolves item IDs from GA4 events to data provider names via batched Elasticsearch queries (1000 items per batch)
  - Merges newly resolved mappings into existing S3-stored `item_data_providers.json`
  - Handles missing S3 object gracefully by initializing empty structure

**New Dependencies**: `google-analytics-data`, `google-oauth2` (for GA4 service account authentication)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingestion3/pull/743?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->