### PR TITLE
Issue 739: NARA audit

### DIFF
--- a/docs/ingestion/README_NARA.md
+++ b/docs/ingestion/README_NARA.md
@@ -415,7 +415,7 @@ cat ~/dpla/data/nara/harvest/OUTPUT/_LOGS/_SUMMARY.txt
  Base:   18,696,139 records (0 duplicates)
  Delta:  298,459 records (1,315 duplicates) -> 297,144 unique
  Merged: 18,789,995 = 18,696,139 + 93,856 new
-         203,288 updates, 93,288 updates
+         203,288 updates, 5 deletes
  Delete: 5 in file, 5 valid, 0 invalid
  Final:  18,789,995
 ```

--- a/docs/ingestion/README_NARA.md
+++ b/docs/ingestion/README_NARA.md
@@ -44,6 +44,9 @@ The `scripts/harvest/nara-ingest.sh` script automates the entire workflow:
 # Stop after merge (no mapping/enrichment/jsonl)
 ./scripts/harvest/nara-ingest.sh --month=202601 --skip-pipeline
 
+# Download the month's originalRecords from NARA's S3 bucket before preprocessing
+./scripts/harvest/nara-ingest.sh --month=202601 --s3-source=s3://nara-deliveries/2026/01/
+
 # Use a specific base harvest
 ./scripts/harvest/nara-ingest.sh --month=202601 --base=~/dpla/data/nara/harvest/20250429_000000-nara-OriginalRecord.avro
 
@@ -127,18 +130,24 @@ export JAVA_HOME=/Users/$USER/Library/Java/JavaVirtualMachines/openjdk-19.0.2/Co
 NARA delivers quarterly delta exports as sets of ZIP files organized by **export group**
 (a numeric code like `17.115`, `09.113`, etc.). Each month's delivery may contain:
 
-- **Multiple export groups**, each with one or more ZIP files
+- **Data ZIPs** — one or more ZIPs per export group, each containing XML record files
   - `2026-02-07_17.115_DESC_0001.zip` through `..._0010.zip`
-- **Delete files** (XML) listing NARA IDs to remove
+- **Delete XMLs** — files listing NARA IDs to be removed from the dataset
+  - `NAC_DESC_Deletes_001.xml`, `NAC_DESC_Deletes_002.xml`, etc.
+  - These may be at the top level of the delivery or inside a ZIP
+- **NaidsList roster XMLs** — files listing all NAIDs in an export group
   - `2026-02-07_14.041_DESC_NaidsList.xml`
+  - ⚠️ **These are NOT delete files.** They are membership rosters for each export group and
+    should be discarded during preprocessing. Do not place them in the `deletes/` directory.
 
-The ZIPs are located at: `~/dpla/data/nara/originalRecords/YYYYMM/`
+The ZIPs and loose XML files are located at: `~/dpla/data/nara/originalRecords/YYYYMM/`
 
 ### Naming Convention
 
 ```
-DATE_EXPORTGROUP_DESC_SEQNUM.zip     # data ZIP
-DATE_EXPORTGROUP_DESC_NaidsList.xml  # deletes file
+DATE_EXPORTGROUP_DESC_SEQNUM.zip      # data ZIP (unzip and repackage as tar.gz)
+NAC_DESC_Deletes_NNN.xml              # delete file (copy to deletes/)
+DATE_EXPORTGROUP_DESC_NaidsList.xml   # roster file (discard — NOT a delete file)
 ```
 
 ---
@@ -173,9 +182,22 @@ rm -rf $DEST/work
 **Move delete files separately:**
 
 ```bash
-# Copy delete XMLs (NaidsList files) to the deletes directory
-cp $SRC/*_DESC_NaidsList.xml $DEST/deletes/
+# Copy actual delete XMLs (NAC_DESC_Deletes_*.xml) to the deletes directory
+# These may be at the top level or inside ZIPs — check both locations
+cp $SRC/NAC_DESC_Deletes_*.xml $DEST/deletes/ 2>/dev/null || true
+
+# IMPORTANT: Do NOT copy NaidsList files to deletes/
+# NaidsList files (DATE_EXPORTGROUP_DESC_NaidsList.xml) are roster files — they
+# list all NAIDs in an export group and are NOT instructions to delete records.
+# Discard them:
+rm -f $SRC/*_DESC_NaidsList.xml
 ```
+
+> **Tip**: After preprocessing, verify that at least one delete file was found:
+> ```bash
+> find $DEST/deletes -name "*.xml" | wc -l
+> ```
+> A count of 0 is unusual and should be confirmed with NARA before proceeding.
 
 **Result structure:**
 
@@ -186,14 +208,15 @@ cp $SRC/*_DESC_NaidsList.xml $DEST/deletes/
   17.115_nara_delta.tar.gz
   ...
   deletes/
-    2026-02-07_14.041_DESC_NaidsList.xml
-    2026-02-08_09.019_DESC_NaidsList.xml
+    NAC_DESC_Deletes_001.xml    # actual delete files only
+    NAC_DESC_Deletes_002.xml
     ...
 ```
 
 > **Important**: The harvester reads ALL `.tar.gz` files in the delta directory.
 > Each tar.gz should contain only the XML data files for its export group.
-> Delete XML files must be in the `deletes/` subdirectory, not alongside the tar.gz files.
+> Delete XML files (`NAC_DESC_Deletes_*.xml`) must be in the `deletes/` subdirectory.
+> NaidsList roster files must NOT be placed in `deletes/`.
 
 ### Step 2: Sync Base Harvest from S3
 
@@ -262,7 +285,7 @@ sbt -java-home "$JAVA_HOME" \
 
 1. Path to base harvest (Avro directory)
 2. Path to delta harvest (Avro directory)
-3. Path to deletes directory (folder with `*NaidsList.xml` files)
+3. Path to deletes directory (folder with `NAC_DESC_Deletes_*.xml` files)
 4. Path for merged output (will be created)
 5. Spark master (`local[1]` recommended - see Performance section)
 
@@ -345,7 +368,7 @@ sbt ... "runMain ...HarvestEntry --output=~/dpla/data/nara/delta/202512/harvest 
 sbt ... "runMain ...NaraMergeUtil \
   ~/dpla/data/nara/harvest/20250429_000000-nara-OriginalRecord.avro \
   ~/dpla/data/nara/delta/202512/harvest/.../DELTA.avro \
-  ~/dpla/data/nara/delta/202512/deletes/ \
+  ~/dpla/data/nara/delta/202512/deletes/ \     # must contain NAC_DESC_Deletes_*.xml
   ~/dpla/data/nara/harvest/202512_000000-nara-OriginalRecord.avro \
   local[1]"
 
@@ -382,27 +405,52 @@ After each merge, check `_LOGS/_SUMMARY.txt` for:
 - **New + Update == Delta unique**: All delta records classified correctly
 - **Delete valid vs invalid**: Invalid deletes are IDs in the delete file not found in the dataset
 
+```bash
+cat ~/dpla/data/nara/harvest/OUTPUT/_LOGS/_SUMMARY.txt
+```
+
 ### Example Summary (Jan 2026)
 
 ```
  Base:   18,696,139 records (0 duplicates)
  Delta:  298,459 records (1,315 duplicates) -> 297,144 unique
  Merged: 18,789,995 = 18,696,139 + 93,856 new
-         203,288 updates, 93,856 inserts
- Delete: 2 in file, 0 valid, 2 invalid
+         203,288 updates, 93,288 updates
+ Delete: 5 in file, 5 valid, 0 invalid
  Final:  18,789,995
 ```
 
-### Operations CSV
+> **If Delete count is 0:** Check that the `NAC_DESC_Deletes_*.xml` files were correctly
+> identified and placed in the `deletes/` directory during preprocessing. A zero delete
+> count when delete files are present indicates the preprocessing glob is wrong.
 
-The merge also writes a CSV of every operation at `_LOGS/ops/`:
+### Operations CSV (Ops Log Review)
+
+The merge writes a detailed CSV of every operation at `_LOGS/ops/`. Review this after
+every merge to confirm the pipeline processed what was expected:
+
+```bash
+# Quick summary of operations by type
+awk -F',' 'NR>1 {counts[$2]++} END {for (op in counts) print counts[op], op}' \
+  ~/dpla/data/nara/harvest/OUTPUT/_LOGS/ops/part-*.csv | sort -rn
+```
+
+Expected operations after a healthy merge:
+- `insert` — new NAIDs not previously in the dataset
+- `update` — NAIDs in both base and delta (delta version wins)
+- `delete` — NAIDs found in both the base and the delete files (removed)
+- `invalid delete` — NAIDs in the delete file but not in the base (logged, no action)
 
 ```csv
 id,operation
 580001954,insert
 17426465,update
+9991234,delete
 1311955,invalid delete
 ```
+
+If you see **only** `invalid delete` and no `delete` operations despite having delete files,
+the delete XMLs were not processed correctly — re-check preprocessing.
 
 ### Pipeline Validation
 
@@ -537,7 +585,7 @@ du -sh /private/var/folders/*/T/blockmgr-* 2>/dev/null
       10.018_nara_delta.tar.gz        # one tar.gz per export group
       21.018_nara_delta.tar.gz
       deletes/                        # delete XMLs
-        2025-11-29_10.008_DESC_NaidsList.xml
+        NAC_DESC_Deletes_001.xml
       harvest/                        # delta harvest output
         nara/harvest/
           20260209_HHMMSS-nara-OriginalRecord.avro
@@ -547,7 +595,8 @@ du -sh /private/var/folders/*/T/blockmgr-* 2>/dev/null
       17.115_nara_delta.tar.gz
       ...
       deletes/
-        2026-02-07_14.041_DESC_NaidsList.xml
+        NAC_DESC_Deletes_001.xml
+        NAC_DESC_Deletes_002.xml
         ...
       harvest/
         nara/harvest/
@@ -576,11 +625,18 @@ du -sh /private/var/folders/*/T/blockmgr-* 2>/dev/null
 
 ## History
 
-| Date | Base | Delta | New | Updates | Deletes | Final |
-|------|------|-------|-----|---------|---------|-------|
-| 2025-04-29 | -- | -- | -- | -- | -- | 18,687,707 |
-| 2025-12 | 18,687,707 | 9,247 | 8,432 | 815 | 0 | 18,696,139 |
-| 2026-01 | 18,696,139 | 298,459 (297,144 unique) | 93,856 | 203,288 | 0 | 18,789,995 |
+| Date | Base | Delta | New | Updates | Deletes | Final | Notes |
+|------|------|-------|-----|---------|---------|-------|-------|
+| 2025-04-29 | -- | -- | -- | -- | -- | 18,687,707 | |
+| 2025-12 | 18,687,707 | 9,247 | 8,432 | 815 | 0 ⚠️ | 18,696,139 | Delete bug: NaidsList used instead of NAC_DESC_Deletes files |
+| 2026-01 | 18,696,139 | 298,459 (297,144 unique) | 93,856 | 203,288 | 0 ⚠️ | 18,789,995 | Delete bug: NaidsList used instead of NAC_DESC_Deletes files |
+
+> ⚠️ **Delete bug (fixed June 2026)**: Prior to the nara-ingest.sh fix in June 2026, the
+> preprocessing step copied `*NaidsList.xml` files to the `deletes/` directory instead of
+> the correct `NAC_DESC_Deletes_*.xml` files. NaidsList files use `<Naid>` tags while the
+> merge looks for `<naId>` tags, so no deletes were ever executed — they all appeared as
+> "invalid." Any records NARA instructed us to delete between April 2025 and June 2026 may
+> still be in the dataset. Retroactive reprocessing is a decision for the team.
 
 ---
 

--- a/ingest_python_scripts/nara/check_nara.py
+++ b/ingest_python_scripts/nara/check_nara.py
@@ -52,11 +52,12 @@ DATA_ROOT   = "/home/ec2-user/data"
 NARA_DATA   = f"{DATA_ROOT}/nara"
 
 STAGE_KEYWORDS = {
-    "jsonl":      ["JsonlEntry", "jsonl complete", ":white_check_mark: jsonl"],
-    "enrichment": ["EnrichEntry", "enrichment complete", ":white_check_mark: enrichment"],
-    "mapping":    ["MappingEntry", "IngestRemap", "mapping complete", ":white_check_mark: mapping"],
-    "merge":      ["NaraMergeUtil", "Merge complete", "merge complete"],
-    "harvest":    ["HarvestEntry", "FileHarvester", "harvest complete", "Preprocessing"],
+    "jsonl":        ["JsonlEntry", "jsonl complete", ":white_check_mark: jsonl"],
+    "enrichment":   ["EnrichEntry", "enrichment complete", ":white_check_mark: enrichment"],
+    "mapping":      ["MappingEntry", "IngestRemap", "mapping complete", ":white_check_mark: mapping"],
+    "merge":        ["NaraMergeUtil", "Merge complete", "merge complete"],
+    "harvest":      ["HarvestEntry", "FileHarvester", "harvest complete", "Preprocessing"],
+    "delete-gate":  ["zero-delete gate", "halted at zero-delete gate", "Zero-delete gate triggered"],
 }
 
 ALL_STAGE_REGEX = (
@@ -64,7 +65,8 @@ ALL_STAGE_REGEX = (
     "HarvestEntry|FileHarvester|Preprocessing|"
     "MappingEntry|IngestRemap|"
     "EnrichEntry|JsonlEntry|"
-    "harvest complete|merge complete|mapping complete|enrichment complete|jsonl complete"
+    "harvest complete|merge complete|mapping complete|enrichment complete|jsonl complete|"
+    "zero-delete gate|halted at zero-delete gate"
 )
 
 
@@ -346,19 +348,39 @@ def render(sections):
         lines.append(c(DIM, "  (no log file found)"))
 
     # SUMMARY
+    summary_text = derive_summary(is_running, current_stage, sections)
     lines.append("")
-    lines.append("SUMMARY: " + derive_summary(is_running, current_stage, sections))
+    lines.append("SUMMARY: " + summary_text)
+
+    # If the process halted at the zero-delete gate, show resume instructions
+    log_tail = sections.get("LOG_TAIL", "")
+    if not is_running and re.search(r"zero-delete gate|halted at zero-delete gate", log_tail, re.IGNORECASE):
+        lines.append("")
+        lines.append(c(YELLOW, "  ZERO-DELETE GATE — action required:"))
+        lines.append("  1. Review the merge summary above for valid/invalid delete counts.")
+        lines.append("  2. Check the delivery: were NAC_DESC_Deletes_*.xml files present?")
+        lines.append("  3. If 0 deletes is expected for this delivery, resume with:")
+        lines.append(c(DIM, "       python3 nara/launch_nara.py --skip-to-pipeline --skip-delete-check"))
+        lines.append("  4. Otherwise, investigate before re-running.")
+
     lines.append("")
     return "\n".join(lines)
 
 
 def derive_summary(is_running, current_stage, sections):
     if is_running:
+        if current_stage == "delete-gate":
+            return c(YELLOW, "running — waiting at zero-delete gate (operator action needed)")
         if current_stage:
             return c(YELLOW, f"running — currently in {current_stage}")
         return c(YELLOW, "running — stage unclear")
 
     log_tail = sections.get("LOG_TAIL", "")
+
+    # Zero-delete gate halt: process exited non-zero after the gate fired
+    if re.search(r"zero-delete gate|halted at zero-delete gate", log_tail, re.IGNORECASE):
+        return c(YELLOW, "HALTED — zero-delete gate (see below for resume instructions)")
+
     if re.search(r"\[SUCCESS\].*jsonl|jsonl complete|:white_check_mark: jsonl", log_tail, re.IGNORECASE):
         return c(GREEN, "complete — all stages done")
     merge_text = sections.get("MERGE_SUMMARY", "").strip()

--- a/ingest_python_scripts/nara/copy_nara.py
+++ b/ingest_python_scripts/nara/copy_nara.py
@@ -10,7 +10,7 @@ to ngc-storage01. EC2's default IAM role has write access to dpla-hub-nara.
 A direct cross-account sync isn't possible with a single credential set, so we:
   1. Download ZIPs from ngc-storage01 → /tmp/nara-<YYYYMM>/ on EC2 (using nara profile)
   2. Upload ZIPs from EC2 → s3://dpla-hub-nara/raw_ingest_files/<YYYYMM>/ (using EC2 role)
-  3. Move ZIPs from /tmp/nara-<YYYYMM>/ → ~/dpla/data/nara/originalRecords/<YYYYMM>/
+  3. Move ZIPs from /tmp/nara-<YYYYMM>/ → ~/data/nara/originalRecords/<YYYYMM>/
      (ready for nara-ingest.sh — no second download needed)
 
 After this script completes, run:

--- a/ingest_python_scripts/nara/launch_nara.py
+++ b/ingest_python_scripts/nara/launch_nara.py
@@ -9,7 +9,7 @@ Orchestrates the NARA monthly delta ingest:
 Prerequisites:
   - copy_nara.py must have already run for this month:
       • ZIPs copied to s3://dpla-hub-nara/raw_ingest_files/<YYYYMM>/
-      • ZIPs staged at ~/dpla/data/nara/originalRecords/<YYYYMM>/ on EC2
+      • ZIPs staged at ~/data/nara/originalRecords/<YYYYMM>/ on EC2
   - AWS CLI authenticated locally with SSM access
 
 Usage:
@@ -19,6 +19,17 @@ Usage:
     python3 nara/launch_nara.py --skip-to-pipeline --harvest /path/to/harvest.avro
     python3 nara/launch_nara.py --resume --month 202605            # re-attach to existing log
     python3 nara/launch_nara.py --resume --log /home/ec2-user/nara-ingest-202605.log
+
+Zero-delete gate:
+    After the merge, nara-ingest.sh checks whether any records were actually
+    deleted. If 0 valid deletes are found, it halts (non-interactively) and sends
+    a Slack notification. This script detects that halt and prompts you here:
+
+        Y = I've verified 0 deletes is expected — continue to pipeline
+        N = Abort so I can investigate before re-running
+
+    To bypass the gate upfront (if you already know this delivery has no deletes):
+        python3 nara/launch_nara.py --month 202605 --skip-delete-check
 """
 
 import argparse
@@ -193,10 +204,14 @@ def launch_ingest(month, log_path, extra_args=""):
     return pid
 
 
-def launch_skip_to_pipeline(harvest_path, log_path):
+def launch_skip_to_pipeline(harvest_path, log_path, skip_delete_check=False):
     step(2, "Launch nara-ingest.sh --skip-to-pipeline on EC2")
-    arg = f"--harvest={harvest_path}" if harvest_path else ""
-    cmd = f"bash {NARA_SCRIPT} --skip-to-pipeline {arg}".strip()
+    flags = ["--skip-to-pipeline"]
+    if harvest_path:
+        flags.append(f"--harvest={harvest_path}")
+    if skip_delete_check:
+        flags.append("--skip-delete-check")
+    cmd = f"bash {NARA_SCRIPT} {' '.join(flags)}"
     info(f"Command: {cmd}")
     info(f"Log:     {log_path}")
     print()
@@ -206,6 +221,65 @@ def launch_skip_to_pipeline(harvest_path, log_path):
     pid = ssm_bg(cmd, log_path)
     ok(f"Launched. PID: {pid}")
     return pid
+
+
+# ---------- Zero-delete gate ----------
+
+def extract_harvest_from_log(log_path):
+    """Pull the merged harvest path from the log's gate-halt message."""
+    try:
+        out = ssm_run(
+            f"grep -oE -- '--harvest=[^ ]+' {log_path} | tail -1 || true",
+            timeout_seconds=30,
+        ).strip()
+        if out.startswith("--harvest="):
+            return out[len("--harvest="):]
+    except Exception:
+        pass
+    # Fallback: scan for any OriginalRecord.avro path in the log
+    try:
+        out = ssm_run(
+            f"grep -oE '/[^ ]+OriginalRecord\\.avro' {log_path} | tail -1 || true",
+            timeout_seconds=30,
+        ).strip()
+        return out or None
+    except Exception:
+        return None
+
+
+def handle_delete_gate_halt(log_path):
+    """Called when tail_log detects the script halted at the zero-delete gate.
+
+    Shows a summary, prompts the operator to continue or abort, and if they
+    confirm, relaunches with --skip-to-pipeline --skip-delete-check.
+    """
+    print()
+    warn("=" * 66)
+    warn("  ZERO-DELETE GATE — nara-ingest.sh halted after merge")
+    warn("=" * 66)
+    print()
+    warn("The merge completed but 0 records were actually deleted.")
+    warn("A Slack notification was sent. Review before continuing:")
+    print()
+    info("  • Was a delete file (NAC_DESC_Deletes_*.xml) present in the delivery?")
+    info("  • Check: cat <merged-harvest>/_LOGS/_SUMMARY.txt")
+    info("  • If no deletes are expected for this delivery, continue.")
+    print()
+
+    harvest_path = extract_harvest_from_log(log_path)
+    if harvest_path:
+        info(f"  Merged harvest: {harvest_path}")
+    else:
+        warn("  Could not detect merged harvest path from log — you'll need to set --harvest manually.")
+
+    print()
+    confirm("Continue to pipeline despite 0 deletes? (confirm you've verified this)", default_yes=False)
+
+    # Relaunch as a new background job
+    label    = datetime.now().strftime("%Y%m%d-%H%M%S")
+    new_log  = f"{LOG_DIR}/nara-ingest-resume-{label}.log"
+    pid      = launch_skip_to_pipeline(harvest_path, new_log, skip_delete_check=True)
+    tail_log(pid, new_log)
 
 
 # ---------- Step 3: tail log ----------
@@ -239,7 +313,9 @@ def tail_log(pid, log_path):
 
             if alive in ("dead", ""):
                 print()
-                print(ssm_run(f"tail -40 {log_path}", timeout_seconds=30).strip())
+                log_tail = ssm_run(f"tail -40 {log_path}", timeout_seconds=30).strip()
+                print(log_tail)
+
                 # Read sidecar exit code written by ssm_bg wrapper
                 exit_file  = f"{log_path}.exitcode"
                 exit_raw   = ssm_run(
@@ -253,9 +329,15 @@ def tail_log(pid, log_path):
                     exit_code = int(exit_raw)
                 except ValueError:
                     exit_code = 1
+
                 if exit_code != 0:
+                    # Check if this was a zero-delete gate halt before raising
+                    if "zero-delete gate" in log_tail.lower():
+                        handle_delete_gate_halt(log_path)
+                        return
                     bad(f"NARA ingest FAILED (exit {exit_code}). See log: {log_path}")
                     raise RuntimeError(f"nara-ingest.sh exited {exit_code}")
+
                 ok(f"Process exited cleanly (exit 0).")
                 return
 
@@ -302,6 +384,8 @@ def main():
                         help="Explicit base harvest avro path")
     parser.add_argument("--force-sync",       action="store_true",
                         help="Force fresh S3 download of base harvest on EC2")
+    parser.add_argument("--skip-delete-check", action="store_true",
+                        help="Bypass the zero-delete gate (use when 0 deletes is expected)")
     parser.add_argument("--resume",           action="store_true",
                         help="Re-attach to an existing running ingest log")
     parser.add_argument("--log",
@@ -326,7 +410,10 @@ def main():
     if args.skip_to_pipeline:
         label    = args.month or datetime.now().strftime("%Y%m%d-%H%M%S")
         log_path = f"{LOG_DIR}/nara-ingest-{label}.log"
-        pid      = launch_skip_to_pipeline(args.harvest, log_path)
+        pid      = launch_skip_to_pipeline(
+            args.harvest, log_path,
+            skip_delete_check=args.skip_delete_check,
+        )
         tail_log(pid, log_path)
         return
 
@@ -356,6 +443,8 @@ def main():
         extra.append(f"--base={args.base}")
     if args.force_sync:
         extra.append("--force-sync")
+    if args.skip_delete_check:
+        extra.append("--skip-delete-check")
 
     pid = launch_ingest(month, log_path, extra_args=" ".join(extra))
 

--- a/scripts/communication/send-ingest-email.sh
+++ b/scripts/communication/send-ingest-email.sh
@@ -5,14 +5,18 @@
 #   ./scripts/send-ingest-email.sh <hub-name>
 #   ./scripts/send-ingest-email.sh <hub-name> <mapping-dir>
 #   ./scripts/send-ingest-email.sh --yes <hub-name>
+#   ./scripts/send-ingest-email.sh --email-override test@example.com <hub-name>
 #
 # Options:
-#   --yes, -y    Skip confirmation prompt and send immediately
+#   --yes, -y                   Skip confirmation prompt and send immediately
+#   --email-override <address>  Send to this address instead of the hub's configured
+#                               contacts. Useful for testing before sending to the
+#                               real hub. (e.g. --email-override ingest@dp.la)
 #
 # This script:
 #   1. Finds the most recent mapping output for the hub
 #   2. Reads the _SUMMARY file
-#   3. Sends an email to the hub's configured contacts
+#   3. Sends an email to the hub's configured contacts (or override address)
 
 set -euo pipefail
 
@@ -26,11 +30,16 @@ setup_java "4g" || die "Failed to setup Java environment"
 
 # Parse options
 SKIP_CONFIRM=false
+EMAIL_OVERRIDE=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --yes|-y)
             SKIP_CONFIRM=true
             shift
+            ;;
+        --email-override)
+            EMAIL_OVERRIDE="$2"
+            shift 2
             ;;
         -*)
             echo "Unknown option: $1"
@@ -43,14 +52,16 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ $# -lt 1 ]]; then
-    echo "Usage: $0 [--yes] <hub-name> [mapping-dir]"
+    echo "Usage: $0 [--yes] [--email-override <address>] <hub-name> [mapping-dir]"
     echo ""
     echo "Options:"
-    echo "  --yes, -y    Skip confirmation prompt and send immediately"
+    echo "  --yes, -y                   Skip confirmation prompt"
+    echo "  --email-override <address>  Override recipient (for testing)"
     echo ""
     echo "Examples:"
     echo "  $0 maryland"
     echo "  $0 --yes nara"
+    echo "  $0 --email-override ingest@dp.la --yes nara   # test run"
     echo "  $0 maryland /Users/scott/dpla/data/maryland/mapping/20260201_120000-maryland-MAP.avro"
     exit 1
 fi
@@ -63,10 +74,16 @@ MERGE_SUMMARY_PATH=""
 PROVIDER_NAME=$(get_provider_name "$HUB")
 EMAIL=$(get_hub_email "$HUB")
 
-if [[ -z "$EMAIL" ]]; then
+if [[ -z "$EMAIL" ]] && [[ -z "$EMAIL_OVERRIDE" ]]; then
     echo "ERROR: No email configured for hub '$HUB' in i3.conf"
     echo "Add: ${HUB}.email = \"contact@example.com\""
     exit 1
+fi
+
+# Apply override if set — replaces the hub's configured address entirely
+if [[ -n "$EMAIL_OVERRIDE" ]]; then
+    echo "⚠️  EMAIL OVERRIDE ACTIVE — sending to $EMAIL_OVERRIDE instead of configured contacts"
+    EMAIL="$EMAIL_OVERRIDE"
 fi
 
 # Find mapping directory if not specified
@@ -148,6 +165,9 @@ cd "$I3_HOME"
 EMAILER_ARGS="$MAPPING_DIR $HUB"
 if [[ -n "$MERGE_SUMMARY_PATH" ]]; then
     EMAILER_ARGS="$EMAILER_ARGS --merge-summary $MERGE_SUMMARY_PATH"
+fi
+if [[ -n "$EMAIL_OVERRIDE" ]]; then
+    EMAILER_ARGS="$EMAILER_ARGS --email-override $EMAIL_OVERRIDE"
 fi
 
 sbt -java-home "$JAVA_HOME" "runMain dpla.ingestion3.utils.Emailer $EMAILER_ARGS"

--- a/scripts/communication/send-ingest-email.sh
+++ b/scripts/communication/send-ingest-email.sh
@@ -57,6 +57,7 @@ fi
 
 HUB="$1"
 MAPPING_DIR="${2:-}"
+MERGE_SUMMARY_PATH=""
 
 # Get hub info using common.sh functions
 PROVIDER_NAME=$(get_provider_name "$HUB")
@@ -97,6 +98,9 @@ echo "Provider:     $PROVIDER_NAME"
 echo "Recipients:   $EMAIL"
 echo "Mapping:      $MAPPING_DIR"
 echo "Summary:      $SUMMARY_FILE"
+if [[ "$HUB" == "nara" ]]; then
+echo "(NARA merge stats will be auto-detected and included)"
+fi
 echo "=============================================="
 echo ""
 
@@ -120,15 +124,33 @@ else
     echo "Sending (--yes flag provided)..."
 fi
 
+# For NARA: find the most recent merge _SUMMARY.txt and include delete stats
+if [[ "$HUB" == "nara" ]]; then
+    NARA_HARVEST_DIR="${DPLA_DATA}/nara/harvest"
+    if [[ -d "$NARA_HARVEST_DIR" ]]; then
+        LATEST_HARVEST=$(ls -td "${NARA_HARVEST_DIR}"/*-nara-OriginalRecord.avro 2>/dev/null | head -1)
+        if [[ -n "$LATEST_HARVEST" && -f "$LATEST_HARVEST/_LOGS/_SUMMARY.txt" ]]; then
+            MERGE_SUMMARY_PATH="$LATEST_HARVEST/_LOGS/_SUMMARY.txt"
+            echo "Merge summary:  $MERGE_SUMMARY_PATH"
+        else
+            echo "WARNING: No merge _SUMMARY.txt found under $NARA_HARVEST_DIR — delete stats will be omitted from email."
+        fi
+    fi
+fi
+echo ""
+
 # Send email using the Scala Emailer
 echo "Sending email..."
 
 cd "$I3_HOME"
 
-# Use sbt to invoke the Emailer
-sbt -java-home "$JAVA_HOME" "runMain dpla.ingestion3.utils.Emailer \
-    $MAPPING_DIR \
-    $HUB"
+# Build the sbt command. For NARA, pass --merge-summary so delete stats appear in the email.
+EMAILER_ARGS="$MAPPING_DIR $HUB"
+if [[ -n "$MERGE_SUMMARY_PATH" ]]; then
+    EMAILER_ARGS="$EMAILER_ARGS --merge-summary $MERGE_SUMMARY_PATH"
+fi
+
+sbt -java-home "$JAVA_HOME" "runMain dpla.ingestion3.utils.Emailer $EMAILER_ARGS"
 
 if [[ $? -eq 0 ]]; then
     echo ""

--- a/scripts/harvest/nara-ingest.sh
+++ b/scripts/harvest/nara-ingest.sh
@@ -1012,15 +1012,11 @@ main() {
             merge_datestamp="$month"
         fi
 
-        # 2a. (Optional) Download delivery from NARA's S3 bucket
+        # 2a. (Optional) Download delivery from NARA's S3 bucket.
+        # Always run sync even when files already exist — aws s3 sync is
+        # idempotent and will resume any partial or interrupted download.
         if [ -n "$S3_SOURCE" ]; then
-            local existing_files
-            existing_files=$(find "$NARA_ORIGINALS/$month" -type f 2>/dev/null | wc -l | tr -d ' ')
-            if [ "$existing_files" -gt 0 ]; then
-                print_info "Source files already present in $NARA_ORIGINALS/$month ($existing_files files). Skipping S3 source sync."
-            else
-                sync_from_nara_s3 "$S3_SOURCE" "$month"
-            fi
+            sync_from_nara_s3 "$S3_SOURCE" "$month"
         fi
 
         # 2b. Preprocess

--- a/scripts/harvest/nara-ingest.sh
+++ b/scripts/harvest/nara-ingest.sh
@@ -121,8 +121,20 @@ Options:
                     Skip directly to pipeline using existing merged harvest
   --harvest=<path>  Specify harvest path for --skip-to-pipeline
 
+  --skip-delete-check
+                    Bypass the zero-delete gate (see below). Use this when
+                    you've confirmed that 0 deletes is expected for this delivery.
+
   --dry-run         Show what would be done without executing
   --help            Show this help message
+
+Zero-Delete Gate:
+  After each merge, the script checks whether any records were actually deleted.
+  If the merge reports 0 valid deletes and delete files were present, the script
+  sends a Slack warning and pauses:
+    - Interactive (TTY): prompts to confirm or halt (30s timeout → halt)
+    - Non-interactive (EC2/cron): halts immediately with resume instructions
+  To resume after a halt: re-run with --skip-to-pipeline --harvest=<path> --skip-delete-check
 
 Environment Variables:
   HARVEST_SBT_OPTS       sbt launcher JVM opts for harvest step  (default: -Xmx12g)
@@ -151,6 +163,9 @@ Examples:
 
   # Download April 2026 delivery from NARA's S3, then run full ingest
   ./nara-ingest.sh --month=202604 --s3-source=s3://ngc-storage01/dpla-bimonthly-report/2026/M04/
+
+  # Skip the zero-delete gate (confirmed no deletes in this delivery)
+  ./nara-ingest.sh --month=202604 --skip-delete-check
 USAGE
     exit 1
 }
@@ -564,6 +579,100 @@ run_merge() {
 }
 
 # ============================================================================
+# Zero-Delete Gate
+#
+# After a merge, checks whether any records were actually deleted. If the
+# merge reports 0 valid deletes and delete files were present in the deletes/
+# dir, this is suspicious (could be a naming-pattern bug or a bad delivery).
+#
+# Behavior:
+#   - Interactive (TTY attached): prompts operator to confirm or halt.
+#     30-second timeout defaults to halt for safety.
+#   - Non-interactive (EC2/cron/no-TTY): halts with Slack notice and
+#     instructions to resume via --skip-to-pipeline --skip-delete-check.
+#   - --skip-delete-check flag: bypasses gate entirely (use when you've
+#     confirmed that 0 deletes is expected for this specific delivery).
+# ============================================================================
+
+check_delete_gate() {
+    local month="$1"
+    local merged_harvest="$2"
+
+    if [ "${SKIP_DELETE_CHECK:-false}" = true ]; then
+        print_info "Zero-delete gate bypassed (--skip-delete-check)"
+        return 0
+    fi
+
+    local summary_file="$merged_harvest/_LOGS/_SUMMARY.txt"
+    if [ ! -f "$summary_file" ]; then
+        print_info "No _SUMMARY.txt found — skipping delete gate check"
+        return 0
+    fi
+
+    # Parse valid delete count from the "Delete: N in file, M valid, K invalid" line
+    local valid_deletes
+    valid_deletes=$(grep -iE "^[[:space:]]*Delete:" "$summary_file" \
+        | grep -oE '[0-9]+ valid' | grep -oE '^[0-9]+' || true)
+    valid_deletes="${valid_deletes:-0}"
+
+    if [ "$valid_deletes" -gt 0 ]; then
+        print_info "Delete gate: $valid_deletes record(s) deleted — OK"
+        return 0
+    fi
+
+    # 0 valid deletes — check whether delete files were actually present
+    local delta_dir="$NARA_DATA/delta/$month"
+    local delete_file_count
+    delete_file_count=$(find "$delta_dir/deletes" -name "*.xml" -type f 2>/dev/null \
+        | wc -l | tr -d ' ')
+
+    local context_msg
+    local severity=":warning:"
+    if [ "$delete_file_count" -gt 0 ]; then
+        context_msg="${delete_file_count} delete file(s) were in \`$delta_dir/deletes/\` but *0 records were actually deleted*. This may indicate a file naming mismatch — check that delete files are named \`NAC_DESC_Deletes_*.xml\` and not \`*NaidsList*.xml\`."
+        severity=":rotating_light:"
+    else
+        context_msg="No delete files were found during preprocessing. 0 deletes may be expected for this delivery — verify with NARA."
+    fi
+
+    print_info ""
+    print_info "⚠️  Zero-delete gate triggered for $month"
+    print_info "   $context_msg"
+    print_info "   Summary: $summary_file"
+    print_info ""
+
+    slack_notify "${severity} *nara merge: 0 valid deletes* (\`$month\`)\n${context_msg}\nSummary: \`$(basename "$merged_harvest")/_LOGS/_SUMMARY.txt\`"
+
+    local resume_cmd="./nara-ingest.sh --skip-to-pipeline --harvest=$merged_harvest --skip-delete-check"
+
+    if [ -t 0 ]; then
+        # Interactive — give operator a chance to confirm or halt
+        echo ""
+        print_info "Continue to pipeline despite 0 deletes? [y/N]  (30s timeout → halt)"
+        local answer=""
+        if read -r -t 30 answer 2>/dev/null && [[ "$answer" =~ ^[Yy]$ ]]; then
+            print_info "Continuing to pipeline (manual confirmation)"
+            slack_notify ":arrow_forward: *nara: continuing pipeline* despite 0 deletes — operator confirmed"
+            return 0
+        else
+            print_error "Halted at zero-delete gate."
+            print_error "To resume:  $resume_cmd"
+            slack_notify ":x: *nara ingest halted* — 0 deletes not confirmed by operator.\nTo resume: \`$resume_cmd\`"
+            TRAP_HANDLED=true
+            exit 1
+        fi
+    else
+        # Non-interactive (EC2, cron, tmux without stdin) — halt and explain
+        print_error "Non-interactive mode: halting at zero-delete gate."
+        print_error "Confirm the delivery has no deletes, then resume with:"
+        print_error "  $resume_cmd"
+        slack_notify ":x: *nara ingest halted* (non-interactive) — 0 deletes not confirmed.\nTo resume after verifying: \`$resume_cmd\`"
+        TRAP_HANDLED=true
+        exit 1
+    fi
+}
+
+# ============================================================================
 # Pipeline (Mapping -> Enrichment -> JSON-L)
 # ============================================================================
 
@@ -723,6 +832,7 @@ main() {
     SKIP_TO_PIPELINE=false
     EXPLICIT_HARVEST=""
     S3_SOURCE=""
+    SKIP_DELETE_CHECK=false
     DRY_RUN=false
 
     while [[ $# -gt 0 ]]; do
@@ -761,6 +871,10 @@ main() {
                 ;;
             --harvest=*)
                 EXPLICIT_HARVEST="${1#*=}"
+                shift
+                ;;
+            --skip-delete-check)
+                SKIP_DELETE_CHECK=true
                 shift
                 ;;
             --dry-run)
@@ -810,6 +924,15 @@ main() {
 
         print_info "Resuming pipeline with: $MERGED_HARVEST"
         slack_notify ":arrow_forward: *nara ingest resuming* — pipeline from \`$(basename "$MERGED_HARVEST")\`"
+
+        # Infer the month from the harvest path for the delete gate check.
+        # The deletes/ dir may not exist if this is a cross-session resume, so
+        # check_delete_gate handles a missing directory gracefully (count = 0 →
+        # "no delete files" branch). Pass a synthesized month from the datestamp.
+        local _resume_month
+        _resume_month=$(basename "$MERGED_HARVEST" | grep -oE '^[0-9]{6}' || echo "unknown")
+        check_delete_gate "$_resume_month" "$MERGED_HARVEST"
+
         run_pipeline
         run_post_pipeline
 
@@ -934,6 +1057,11 @@ main() {
         else
             run_merge "$month" "$merge_datestamp"
         fi
+
+        # Gate: warn + pause if 0 records were actually deleted
+        # (Only meaningful before the pipeline runs — skip for intermediate months
+        # where --skip-pipeline was not set but we still want to gate the final run)
+        check_delete_gate "$month" "$MERGED_HARVEST"
 
         # Use this month's merged output as the base for the next month
         BASE_HARVEST="$MERGED_HARVEST"

--- a/scripts/harvest/nara-ingest.sh
+++ b/scripts/harvest/nara-ingest.sh
@@ -108,6 +108,13 @@ Options:
                     Override output datestamp (default: today).
                     Used for the final merged harvest directory name.
 
+  --s3-source=<s3://...>
+                    S3 prefix to sync from NARA's bucket before preprocessing.
+                    Uses the [nara] AWS profile. Files are downloaded to
+                    ~/dpla/data/nara/originalRecords/YYYYMM/ before the normal
+                    preprocess step runs.
+                    Example: --s3-source=s3://ngc-storage01/dpla-bimonthly-report/2026/M04/
+
   --skip-preprocess Skip preprocessing (use existing delta/ directory)
   --skip-pipeline   Stop after merge (don't run mapping/enrichment/jsonl)
   --skip-to-pipeline
@@ -141,6 +148,9 @@ Examples:
 
   # Use a specific base instead of S3
   ./nara-ingest.sh --month=202601 --base=~/dpla/data/nara/harvest/202512_000000-nara-OriginalRecord.avro
+
+  # Download April 2026 delivery from NARA's S3, then run full ingest
+  ./nara-ingest.sh --month=202604 --s3-source=s3://ngc-storage01/dpla-bimonthly-report/2026/M04/
 USAGE
     exit 1
 }
@@ -301,11 +311,36 @@ sync_outputs_to_s3() {
 }
 
 # ============================================================================
+# NARA S3 Source Sync
+#
+# Downloads a delivery from NARA's bucket (ngc-storage01) to the local
+# originalRecords directory using the [nara] AWS profile.
+# ============================================================================
+
+sync_from_nara_s3() {
+    local s3_prefix="$1"
+    local month="$2"
+    local dest="$NARA_ORIGINALS/$month"
+
+    print_step "Syncing NARA delivery from $s3_prefix ..."
+    mkdir -p "$dest"
+
+    aws s3 sync "$s3_prefix" "$dest/" --profile nara
+
+    local file_count
+    file_count=$(find "$dest" -type f | wc -l | tr -d ' ')
+    print_success "Downloaded $file_count file(s) to $dest"
+    slack_notify ":arrow_down: *nara S3 source sync complete* — $file_count file(s) from \`$s3_prefix\`"
+}
+
+# ============================================================================
 # Preprocessing
 #
 # NARA delivers ZIPs organized by export group (e.g., 17.115_DESC_0001.zip).
 # Each export group may have multiple ZIPs that need to be combined into a
-# single tar.gz. Delete files (*NaidsList.xml) are separated out.
+# single tar.gz. Real delete files (NAC_DESC_Deletes_*.xml) are separated out.
+# NaidsList files (DATE_GROUP_NaidsList.xml) are export group rosters — not
+# delete lists — and are discarded.
 # ============================================================================
 
 preprocess_month() {
@@ -322,14 +357,16 @@ preprocess_month() {
 
     mkdir -p "$dest_dir/deletes"
 
-    # Step 1: Move delete files (NaidsList.xml) to deletes/
+    # Step 1: Copy real delete files (NAC_DESC_Deletes_*.xml) to deletes/.
+    # NaidsList files are export-group rosters used for reconciliation, not
+    # delete lists — they are intentionally ignored here.
     local delete_count=0
-    for f in "$src_dir"/*_NaidsList.xml "$src_dir"/*NaidsList*.xml; do
+    for f in "$src_dir"/NAC_DESC_Deletes_*.xml; do
         [ -f "$f" ] || continue
         cp "$f" "$dest_dir/deletes/"
         ((delete_count++)) || true
     done
-    print_info "Copied $delete_count delete file(s) to $dest_dir/deletes/"
+    print_info "Copied $delete_count top-level delete file(s) to $dest_dir/deletes/"
 
     # Step 2: Identify unique export groups from ZIP filenames
     # Naming pattern: DATE_EXPORTGROUP_DESC_SEQNUM.zip
@@ -374,7 +411,14 @@ preprocess_month() {
             continue
         fi
 
-        # Remove any delete files that ended up in the work dir
+        # Extract any delete files that came out of the ZIPs into deletes/,
+        # then remove both delete and NaidsList files so they are not bundled
+        # into the data tar.gz.
+        find "$work_dir" -name "NAC_DESC_Deletes_*.xml" | while IFS= read -r f; do
+            cp "$f" "$dest_dir/deletes/"
+            ((delete_count++)) || true
+        done
+        find "$work_dir" -name "NAC_DESC_Deletes_*.xml" -delete 2>/dev/null || true
         find "$work_dir" -name "*NaidsList*" -delete 2>/dev/null || true
 
         # Count XML data files
@@ -404,6 +448,18 @@ preprocess_month() {
     if [ "$tgz_count" -eq 0 ]; then
         print_error "No tar.gz archives created. Check ZIP file naming patterns."
         exit 1
+    fi
+
+    # Sanity check: report delete file count. Zero is not an error (some deliveries
+    # genuinely contain no deletes) but is worth logging prominently so it doesn't
+    # silently go unnoticed.
+    local actual_deletes
+    actual_deletes=$(find "$dest_dir/deletes" -name "*.xml" -type f | wc -l | tr -d ' ')
+    if [ "$actual_deletes" -eq 0 ]; then
+        print_info "⚠️  No delete files found for $month — verify this is expected for this delivery"
+        slack_notify_resilient ":warning: *nara preprocess $month* — 0 delete files found (expected for some deliveries; verify)"
+    else
+        print_info "Delete files: $actual_deletes file(s) in $dest_dir/deletes/"
     fi
 }
 
@@ -666,6 +722,7 @@ main() {
     SKIP_PIPELINE=false
     SKIP_TO_PIPELINE=false
     EXPLICIT_HARVEST=""
+    S3_SOURCE=""
     DRY_RUN=false
 
     while [[ $# -gt 0 ]]; do
@@ -684,6 +741,10 @@ main() {
                 ;;
             --datestamp=*)
                 OUTPUT_DATESTAMP="${1#*=}"
+                shift
+                ;;
+            --s3-source=*)
+                S3_SOURCE="${1#*=}"
                 shift
                 ;;
             --skip-preprocess)
@@ -828,7 +889,18 @@ main() {
             merge_datestamp="$month"
         fi
 
-        # 2a. Preprocess
+        # 2a. (Optional) Download delivery from NARA's S3 bucket
+        if [ -n "$S3_SOURCE" ]; then
+            local existing_files
+            existing_files=$(find "$NARA_ORIGINALS/$month" -type f 2>/dev/null | wc -l | tr -d ' ')
+            if [ "$existing_files" -gt 0 ]; then
+                print_info "Source files already present in $NARA_ORIGINALS/$month ($existing_files files). Skipping S3 source sync."
+            else
+                sync_from_nara_s3 "$S3_SOURCE" "$month"
+            fi
+        fi
+
+        # 2b. Preprocess
         if [ "$SKIP_PREPROCESS" != true ]; then
             # Check if already preprocessed (tar.gz files exist)
             local existing_tgz
@@ -842,7 +914,7 @@ main() {
             print_info "Skipping preprocessing (--skip-preprocess)"
         fi
 
-        # 2b. Delta Harvest
+        # 2c. Delta Harvest
         # Check if already harvested
         local existing_harvest
         existing_harvest=$(find "$NARA_DATA/delta/$month/harvest" -type d -name "*-nara-OriginalRecord.avro" 2>/dev/null | sort | tail -1)
@@ -853,7 +925,7 @@ main() {
             run_delta_harvest "$month"
         fi
 
-        # 2c. Merge
+        # 2d. Merge
         # Check if already merged
         local existing_merge="$NARA_HARVEST/${merge_datestamp}_000000-nara-OriginalRecord.avro"
         if [ -d "$existing_merge" ] && [ -f "$existing_merge/_LOGS/_SUMMARY.txt" ]; then

--- a/src/main/scala/dpla/ingestion3/utils/Emailer.scala
+++ b/src/main/scala/dpla/ingestion3/utils/Emailer.scala
@@ -40,22 +40,46 @@ object Emailer {
 
   /**
     * Main method for CLI invocation
-    * Usage: Emailer <mapping-dir> <hub-name> [conf-file]
+    *
+    * Usage:
+    *   Emailer <mapping-dir> <hub-name> [conf-file] [--merge-summary <path>]
+    *
+    * --merge-summary <path>
+    *   Path to a NaraMergeUtil _SUMMARY.txt file. When provided, a "NARA Merge
+    *   Statistics" section (record counts, delete stats) is prepended to the
+    *   mapping summary in the email body. Intended for the nara hub only.
     */
   def main(args: Array[String]): Unit = {
     if (args.length < 2) {
-      System.err.println("Usage: Emailer <mapping-dir> <hub-name> [conf-file]")
+      System.err.println("Usage: Emailer <mapping-dir> <hub-name> [conf-file] [--merge-summary <path>]")
       System.err.println("Example: Emailer /path/to/mapping/dir nara")
-      System.err.println("         Emailer /path/to/mapping/dir nara /path/to/i3.conf")
+      System.err.println("         Emailer /path/to/mapping/dir nara /path/to/i3.conf --merge-summary /path/to/harvest/_LOGS/_SUMMARY.txt")
       System.exit(1)
     }
 
-    val mappingDir = args(0)
-    val hubName = args(1)
+    // Pull out --merge-summary <path> before processing positional args
+    val argList = args.toList
+    val mergeSummaryPath: Option[String] = {
+      val idx = argList.indexOf("--merge-summary")
+      if (idx >= 0 && idx + 1 < argList.length) Some(argList(idx + 1)) else None
+    }
+
+    // Strip the flag and its value to get clean positional args
+    val positionalArgs: List[String] = {
+      var skipNext = false
+      argList.filter { a =>
+        if (skipNext) { skipNext = false; false }
+        else if (a == "--merge-summary") { skipNext = true; false }
+        else true
+      }
+    }
+
+    val mappingDir = positionalArgs(0)
+    val hubName    = positionalArgs(1)
 
     // Get config file path from args or environment
-    val confPath = if (args.length >= 3) {
-      args(2)
+    val confPath = if (positionalArgs.length >= 3) {
+      positionalArgs(2)
     } else {
       Option(System.getenv("I3_CONF"))
         .getOrElse(s"${System.getProperty("user.home")}/dpla/code/ingestion3-conf/i3.conf")
@@ -75,7 +99,7 @@ object Emailer {
     val subject = s"DPLA Ingest Summary for $providerName - $currentMonth"
 
     // Send email
-    emailSummaryWithSubject(mappingDir, subject, conf)
+    emailSummaryWithSubject(mappingDir, subject, conf, mergeSummaryPath)
   }
 
   /**
@@ -94,9 +118,21 @@ object Emailer {
   }
 
   /**
-    * Send email summary with custom subject
+    * Send email summary with custom subject.
+    *
+    * @param mapOutput        Path to the mapping output directory (contains _SUMMARY)
+    * @param subject          Email subject line
+    * @param i3conf           Loaded i3.conf
+    * @param mergeSummaryPath Optional path to NaraMergeUtil's _SUMMARY.txt. When
+    *                         supplied, a "NARA Merge Statistics" section is prepended
+    *                         to the mapping summary in the email body.
     */
-  def emailSummaryWithSubject(mapOutput: String, subject: String, i3conf: i3Conf): Unit = {
+  def emailSummaryWithSubject(
+      mapOutput: String,
+      subject: String,
+      i3conf: i3Conf,
+      mergeSummaryPath: Option[String] = None
+  ): Unit = {
     val rawEmails = i3conf.email.getOrElse("tech@dp.la")
     val emails = normalizeEmails(rawEmails)
 
@@ -104,10 +140,14 @@ object Emailer {
     println(s"Raw emails from config: $rawEmails")
     println(s"Normalized emails: ${emails.mkString(", ")}")
 
-    val _summary = s"$mapOutput/_SUMMARY"
+    val _summary    = s"$mapOutput/_SUMMARY"
     val zipped_logs = s"$mapOutput/_LOGS/logs.zip"
 
-    val body = emailBody(_summary)
+    val mergeSection = mergeSummaryPath
+      .filter(p => new File(p).exists())
+      .map(formatMergeStats)
+
+    val body = emailBody(_summary, mergeSection)
 
     val attachment: Option[File] = zip(zipped_logs, mapOutput) match {
       case Some(z) => if (z.length() < 7485760) Some(z) else None
@@ -116,10 +156,76 @@ object Emailer {
 
     send(
       recipients = emails,
-      subject = subject,
-      text = body,
+      subject    = subject,
+      text       = body,
       attachment = attachment
     )
+  }
+
+  /**
+    * Parse a NaraMergeUtil _SUMMARY.txt and return a formatted HTML block
+    * suitable for inclusion in the ingest summary email.
+    *
+    * The summary file has labelled lines like:
+    *   " record count 18,696,139"
+    *   " valid deletes (IDs in merged dataset): 5"
+    * We extract the values we care about and render them in a clean table.
+    */
+  private def formatMergeStats(summaryPath: String): String = {
+    val source = Source.fromFile(summaryPath)
+    val text = try source.mkString finally source.close()
+
+    def extract(pattern: scala.util.matching.Regex): String =
+      pattern.findFirstMatchIn(text).map(_.group(1).trim).getOrElse("—")
+
+    // Base
+    val baseLines   = text.split("\n").dropWhile(!_.contains("Base")).take(10).mkString("\n")
+    val baseTotal   = extract("""\|\s*record count\s+([\d,]+)""".r.unanchored)
+
+    // Delta
+    val deltaTotal  = extract("""\|\s*record count:\s+([\d,]+)""".r.unanchored)
+    val deltaDups   = extract("""\|\s*duplicate count:\s+([\d,]+)""".r.unanchored)
+    val deltaUnique = extract("""\|\s*unique count:\s+([\d,]+)""".r.unanchored)
+
+    // Merged
+    val mergeNew    = extract("""\|\s*new:\s+([\d,]+)""".r.unanchored)
+    val mergeUpdate = extract("""\|\s*update:\s+([\d,]+)""".r.unanchored)
+    val mergeActual = extract("""\|\s*total \[actual\]:\s+([\d,]+)""".r.unanchored)
+
+    // Delete
+    val delInFile   = extract("""\|\s*ids to delete specified at path:\s+([\d,]+)""".r.unanchored)
+    val delValid    = extract("""\|\s*valid deletes \(IDs in merged dataset\):\s+([\d,]+)""".r.unanchored)
+    val delInvalid  = extract("""\|\s*invalid deletes \(IDs not in merged dataset\):\s+([\d,]+)""".r.unanchored)
+    val delActual   = extract("""\|\s*actual removed.*?:\s+([\d,]+)""".r.unanchored)
+
+    // Final
+    val finalTotal  = extract("""\|\s*total \[actual\]:\s+([\d,]+) = """.r.unanchored)
+
+    val zeroDeleteWarning =
+      if (delValid == "0" || delValid == "—")
+        "\n<b>⚠️  Note: 0 records were deleted this cycle.</b> " +
+        "If delete files were expected in this delivery, please contact DPLA at tech@dp.la.\n"
+      else ""
+
+    s"""<b>NARA Merge Statistics</b>
+       |$zeroDeleteWarning
+       |<table style="border-collapse:collapse;font-family:monospace;font-size:13px">
+       |<tr><td colspan="2" style="padding:4px 8px;background:#f0f0f0"><b>Base</b></td></tr>
+       |<tr><td style="padding:2px 8px 2px 16px">Records in base</td><td style="padding:2px 8px">$baseTotal</td></tr>
+       |<tr><td colspan="2" style="padding:4px 8px;background:#f0f0f0"><b>Delta (this delivery)</b></td></tr>
+       |<tr><td style="padding:2px 8px 2px 16px">Total records in delivery</td><td style="padding:2px 8px">$deltaTotal</td></tr>
+       |<tr><td style="padding:2px 8px 2px 16px">Duplicates removed</td><td style="padding:2px 8px">$deltaDups</td></tr>
+       |<tr><td style="padding:2px 8px 2px 16px">Unique records processed</td><td style="padding:2px 8px">$deltaUnique</td></tr>
+       |<tr><td colspan="2" style="padding:4px 8px;background:#f0f0f0"><b>Changes applied</b></td></tr>
+       |<tr><td style="padding:2px 8px 2px 16px">New records added</td><td style="padding:2px 8px">$mergeNew</td></tr>
+       |<tr><td style="padding:2px 8px 2px 16px">Existing records updated</td><td style="padding:2px 8px">$mergeUpdate</td></tr>
+       |<tr><td style="padding:2px 8px 2px 16px">Records deleted (valid)</td><td style="padding:2px 8px">$delValid</td></tr>
+       |<tr><td style="padding:2px 8px 2px 16px">Delete IDs not found (invalid)</td><td style="padding:2px 8px">$delInvalid</td></tr>
+       |<tr><td style="padding:2px 8px 2px 16px">Delete IDs in file</td><td style="padding:2px 8px">$delInFile</td></tr>
+       |<tr><td colspan="2" style="padding:4px 8px;background:#f0f0f0"><b>Final</b></td></tr>
+       |<tr><td style="padding:2px 8px 2px 16px"><b>Total records in DPLA</b></td><td style="padding:2px 8px"><b>$mergeActual</b></td></tr>
+       |</table>
+       |<br>""".stripMargin
   }
 
   private lazy val suffix =
@@ -163,7 +269,7 @@ object Emailer {
     )
   }
 
-  private def emailBody(summaryFile: String): String = {
+  private def emailBody(summaryFile: String, mergeSection: Option[String] = None): String = {
     // READ in _SUMMARY file
     val source: BufferedSource = Source.fromFile(summaryFile)
     val lines =
@@ -172,10 +278,14 @@ object Emailer {
       } finally {
         source.close
       }
-    // Create body of email by wrapping text in <pre> tags and dropping the last five line (which reference local
-    // log files)
+    // Create body of email. Merge stats (if present) are inserted between the
+    // boilerplate prefix and the mapping summary so recipients see record/delete
+    // counts before the per-record error breakdown.
+    // The last five lines of the mapping _SUMMARY reference local log file paths
+    // that are meaningless to external recipients, so we drop them.
+    val mergePart = mergeSection.map(s => List(s)).getOrElse(Nil)
     List
-      .concat(List("<pre>"), prefix, lines.dropRight(5), suffix, List("</pre>"))
+      .concat(List("<pre>"), prefix, mergePart, lines.dropRight(5), suffix, List("</pre>"))
       .mkString("\n")
   }
 

--- a/src/main/scala/dpla/ingestion3/utils/Emailer.scala
+++ b/src/main/scala/dpla/ingestion3/utils/Emailer.scala
@@ -175,13 +175,8 @@ object Emailer {
   }
 
   /**
-    * Parse a NaraMergeUtil _SUMMARY.txt and return a formatted HTML block
-    * suitable for inclusion in the ingest summary email.
-    *
-    * The summary file has labelled lines like:
-    *   " record count 18,696,139"
-    *   " valid deletes (IDs in merged dataset): 5"
-    * We extract the values we care about and render them in a clean table.
+    * Parse a NaraMergeUtil _SUMMARY.txt and return a short plain-text section
+    * reporting rows removed this cycle. Appended to the normal email body.
     */
   private def formatMergeStats(summaryPath: String): String = {
     val source = Source.fromFile(summaryPath)
@@ -190,54 +185,25 @@ object Emailer {
     def extract(pattern: scala.util.matching.Regex): String =
       pattern.findFirstMatchIn(text).map(_.group(1).trim).getOrElse("—")
 
-    // Base
-    val baseLines   = text.split("\n").dropWhile(!_.contains("Base")).take(10).mkString("\n")
-    val baseTotal   = extract("""\|\s*record count\s+([\d,]+)""".r.unanchored)
+    val newRecs    = extract("""\|\s*new:\s+([\d,]+)""".r.unanchored)
+    val updated    = extract("""\|\s*update:\s+([\d,]+)""".r.unanchored)
+    val delValid   = extract("""\|\s*valid deletes \(IDs in merged dataset\):\s+([\d,]+)""".r.unanchored)
+    val delInvalid = extract("""\|\s*invalid deletes \(IDs not in merged dataset\):\s+([\d,]+)""".r.unanchored)
+    val delInFile  = extract("""\|\s*ids to delete specified at path:\s+([\d,]+)""".r.unanchored)
 
-    // Delta
-    val deltaTotal  = extract("""\|\s*record count:\s+([\d,]+)""".r.unanchored)
-    val deltaDups   = extract("""\|\s*duplicate count:\s+([\d,]+)""".r.unanchored)
-    val deltaUnique = extract("""\|\s*unique count:\s+([\d,]+)""".r.unanchored)
+    val warning = if (delValid == "0" || delValid == "—")
+      "\n⚠️  Note: 0 rows were removed this cycle. If deletes were expected in this delivery, please contact us at tech@dp.la.\n"
+    else ""
 
-    // Merged
-    val mergeNew    = extract("""\|\s*new:\s+([\d,]+)""".r.unanchored)
-    val mergeUpdate = extract("""\|\s*update:\s+([\d,]+)""".r.unanchored)
-    val mergeActual = extract("""\|\s*total \[actual\]:\s+([\d,]+)""".r.unanchored)
-
-    // Delete
-    val delInFile   = extract("""\|\s*ids to delete specified at path:\s+([\d,]+)""".r.unanchored)
-    val delValid    = extract("""\|\s*valid deletes \(IDs in merged dataset\):\s+([\d,]+)""".r.unanchored)
-    val delInvalid  = extract("""\|\s*invalid deletes \(IDs not in merged dataset\):\s+([\d,]+)""".r.unanchored)
-    val delActual   = extract("""\|\s*actual removed.*?:\s+([\d,]+)""".r.unanchored)
-
-    // Final
-    val finalTotal  = extract("""\|\s*total \[actual\]:\s+([\d,]+) = """.r.unanchored)
-
-    val zeroDeleteWarning =
-      if (delValid == "0" || delValid == "—")
-        "\n<b>⚠️  Note: 0 records were deleted this cycle.</b> " +
-        "If delete files were expected in this delivery, please contact DPLA at tech@dp.la.\n"
-      else ""
-
-    s"""<b>NARA Merge Statistics</b>
-       |$zeroDeleteWarning
-       |<table style="border-collapse:collapse;font-family:monospace;font-size:13px">
-       |<tr><td colspan="2" style="padding:4px 8px;background:#f0f0f0"><b>Base</b></td></tr>
-       |<tr><td style="padding:2px 8px 2px 16px">Records in base</td><td style="padding:2px 8px">$baseTotal</td></tr>
-       |<tr><td colspan="2" style="padding:4px 8px;background:#f0f0f0"><b>Delta (this delivery)</b></td></tr>
-       |<tr><td style="padding:2px 8px 2px 16px">Total records in delivery</td><td style="padding:2px 8px">$deltaTotal</td></tr>
-       |<tr><td style="padding:2px 8px 2px 16px">Duplicates removed</td><td style="padding:2px 8px">$deltaDups</td></tr>
-       |<tr><td style="padding:2px 8px 2px 16px">Unique records processed</td><td style="padding:2px 8px">$deltaUnique</td></tr>
-       |<tr><td colspan="2" style="padding:4px 8px;background:#f0f0f0"><b>Changes applied</b></td></tr>
-       |<tr><td style="padding:2px 8px 2px 16px">New records added</td><td style="padding:2px 8px">$mergeNew</td></tr>
-       |<tr><td style="padding:2px 8px 2px 16px">Existing records updated</td><td style="padding:2px 8px">$mergeUpdate</td></tr>
-       |<tr><td style="padding:2px 8px 2px 16px">Records deleted (valid)</td><td style="padding:2px 8px">$delValid</td></tr>
-       |<tr><td style="padding:2px 8px 2px 16px">Delete IDs not found (invalid)</td><td style="padding:2px 8px">$delInvalid</td></tr>
-       |<tr><td style="padding:2px 8px 2px 16px">Delete IDs in file</td><td style="padding:2px 8px">$delInFile</td></tr>
-       |<tr><td colspan="2" style="padding:4px 8px;background:#f0f0f0"><b>Final</b></td></tr>
-       |<tr><td style="padding:2px 8px 2px 16px"><b>Total records in DPLA</b></td><td style="padding:2px 8px"><b>$mergeActual</b></td></tr>
-       |</table>
-       |<br>""".stripMargin
+    s"""
+       |Merge Statistics
+       |----------------
+       |New records added:         $newRecs
+       |Records updated:           $updated
+       |Records deleted:           $delValid
+       |Invalid delete IDs:        $delInvalid (in delete file but not in dataset)
+       |Total IDs in delete file:  $delInFile
+       |$warning""".stripMargin
   }
 
   private lazy val suffix =
@@ -290,23 +256,24 @@ object Emailer {
       } finally {
         source.close
       }
-    // Create body of email. Merge stats (if present) are inserted between the
-    // boilerplate prefix and the mapping summary so recipients see record/delete
-    // counts before the per-record error breakdown.
     // The last five lines of the mapping _SUMMARY reference local log file paths
     // that are meaningless to external recipients, so we drop them.
+    // The merge delete stats section (NARA only) is appended after the mapping
+    // summary so the normal output comes first, with the extra stats at the end.
     val mergePart = mergeSection.map(s => List(s)).getOrElse(Nil)
     List
-      .concat(List("<pre>"), prefix, mergePart, lines.dropRight(5), suffix, List("</pre>"))
+      .concat(List("<pre>"), prefix, lines.dropRight(5), mergePart, suffix, List("</pre>"))
       .mkString("\n")
   }
 
   private def zip(zippedLogs: String, mapOutput: String): Option[File] = {
-    // Build the zip file contents
-    val zipOut = new ZipFile(zippedLogs)
     val errors = new File(s"$mapOutput/_LOGS/errors/")
-
-    if (errors.exists()) {
+    // Only create the zip if there are actual CSV error files — an empty errors
+    // directory (or no directory at all) means there's nothing worth attaching.
+    val csvFiles = Option(errors.listFiles()).getOrElse(Array.empty)
+      .filter(f => f.isFile && f.getName.endsWith(".csv"))
+    if (csvFiles.nonEmpty) {
+      val zipOut = new ZipFile(zippedLogs)
       zipOut.addFolder(errors, zipParameters)
       zipOut.close()
       Some(new File(zippedLogs))

--- a/src/main/scala/dpla/ingestion3/utils/Emailer.scala
+++ b/src/main/scala/dpla/ingestion3/utils/Emailer.scala
@@ -64,12 +64,19 @@ object Emailer {
       if (idx >= 0 && idx + 1 < argList.length) Some(argList(idx + 1)) else None
     }
 
-    // Strip the flag and its value to get clean positional args
+    // Pull out --email-override <address>
+    val emailOverride: Option[String] = {
+      val idx = argList.indexOf("--email-override")
+      if (idx >= 0 && idx + 1 < argList.length) Some(argList(idx + 1)) else None
+    }
+
+    // Strip named flags and their values to get clean positional args
+    val namedFlags = Set("--merge-summary", "--email-override")
     val positionalArgs: List[String] = {
       var skipNext = false
       argList.filter { a =>
         if (skipNext) { skipNext = false; false }
-        else if (a == "--merge-summary") { skipNext = true; false }
+        else if (namedFlags.contains(a)) { skipNext = true; false }
         else true
       }
     }
@@ -98,8 +105,12 @@ object Emailer {
 
     val subject = s"DPLA Ingest Summary for $providerName - $currentMonth"
 
+    emailOverride.foreach(addr =>
+      println(s"⚠️  EMAIL OVERRIDE ACTIVE — sending to $addr instead of configured contacts")
+    )
+
     // Send email
-    emailSummaryWithSubject(mappingDir, subject, conf, mergeSummaryPath)
+    emailSummaryWithSubject(mappingDir, subject, conf, mergeSummaryPath, emailOverride)
   }
 
   /**
@@ -131,9 +142,10 @@ object Emailer {
       mapOutput: String,
       subject: String,
       i3conf: i3Conf,
-      mergeSummaryPath: Option[String] = None
+      mergeSummaryPath: Option[String] = None,
+      emailOverride: Option[String] = None
   ): Unit = {
-    val rawEmails = i3conf.email.getOrElse("tech@dp.la")
+    val rawEmails = emailOverride.getOrElse(i3conf.email.getOrElse("tech@dp.la"))
     val emails = normalizeEmails(rawEmails)
 
     // Debug output


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR addresses Issue 739 by fixing a critical bug in NARA delta ingest delete-file handling and adding optional S3 source download capability. The issue was that the preprocessing logic incorrectly identified NaidsList roster files as delete files, when delete instructions actually come from separate NAC_DESC_Deletes_*.xml files.

## Changes

### `scripts/harvest/nara-ingest.sh`

**New functionality:**
- Added `--s3-source=<s3://...>` CLI option to download NARA deliveries from an arbitrary S3 prefix before preprocessing (e.g., `--s3-source=s3://ngc-storage01/dpla-bimonthly-report/2026/M04/`)
- New `sync_from_nara_s3()` function that syncs the specified S3 prefix to `$NARA_ORIGINALS/$month/` using the `[nara]` AWS profile
- S3 sync is inserted as an optional "2a" step before preprocessing with skip logic if files already exist

**Bug fix — delete file handling:**
- Changed preprocessing to correctly identify and process `NAC_DESC_Deletes_*.xml` files (actual delete instructions) instead of NaidsList files
- Now explicitly discards `*NaidsList*.xml` files (export group roster files, NOT delete lists)
- Handles delete XMLs that may be at the top level of delivery or nested inside ZIPs
- Added sanity check after preprocessing that logs warning (and sends Slack notification) if zero delete files found

**Robustness improvements:**
- Updated stage label comments for "Delta Harvest" and "Merge" steps
- Added resilient Slack notifications for delete file warnings

### `docs/ingestion/README_NARA.md`

**Updated documentation:**
- Added `--s3-source` example to "Automated Script" section
- Clarified "Data Delivery Format" section to distinguish between:
  - **Data ZIPs** (`DATE_EXPORTGROUP_DESC_SEQNUM.zip`)
  - **Delete XMLs** (`NAC_DESC_Deletes_*.xml`) — actual files with NARA IDs to remove
  - **NaidsList roster XMLs** (`DATE_EXPORTGROUP_DESC_NaidsList.xml`) — export group membership rosters that should be discarded, not placed in `deletes/` directory
- Expanded Step 1 preprocessing with explicit commands to copy `NAC_DESC_Deletes_*.xml` to `deletes/` and delete NaidsList files
- Added tip to verify delete files were found via `find $DEST/deletes -name "*.xml" | wc -l`
- Updated Step 4 merge instructions to specify `NAC_DESC_Deletes_*.xml` filenames
- Rewrote validation section with new operations CSV review commands and troubleshooting guidance for zero delete counts
- Updated example summary values and added "Operations CSV" section with expected operation types
- Added specific guidance: "If you see only `invalid delete` and no `delete` operations despite having delete files, the delete XMLs were not processed correctly"
- Updated directory layout examples to show `NAC_DESC_Deletes_*.xml` filenames instead of NaidsList files
- Added "Delete bug (fixed June 2026)" section in History documenting the retroactive impact on prior runs (2025-12 and 2026-01 were affected)

## Deployment Considerations

**AWS Profile Requirement**: The new `--s3-source` option requires the `[nara]` AWS profile to be configured locally. No AWS Secrets Manager keys or new environment variables are added.

**Manual Invocation**: The script is manually triggered; no ECS redeployment is required. However, to use the new S3 download feature, users must invoke the script with the `--s3-source` parameter.

**Backward Compatible**: Existing invocations without `--s3-source` work unchanged; the new option is optional.

## Scope

- No public API changes (NARA is internal data source)
- No database migrations
- No shared infrastructure configuration changes
- No changes to environment variables or AWS Secrets Manager keys
- No security implications beyond existing AWS profile usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->