### PR TITLE
Fix generate_hub_stats.py script

### DIFF
--- a/scripts/generate_hub_stats.py
+++ b/scripts/generate_hub_stats.py
@@ -30,6 +30,7 @@ import json
 import os
 import urllib.request
 from datetime import datetime, timezone
+from typing import Optional
 
 import boto3
 import botocore.exceptions
@@ -113,7 +114,7 @@ def contributor_counts(hub_name: str, bws: bool = False) -> dict:
     return {b["key"]: b["doc_count"] for b in contributors_agg["buckets"]}
 
 
-def build_stats(bws: bool = False, generated_at: str | None = None) -> dict:
+def build_stats(bws: bool = False, generated_at: Optional[str] = None) -> dict:
     if generated_at is None:
         generated_at = datetime.now(timezone.utc).isoformat()
     totals = hub_totals(bws)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the `generate_hub_stats.py` script to use the older `Optional[str]` type annotation syntax instead of the modern `str | None` union syntax for the `generated_at` parameter in the `build_stats()` function. The import statement is also added to include `Optional` from the `typing` module. No functional changes or behavioral modifications are made—the code operates identically.

## Changes

**File: `scripts/generate_hub_stats.py`**
- Added import: `from typing import Optional`
- Updated function signature: `build_stats(bws: bool = False, generated_at: Optional[str] = None) -> dict`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->