### PR TITLE
Slack notification adjustments.

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -305,10 +305,13 @@ slack_notify() {
     local payload
     payload=$(python3 -c "import json,sys; print(json.dumps({'channel':sys.argv[1],'text':sys.argv[2]}))" \
         "$channel" "$msg") || return 0
-    curl -s -X POST "https://slack.com/api/chat.postMessage" \
+    local response
+    response=$(curl -s -X POST "https://slack.com/api/chat.postMessage" \
         -H "Authorization: Bearer $token" \
         -H "Content-Type: application/json" \
-        -d "$payload" > /dev/null || true
+        -d "$payload") || return 1
+    python3 -c "import json,sys; d=json.loads(sys.argv[1]); sys.exit(0 if d.get('ok') else 1)" \
+        "$response" 2>/dev/null
 }
 
 # Start a background heartbeat that sends progress updates to Slack.

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -306,7 +306,8 @@ slack_notify() {
     payload=$(python3 -c "import json,sys; print(json.dumps({'channel':sys.argv[1],'text':sys.argv[2]}))" \
         "$channel" "$msg") || return 0
     local response
-    response=$(curl -s -X POST "https://slack.com/api/chat.postMessage" \
+    response=$(curl -s --connect-timeout 10 --max-time 30 \
+        -X POST "https://slack.com/api/chat.postMessage" \
         -H "Authorization: Bearer $token" \
         -H "Content-Type: application/json" \
         -d "$payload") || return 1

--- a/scripts/ingest.sh
+++ b/scripts/ingest.sh
@@ -14,15 +14,15 @@ source "$SCRIPT_DIR/common.sh"
 # Setup Java environment (8g default memory)
 setup_java "8g" || die "Failed to setup Java environment"
 
-# slack_notify_resilient — wraps slack_notify with one retry after 15s.
-# slack_notify (defined in common.sh) may swallow errors and always return 0,
-# so we always send twice with a gap for critical stage-checkpoint messages.
-# The brief duplicate on a healthy connection is intentional — a missed
-# "harvest complete" is worse than an occasional double-post.
+# slack_notify_resilient — sends a Slack notification with one retry on failure.
+# slack_notify now returns 0 on API success (ok:true) and 1 on failure.
+# The retry only fires if the first attempt failed, so no duplicate posts
+# on a healthy connection.
 slack_notify_resilient() {
-    slack_notify "$@" || true
-    sleep 15
-    slack_notify "$@" || log_warn "Slack notify failed on retry (message: ${1:-})"
+    if ! slack_notify "$@"; then
+        sleep 15
+        slack_notify "$@" || log_warn "Slack notify failed on retry (message: ${1:-})"
+    fi
 }
 
 usage() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR improves Slack notification reliability in the ingestion pipeline by:

1. **Enhanced `slack_notify` error handling** (`scripts/common.sh`): The function now validates Slack API responses by capturing the curl output and checking that the returned JSON contains `"ok": true`. Previously, curl output was discarded and API failures were silently ignored. The function now returns a non-zero exit code on Slack failures, enabling callers to detect and handle them.

2. **Added retry logic to `slack_notify_resilient`** (`scripts/ingest.sh`): The helper function now conditionally retries failed notifications after a 15-second delay. The retry only fires when the initial attempt fails, preventing duplicate posts on healthy connections. Retry failures are logged as warnings with the original message for debugging.

These changes are purely operational improvements to error handling and resilience—no changes to environment variables, configuration, infrastructure, or APIs. Scripts will behave identically on Slack success (no duplicate posts), but now properly surface and retry transient Slack failures instead of silently ignoring them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->