### PR TITLE
Hathi Mapping Updates

### DIFF
--- a/ingest_python_scripts/README.md
+++ b/ingest_python_scripts/README.md
@@ -273,3 +273,5 @@ Make sure `sbt` is installed (`brew install sbt` on Mac) and `batch-process-dpla
 
 **NARA credentials expired**
 The `[nara]` profile in `~/.aws/credentials` on EC2 uses time-limited keys. Request new ones from NARA and update the profile.
+
+

--- a/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
@@ -282,11 +282,20 @@ class HathiMapping extends MarcXmlMapping {
     if (from974.nonEmpty) from974
     else
       // OAI harvest: 035 field contains "sdr-{code}.{barcode}" e.g. "sdr-miu.990000000400106381"
+      // Some records omit the dot and embed the barcode directly, e.g. "sdr-miu000000075"
+      // or include uppercase barcodes, e.g. "sdr-nrlfGLAD50600249-B".
+      // Strategy: try exact code first; if no match, strip trailing barcode noise
+      // (first digit or uppercase letter onward, then any trailing dash).
       marcFields(data, Seq("035"), Seq("a"))
         .flatMap(extractStrings)
         .find(_.startsWith("sdr-"))
-        .flatMap(_.stripPrefix("sdr-").split("\\.").headOption)
-        .flatMap(key => Try { dataProviderMapping(key) }.toOption)
+        .flatMap { sdr =>
+          val raw = sdr.stripPrefix("sdr-").split("\\.").head
+          Try { dataProviderMapping(raw) }.toOption.orElse {
+            val base = raw.replaceAll("[A-Z0-9].*$", "").stripSuffix("-")
+            Try { dataProviderMapping(base) }.toOption
+          }
+        }
         .map(nameOnlyAgent)
         .toSeq
   }
@@ -416,6 +425,7 @@ class HathiMapping extends MarcXmlMapping {
     "coo" -> "Cornell University",
     "dul1" -> "Duke University",
     "gri" -> "Getty Research Institute",
+    "gu" -> "Georgetown University",
     "hvd" -> "Harvard University",
     "ien" -> "Northwestern University",
     "inu" -> "Indiana University",
@@ -425,23 +435,41 @@ class HathiMapping extends MarcXmlMapping {
     "miu" -> "University of Michigan",
     "miua" -> "University of Michigan",
     "miun" -> "University of Michigan",
+    "msu" -> "Michigan State University",
     "nc01" -> "University of North Carolina",
     "ncs1" -> "North Carolina State University",
     "njp" -> "Princeton University",
+    "njr" -> "Rutgers University",
     "nnc1" -> "Columbia University",
     "nnc2" -> "Columbia University",
+    "nrlf" -> "Northern Regional Library Facility",
+    "nwu" -> "Northwestern University",
     "nyp" -> "New York Public Library",
+    "osu" -> "Ohio State University",
     "psia" -> "Penn State University",
     "pst" -> "Penn State University",
+    "pur" -> "Purdue University",
     "pur1" -> "Purdue University",
     "pur2" -> "Purdue University",
+    "txu" -> "University of Texas",
     "uc1" -> "University of California",
     "uc2" -> "University of California",
+    "ucbk" -> "University of California",
+    "ucd" -> "University of California",
+    "uci" -> "University of California",
+    "ucla" -> "University of California",
     "ucm" -> "Universidad Complutense de Madrid",
+    "ucr" -> "University of California",
+    "ucsc" -> "University of California",
+    "ucsd" -> "University of California",
     "ufl1" -> "University of Florida",
+    "ufdc" -> "University of Florida",
+    "uiowa" -> "University of Iowa",
+    "uiuc" -> "University of Illinois",
     "uiug" -> "University of Illinois",
     "uiuo" -> "University of Illinois",
     "umn" -> "University of Minnesota",
+    "unc" -> "University of North Carolina",
     "usu" -> "Utah State University Press",
     "uva" -> "University of Virginia",
     "wu" -> "University of Wisconsin",

--- a/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
@@ -272,14 +272,23 @@ class HathiMapping extends MarcXmlMapping {
     mintDplaItemUri(data)
 
   override def dataProvider(data: Document[NodeSeq]): ZeroToMany[EdmAgent] = {
-    // <datafield> tag = 974 <subfield> code = u
-    marcFields(data, Seq("974"), Seq("u"))
+    // <datafield> tag = 974 <subfield> code = u (file harvest)
+    val from974 = marcFields(data, Seq("974"), Seq("u"))
       .flatMap(extractStrings)
-      .flatMap(
-        _.splitAtDelimiter("\\.").slice(0, 1)
-      ) // split at "." and take first value
+      .flatMap(_.splitAtDelimiter("\\.").slice(0, 1))
       .flatMap(key => Try { dataProviderMapping(key) }.toOption)
       .map(nameOnlyAgent)
+
+    if (from974.nonEmpty) from974
+    else
+      // OAI harvest: 035 field contains "sdr-{code}.{barcode}" e.g. "sdr-miu.990000000400106381"
+      marcFields(data, Seq("035"), Seq("a"))
+        .flatMap(extractStrings)
+        .find(_.startsWith("sdr-"))
+        .flatMap(_.stripPrefix("sdr-").split("\\.").headOption)
+        .flatMap(key => Try { dataProviderMapping(key) }.toOption)
+        .map(nameOnlyAgent)
+        .toSeq
   }
 
   override def isShownAt(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
@@ -413,6 +422,7 @@ class HathiMapping extends MarcXmlMapping {
     "loc" -> "Library of Congress",
     "mdl" -> "Minnesota Digital Library",
     "mdp" -> "University of Michigan",
+    "miu" -> "University of Michigan",
     "miua" -> "University of Michigan",
     "miun" -> "University of Michigan",
     "nc01" -> "University of North Carolina",

--- a/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
@@ -27,10 +27,18 @@ class HathiMapping extends MarcXmlMapping {
   override def getProviderName: Option[String] = Some("hathitrust")
 
   override def originalId(implicit data: Document[NodeSeq]): ZeroToOne[String] =
-    // <controlfield> tag = 001
+    // <controlfield> tag = 001 (file harvest); fall back to OAI <identifier> (OAI harvest)
     controlfield(data, Seq("001"))
       .flatMap(extractStrings)
       .headOption
+      .orElse {
+        // OAI identifier looks like "oai:hathitrust.org:000000040" — take the last segment
+        (data \\ "identifier")
+          .headOption
+          .map(_.text.trim)
+          .map(_.split(":").last)
+          .filter(_.nonEmpty)
+      }
 
   // SourceResource mapping
 
@@ -190,17 +198,26 @@ class HathiMapping extends MarcXmlMapping {
       .map(_.mkString(". "))
       .map(eitherStringOrUri)
 
-  override def rights(data: Document[NodeSeq]): AtLeastOne[String] =
-    // <datafield> tag = 506 or 540
-    // <datafield> tag = 974          <subfield> code = r
-    (marcFields(data, Seq("974"), Seq("r")) ++ marcFields(
-      data,
-      Seq("506", "540")
-    ))
+  override def rights(data: Document[NodeSeq]): AtLeastOne[String] = {
+    // <datafield> tag = 974 <subfield> code = r (file harvest)
+    // <datafield> tag = 506 or 540 (fallback)
+    val from974 = (marcFields(data, Seq("974"), Seq("r")) ++ marcFields(data, Seq("506", "540")))
       .flatMap(extractStrings)
       .slice(0, 1)
       .flatMap(key => Try { rightsMapping(key) }.toOption)
       .map(_ + ". Learn more at http://www.hathitrust.org/access_use")
+
+    if (from974.nonEmpty) from974
+    else
+      // OAI harvest: derive from <setSpec> e.g. "hathitrust:pdus" → "pdus"
+      (data \\ "setSpec")
+        .map(_.text.trim)
+        .filter(s => s.startsWith("hathitrust:") && s != "hathitrust")
+        .map(_.split(":").last)
+        .flatMap(key => Try { rightsMapping(key) }.toOption)
+        .map(_ + ". Learn more at http://www.hathitrust.org/access_use")
+        .slice(0, 1)
+  }
 
   override def subject(data: Document[NodeSeq]): ZeroToMany[SkosConcept] =
     // <datafield> tag = any from subjectTags <subfield> where code is a letter (not a number)
@@ -266,11 +283,11 @@ class HathiMapping extends MarcXmlMapping {
   }
 
   override def isShownAt(data: Document[NodeSeq]): ZeroToMany[EdmWebResource] =
-    // <controlfield> tag = 001
-    controlfield(data, Seq("001"))
-      .flatMap(extractStrings)
+    // Reuses originalId so it works for both file and OAI harvests
+    originalId(data)
       .map(IS_SHOWN_AT_PREFIX + _)
       .map(stringOnlyWebResource)
+      .toSeq
 
   override def originalRecord(data: Document[NodeSeq]): ExactlyOne[String] =
     Utils.formatXml(data)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the HathiTrust provider mapping to improve support for both file harvests and OAI protocol harvests.

### Key Changes

**HathiMapping.scala** (73 insertions, 16 deletions):

- **originalId**: Now falls back to parsing OAI `<identifier>` (extracting the last colon-delimited segment) when MARC controlfield `001` is absent, enabling support for OAI harvest records
- **rights**: Prefers MARC `974$r` (with `506`/`540` as fallback) for file harvests; for OAI harvests, derives rights from `setSpec` values (e.g., `hathitrust:pdus` → `pdus`); both paths append the "Learn more at http://www.hathitrust.org/access_use" suffix
- **dataProvider**: Prefers MARC `974$u` (splitting on `.` and using the first segment); for OAI harvests, derives provider from MARC `035$a` by locating `sdr-` codes and applying `dataProviderMapping` with fallback to cleaned base strings
- **isShownAt**: Now reuses `originalId` to build the catalog URL, enabling correct behavior for both harvest types
- **dataProviderMapping**: Expanded with numerous institution code mappings including `gu`, `miu`, `msu`, `njr`, `nrlf`, `nwu`, `osu`, `pur`, `txu`, and expanded UC campus mappings (`ucbk`, `ucd`, `uci`, `ucla`, `ucr`, `ucsc`, `ucsd`), plus additional mappings for `ufdc`, `uiowa`, `uiuc`, and `unc`

**ingest_python_scripts/README.md** (2 insertions):
- Minor whitespace changes after troubleshooting section

### Deployment Note

**Requires manual pipeline redeployment** to take effect, as this modifies the provider mapping code compiled into the ingestion processor JAR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->