### PR TITLE
Edit file harvester to accept both jsonl and zip files

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/file/FlFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/FlFileHarvester.scala
@@ -87,13 +87,18 @@ class FlFileHarvester(
 
   /** Executes the Florida harvest.
     *
-    * Accepts both ZIP archives and plain JSONL files in the endpoint directory.
-    * ZIP files are unpacked entry-by-entry; plain JSONL files are read directly.
+    * Accepts both ZIP archives and plain JSONL files in the endpoint directory
+    * or as a single S3 object. If the endpoint is an s3:// URI pointing at a
+    * single file (e.g. s3://dpla-hub-fl/SSDN-2026-05-24.jsonl), it is copied
+    * to a temp directory first via `aws s3 cp`. If it is an s3:// prefix
+    * (directory), it is synced. Local paths are used as-is.
     */
   override def harvest: DataFrame = {
     val harvestTime = System.currentTimeMillis()
     val unixEpoch = harvestTime / 1000L
-    val inFiles = new File(conf.harvest.endpoint.getOrElse("in"))
+    val endpoint = conf.harvest.endpoint.getOrElse("in")
+    val s3SubCmd = if (endpoint.startsWith("s3://") && !endpoint.endsWith("/")) "cp" else "sync"
+    val inFiles = LocalHarvester.resolveToLocalDir(endpoint, harvestTime, "fl-s3", conf.harvest.awsProfile, s3SubCmd)
 
     val logger = LogManager.getLogger(this.getClass)
 

--- a/src/main/scala/dpla/ingestion3/harvesters/file/FlFileHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/FlFileHarvester.scala
@@ -97,7 +97,10 @@ class FlFileHarvester(
     val harvestTime = System.currentTimeMillis()
     val unixEpoch = harvestTime / 1000L
     val endpoint = conf.harvest.endpoint.getOrElse("in")
-    val s3SubCmd = if (endpoint.startsWith("s3://") && !endpoint.endsWith("/")) "cp" else "sync"
+    val lowerEndpoint = endpoint.toLowerCase
+    val isS3Object =
+      endpoint.startsWith("s3://") && (lowerEndpoint.endsWith(".jsonl") || lowerEndpoint.endsWith(".zip"))
+    val s3SubCmd = if (isS3Object) "cp" else "sync"
     val inFiles = LocalHarvester.resolveToLocalDir(endpoint, harvestTime, "fl-s3", conf.harvest.awsProfile, s3SubCmd)
 
     val logger = LogManager.getLogger(this.getClass)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Modified `FlFileHarvester.harvest()` to accept both ZIP archives and plain JSONL files from local paths or S3 endpoints using the existing `LocalHarvester.resolveToLocalDir()` method. The harvester now intelligently selects between `aws s3 cp` (for single-file S3 URIs) and `aws s3 sync` (for S3 directory prefixes) based on the endpoint format, resolving either to a local directory where both file types are processed.

### Changes

- **FlFileHarvester.scala**: 
  - Added logic to determine S3 subcommand based on endpoint format (lines 100-101)
  - Updated `harvest()` to call `LocalHarvester.resolveToLocalDir()` with the computed subcommand and AWS profile (line 101)
  - Expanded javadoc to document ZIP/JSONL handling and S3 copy vs. sync behavior (lines 88-95)
  - Processing flow for ZIP files via `ZipInputStream` and JSONL files remains unchanged

### Deployment considerations

- **Requires ECS redeployment**: Changes to harvester logic require redeployment of the harvesting service to take effect
- **Uses existing AWS credentials**: Leverages existing `conf.harvest.awsProfile` configuration; no new environment variables or secrets added
- **Follows established pattern**: Implementation mirrors existing approach used in other file harvesters (OaiFileHarvester, NYPLFileHarvester, DlgFileHarvester, etc.) and the shared `LocalHarvester.resolveToLocalDir()` utility method

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingestion3/pull/744?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->