### PR TITLE
Regenerate institutions_v2.json from the current index

### DIFF
--- a/src/main/resources/wiki/institutions_v2.json
+++ b/src/main/resources/wiki/institutions_v2.json
@@ -426,10 +426,6 @@
         "Wikidata": "",
         "upload": false
       },
-      "Ants of India": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Archives of Ontario": {
         "Wikidata": "",
         "upload": false
@@ -439,6 +435,10 @@
         "upload": false
       },
       "Arnold Arboretum of Harvard University": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Arthur Chapman": {
         "Wikidata": "",
         "upload": false
       },
@@ -454,6 +454,14 @@
         "Wikidata": "",
         "upload": false
       },
+      "Australasian Affiliation of Herpetological Societies": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Australasian Native Orchid Society": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Australasian Systematic Botany Society": {
         "Wikidata": "",
         "upload": false
@@ -463,6 +471,10 @@
         "upload": false
       },
       "Australian Entomological Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Australian Freshwater Sciences Society": {
         "Wikidata": "",
         "upload": false
       },
@@ -511,6 +523,10 @@
         "upload": false
       },
       "Biblioteca de la Universidad de Sevilla": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Biblioteka Jagiello\u0144ska": {
         "Wikidata": "",
         "upload": false
       },
@@ -634,6 +650,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Centre for Agriculture and Bioscience International (CABI)": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Cherokee Garden Library, Kenan Research Center at the Atlanta History Center": {
         "Wikidata": "",
         "upload": false
@@ -643,6 +663,10 @@
         "upload": false
       },
       "Chicago Botanic Garden, Lenhardt Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Chicago Herpetological Society": {
         "Wikidata": "",
         "upload": false
       },
@@ -690,6 +714,10 @@
         "Wikidata": "Q5171572",
         "upload": false
       },
+      "Daryl Fleay": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Delaware Museum of Natural History Library": {
         "Wikidata": "",
         "upload": false
@@ -727,6 +755,10 @@
         "upload": false
       },
       "Dumbarton Oaks": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "EJT consortium": {
         "Wikidata": "",
         "upload": false
       },
@@ -791,6 +823,10 @@
         "upload": false
       },
       "Facultad de Ciencias, UNAM": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Field Museum of Natural History": {
         "Wikidata": "",
         "upload": false
       },
@@ -862,11 +898,23 @@
         "Wikidata": "",
         "upload": false
       },
+      "Halteres": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Hardy Fern Foundation": {
         "Wikidata": "",
         "upload": false
       },
       "Harold B. Lee Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Harry Ransom Center, University of Texas at Austin": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Harvard University": {
         "Wikidata": "",
         "upload": false
       },
@@ -918,6 +966,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Illinois Ornithological Society": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Indiana Native Plant Society (INPS)": {
         "Wikidata": "",
         "upload": false
@@ -966,6 +1018,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Irish Biogeographical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
       "James Lendemer": {
         "Wikidata": "",
         "upload": false
@@ -986,11 +1042,19 @@
         "Wikidata": "",
         "upload": false
       },
+      "John Read": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Joint Committee on Taxation, US Congress": {
         "Wikidata": "",
         "upload": false
       },
       "Joseph Palmer Knapp Library, UNC School of Government": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Juan F. Masello": {
         "Wikidata": "",
         "upload": false
       },
@@ -1115,6 +1179,10 @@
         "upload": false
       },
       "Meise Botanic Garden": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Michael R. Kearney": {
         "Wikidata": "",
         "upload": false
       },
@@ -1322,6 +1390,14 @@
         "Wikidata": "",
         "upload": false
       },
+      "Northwest Scientific Association": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Nova Scotian Institute of Science": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Oak Spring Garden Foundation": {
         "Wikidata": "Q62598736",
         "upload": false
@@ -1490,6 +1566,10 @@
         "Wikidata": "Q5401695",
         "upload": false
       },
+      "Royal Society of Tasmania": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Royal Society of Victoria": {
         "Wikidata": "Q1031402",
         "upload": false
@@ -1542,6 +1622,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Scottish Ornithologists' Club": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Servants Of Knowledge": {
         "Wikidata": "",
         "upload": false
@@ -1588,6 +1672,10 @@
       },
       "South Australian Museum": {
         "Wikidata": "Q2546445",
+        "upload": false
+      },
+      "Southern California Academy of Sciences": {
+        "Wikidata": "",
         "upload": false
       },
       "Southern California Association of Marine Invertebrate Taxonomists": {
@@ -1643,6 +1731,10 @@
         "upload": false
       },
       "Tasmanian Field Naturalists Club": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Taxonomy Australia": {
         "Wikidata": "",
         "upload": false
       },
@@ -1703,6 +1795,10 @@
         "upload": false
       },
       "The Newberry Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "The Ohio State University Library": {
         "Wikidata": "",
         "upload": false
       },
@@ -1799,6 +1895,10 @@
         "upload": false
       },
       "Universidad de Concepci\u00f3n": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Universidade Federal do Paran\u00e1 Sistema de Bibliotecas (SiBi)": {
         "Wikidata": "",
         "upload": false
       },
@@ -2096,6 +2196,10 @@
       },
       "Zoologisches Forschungsmuseum Alexander Koenig": {
         "Wikidata": "Q52659970",
+        "upload": false
+      },
+      "\u0633\u0648\u0631 \u0627\u0644\u0623\u0632\u0628\u0643\u064a\u0629 (Soor el-Azbakeya)": {
+        "Wikidata": "",
         "upload": false
       }
     },
@@ -3220,10 +3324,6 @@
         "Wikidata": "",
         "upload": false
       },
-      "UC Berkeley, Institute for Research on Labor and Employment Collections": {
-        "Wikidata": "",
-        "upload": false
-      },
       "UC Berkeley, Institute of Governmental Studies Library": {
         "Wikidata": "",
         "upload": false
@@ -3377,10 +3477,6 @@
         "upload": false
       },
       "UCLA, Ethnomusicology Archive": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "UCLA, Fowler Museum of Cultural History": {
         "Wikidata": "",
         "upload": false
       },
@@ -3550,7 +3646,15 @@
         "Wikidata": "",
         "upload": false
       },
+      "Auburn Avenue Research Library on African American Culture and History": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Bensenville Community Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Black Lunch Table": {
         "Wikidata": "",
         "upload": false
       },
@@ -3634,6 +3738,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "North Liberty Library": {
+        "Wikidata": "",
+        "upload": false
+      },
       "People's Archive, DC Public Library": {
         "Wikidata": "",
         "upload": false
@@ -3647,6 +3755,10 @@
         "upload": false
       },
       "Scott County Library System": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Special Collections and Archives, Denver Public Library": {
         "Wikidata": "",
         "upload": false
       },
@@ -3667,10 +3779,6 @@
         "upload": false
       },
       "Watsonville Public Library": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Western History and Genealogy Department and Blair-Caldwell African American Research Library, Denver Public Library": {
         "Wikidata": "",
         "upload": false
       },
@@ -4216,11 +4324,23 @@
         "Wikidata": "Q49129",
         "upload": false
       },
+      "Boston Little Syria Project": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Boston Public Library": {
         "Wikidata": "Q894583",
         "upload": true
       },
+      "Boston Symphony Orchestra Archives": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Bourne Archives": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Boxford Historic Document Center": {
         "Wikidata": "",
         "upload": false
       },
@@ -4380,6 +4500,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Det Kongelige Bibliotek (Royal Danish Library)": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Detroit Public Television (aka DPTV and WTVS)": {
         "Wikidata": "",
         "upload": false
@@ -4464,6 +4588,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Filson Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
       "First Parish in Brookline": {
         "Wikidata": "",
         "upload": false
@@ -4490,6 +4618,10 @@
       },
       "Forbes Library": {
         "Wikidata": "Q69478039",
+        "upload": false
+      },
+      "Forbush Memorial Library": {
+        "Wikidata": "",
         "upload": false
       },
       "Frameline Distribution": {
@@ -4520,6 +4652,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "George Washington Presidential Library at Mount Vernon": {
+        "Wikidata": "",
+        "upload": false
+      },
       "George Washington's Mount Vernon": {
         "Wikidata": "",
         "upload": false
@@ -4542,6 +4678,10 @@
       },
       "Granville Public Library": {
         "Wikidata": "Q69477687",
+        "upload": false
+      },
+      "Greater Lowell Technical High School": {
+        "Wikidata": "",
         "upload": false
       },
       "Greenfield Community College": {
@@ -4596,11 +4736,19 @@
         "Wikidata": "Q13371",
         "upload": false
       },
+      "Harvard University, Harvard Library": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Haston Free Public Library": {
         "Wikidata": "Q69478032",
         "upload": false
       },
       "Hatfield Historical Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Heritage Museums & Gardens": {
         "Wikidata": "",
         "upload": false
       },
@@ -4636,6 +4784,10 @@
         "Wikidata": "Q5887074",
         "upload": false
       },
+      "Holyoke Gas & Electric Department": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Holyoke Public Library": {
         "Wikidata": "Q30258074",
         "upload": false
@@ -4650,6 +4802,10 @@
       },
       "Hopkinton Public Library": {
         "Wikidata": "Q69477770",
+        "upload": false
+      },
+      "Housatonic Heritage Oral History Center at Berkshire Community College": {
+        "Wikidata": "",
         "upload": false
       },
       "Hubbard Memorial Library": {
@@ -4694,6 +4850,10 @@
       },
       "Iowa Public Television": {
         "Wikidata": "Q6064557",
+        "upload": false
+      },
+      "Ipswich Public Library": {
+        "Wikidata": "",
         "upload": false
       },
       "J. V. Fletcher Library": {
@@ -5136,6 +5296,10 @@
         "Wikidata": "Q69863171",
         "upload": false
       },
+      "Millicent Library": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Mississippi Public Broadcasting": {
         "Wikidata": "Q6879250",
         "upload": false
@@ -5224,7 +5388,15 @@
         "Wikidata": "",
         "upload": false
       },
+      "New-York Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Newburyport Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Newport Historical Society": {
         "Wikidata": "",
         "upload": false
       },
@@ -5368,6 +5540,10 @@
         "Wikidata": "Q69770337",
         "upload": false
       },
+      "Plymouth Antiquarian Society": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Plymouth Public Library": {
         "Wikidata": "Q69478113",
         "upload": false
@@ -5409,6 +5585,10 @@
         "upload": false
       },
       "Queer Digital History Project": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Queer History Boston": {
         "Wikidata": "",
         "upload": false
       },
@@ -5552,6 +5732,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "St. Barnabas Episcopal Church": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Stanford University": {
         "Wikidata": "",
         "upload": false
@@ -5621,10 +5805,6 @@
         "upload": false
       },
       "The Eliot School of Fine & Applied Arts": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The History Project": {
         "Wikidata": "",
         "upload": false
       },
@@ -5720,6 +5900,10 @@
         "Wikidata": "Q7834220",
         "upload": false
       },
+      "Trinity Episcopal Church": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Truro Historical Society, Cobb Archive": {
         "Wikidata": "",
         "upload": false
@@ -5752,6 +5936,10 @@
         "Wikidata": "Q7868542",
         "upload": false
       },
+      "United States Naval Shipbuilding Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
       "University of Alabama Center for Public Television": {
         "Wikidata": "",
         "upload": false
@@ -5769,6 +5957,10 @@
         "upload": false
       },
       "University of Massachusetts Boston, Joseph P. Healey Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "University of Massachusetts Dartmouth, Claire T. Carney Library": {
         "Wikidata": "",
         "upload": false
       },
@@ -6214,6 +6406,10 @@
         "Wikidata": "Q72940756",
         "upload": false
       },
+      "Baylor University. Libraries. Digital Collections": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Berrien Historical Foundation": {
         "Wikidata": "",
         "upload": false
@@ -6302,6 +6498,10 @@
         "Wikidata": "Q69765686",
         "upload": true
       },
+      "Clay County Library (Fort Gaines, Ga.)": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Coastal Heritage Society (Ga.)": {
         "Wikidata": "",
         "upload": false
@@ -6326,6 +6526,10 @@
         "Wikidata": "Q77062489",
         "upload": true
       },
+      "Columbia County Library System": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Columbia Theological Seminary": {
         "Wikidata": "Q5149859",
         "upload": false
@@ -6343,6 +6547,10 @@
         "upload": false
       },
       "Cordele-Crisp Carnegie Library. Special Collections": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Dade County Ga. Historical Society": {
         "Wikidata": "",
         "upload": false
       },
@@ -6530,6 +6738,10 @@
         "Wikidata": "Q87489677",
         "upload": false
       },
+      "Georgia Trust for Historic Preservation": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Gilbert H. Gragg Library": {
         "Wikidata": "",
         "upload": false
@@ -6588,6 +6800,10 @@
       },
       "Henry W. Grady College of Journalism and Mass Communication": {
         "Wikidata": "Q5729648",
+        "upload": false
+      },
+      "Historically Black Colleges and Universities (HBCU) Library Alliance": {
+        "Wikidata": "",
         "upload": false
       },
       "Houston County Public Library System": {
@@ -6708,6 +6924,10 @@
       },
       "Lee County Library System (Ga.)": {
         "Wikidata": "Q30637232",
+        "upload": false
+      },
+      "Level Creek United Methodist Church (Suwanee, Ga.)": {
+        "Wikidata": "",
         "upload": false
       },
       "Levi Watkins Learning Center (Alabama State University)": {
@@ -6884,6 +7104,10 @@
       },
       "Okefenokee Regional Library System": {
         "Wikidata": "Q30634560",
+        "upload": false
+      },
+      "Old Suwanee Baptist Church (Suwanee, Ga.)": {
+        "Wikidata": "",
         "upload": false
       },
       "Oregon Historical Society": {
@@ -7102,6 +7326,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Sylvester-Margaret Jones Library": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Tennessee State Library and Archives": {
         "Wikidata": "Q7700170",
         "upload": false
@@ -7138,16 +7366,24 @@
         "Wikidata": "Q1782724",
         "upload": false
       },
+      "Towns County Historical Society (Hiawassee, Ga.)": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Troup County Archives": {
         "Wikidata": "Q72941269",
         "upload": false
       },
-      "Truett McConnell University, Cofer Library": {
+      "Truett McConnell University. Cofer Library": {
         "Wikidata": "",
         "upload": false
       },
       "Tubman African-American Museum": {
         "Wikidata": "Q7850901",
+        "upload": false
+      },
+      "Tulane University. Special Collections": {
+        "Wikidata": "",
         "upload": false
       },
       "Tuskegee University. Libraries": {
@@ -7232,10 +7468,6 @@
       },
       "University of North Carolina at Chapel Hill. Documenting the American South (Project)": {
         "Wikidata": "Q111308923",
-        "upload": false
-      },
-      "University of North Carolina at Greensboro. University Libraries": {
-        "Wikidata": "",
         "upload": false
       },
       "University of North Georgia. Library Technology Center": {
@@ -8296,11 +8528,19 @@
         "Wikidata": "",
         "upload": false
       },
+      "Annapolis Maritime Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Anne Arundel County Public Libraries": {
         "Wikidata": "",
         "upload": false
       },
       "Anne Arundel County Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Baltimore Clayworks": {
         "Wikidata": "",
         "upload": false
       },
@@ -8329,6 +8569,10 @@
         "upload": false
       },
       "C. Burr Artz Public Library, Frederick County Public Libraries, Ross Manuscript Collection (MR11), Maryland Room": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Calvert Library (Calvert County, Md.)": {
         "Wikidata": "",
         "upload": false
       },
@@ -8488,10 +8732,6 @@
         "Wikidata": "",
         "upload": false
       },
-      "City of Cumberland": {
-        "Wikidata": "",
-        "upload": false
-      },
       "College Park Aviation Museum": {
         "Wikidata": "Q62032417",
         "upload": false
@@ -8564,7 +8804,15 @@
         "Wikidata": "",
         "upload": false
       },
+      "Enoch Pratt Free Library / tate Library Reource Center: Maryland Department: Naylor Collection, Binder 5": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Enoch Pratt Free Library/State Library Resource Center": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Ensign C. Markland Kelly, Jr. Foundation": {
         "Wikidata": "",
         "upload": false
       },
@@ -8680,6 +8928,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Maryland Punk Archive": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Maryland State Archives": {
         "Wikidata": "Q17109505",
         "upload": false
@@ -8688,11 +8940,27 @@
         "Wikidata": "",
         "upload": false
       },
+      "Maryland Zoological Society, Inc": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "McDonogh Archives & Special Collections": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "McDonogh Archives and Special Collections": {
+        "Wikidata": "",
+        "upload": false
+      },
       "McDonogh School Archives": {
         "Wikidata": "",
         "upload": false
       },
       "McDonogh School Archives & Special Collection": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "McDonogh School Archives & Special Collections": {
         "Wikidata": "",
         "upload": false
       },
@@ -8705,6 +8973,10 @@
         "upload": false
       },
       "Montgomery College, Bliss Electrical School": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Montgomery College, Rockville Campus": {
         "Wikidata": "",
         "upload": false
       },
@@ -8724,6 +8996,14 @@
         "Wikidata": "",
         "upload": false
       },
+      "Natural History Society of Maryland": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Oral History Archive, Special Collections, Enoch Pratt Free Library": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Pennsylvania Trolley Museum": {
         "Wikidata": "Q7164216",
         "upload": false
@@ -8733,6 +9013,10 @@
         "upload": false
       },
       "Prince George's County Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Prince George's County Memorial Library System": {
         "Wikidata": "",
         "upload": false
       },
@@ -12072,6 +12356,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Sandy Spring Museum - 1997.0005.0647": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Sandy Spring Museum - 1997.0005.0648 (Gift of Helen Bentley)": {
         "Wikidata": "",
         "upload": false
@@ -13452,6 +13740,18 @@
         "Wikidata": "",
         "upload": false
       },
+      "Sandy Spring Museum - 2005.0004.0084b (Gift of Jean Ladson)": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Sandy Spring Museum - 2005.0004.0084c (Gift of Jean Ladson)": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Sandy Spring Museum - 2005.0004.0084d (Gift of Jean Ladson)": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Sandy Spring Museum - 2005.0004.0109 (Gift of Jean Ladson)": {
         "Wikidata": "",
         "upload": false
@@ -13896,6 +14196,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Sandy Spring Museum - 2013.0008.0001 (Gift of Catherine Brown)": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Sandy Spring Museum - 2013.0010.0001 (Gift of Tim Ladson)": {
         "Wikidata": "",
         "upload": false
@@ -14036,6 +14340,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Sandy Spring Museum - 2023.0008.0004 (Gift of Giulia Adelfio)": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Sandy Spring Museum - Deeds - 1997.0005.0632 (Gift of Helen Bentley)": {
         "Wikidata": "",
         "upload": false
@@ -14045,6 +14353,14 @@
         "upload": false
       },
       "Sandy Spring Museum - Deeds - 1997.0005.0642 (Gift of Helen Bentley)": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Sandy Spring Museum - Deeds - 1997.0005.0649 (Gift of Helen Bentley)": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Sandy Spring Museum - Deeds - 1997.0005.0651 (Gift of Helen Bentley)": {
         "Wikidata": "",
         "upload": false
       },
@@ -14613,6 +14929,10 @@
         "upload": false
       },
       "Sandy Spring Museum - Diaries - 2012.0006.0006 (Gift of Janice Iddings Thompson)": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Sandy Spring Museum - Equity in Metadata Project - 2009.0028.0019b (Gift of John S. Lea, Jr.)": {
         "Wikidata": "",
         "upload": false
       },
@@ -17532,6 +17852,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Sandy Spring Museum -Deeds -1997.0005.0646 (Gift of Helen Bentley)": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Sandy Spring Museum Archives": {
         "Wikidata": "",
         "upload": false
@@ -17576,6 +17900,14 @@
         "Wikidata": "",
         "upload": false
       },
+      "Sandy Spring Museum Archives - 1990.0092.0001 (Gift of Diane and William Grimes)": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Sandy Spring Museum Archives - 1990.0092.0002 (Gift of Diane and William Grimes)": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Sandy Spring Museum Archives - 2005.0006.0002 (Gift of Betsy Eves Bak)": {
         "Wikidata": "",
         "upload": false
@@ -17589,6 +17921,22 @@
         "upload": false
       },
       "Sandy Spring Museum Archives - 2012.0007.0002 (Gift of Barbara Hallowell)": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Sandy Spring Museum Archives - 2021.0006.0004a (Gift of Tom Farquhar)": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Sandy Spring Museum Archives - 2025.0001.0386 (Sandy Spring Bank Collection)": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Sandy Spring Museum Archives - 2025.0001.0387 (Sandy Spring Bank Collection)": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Sandy Spring Museum Archives - 2025.0001.0391 (Sandy Spring Bank Collection)": {
         "Wikidata": "",
         "upload": false
       },
@@ -17609,6 +17957,10 @@
         "upload": false
       },
       "Sandy Spring Museum Archives - Club Minutes - 1991.0022.0005 (Gift of Helen Bentley)": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Sandy Spring Museum Archives - Club Minutes - 1997.0005.0227 (Gift of Helen Bentley)": {
         "Wikidata": "",
         "upload": false
       },
@@ -17836,6 +18188,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Sandy Spring Museum Archives - Club Minutes - 2005.0016.0001": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Sandy Spring Museum Archives - Club Minutes - 2005.0016.0002": {
         "Wikidata": "",
         "upload": false
@@ -17865,6 +18221,14 @@
         "upload": false
       },
       "Sandy Spring Museum Archives - Club Minutes - 2005.0016.0010": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Sandy Spring Museum Archives - Club Minutes - 2005.0016.0012": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Sandy Spring Museum Archives - Club Minutes - 2005.0016.0013": {
         "Wikidata": "",
         "upload": false
       },
@@ -18616,6 +18980,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Sandy Spring Museum, Equity in Metadata Project - 1989.0010.0008 (Gift of Mary Reading Miller)": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Sandy Spring Museum, Equity in Metadata Project - 1998.0078.0003 (Gift of Kym Rice)": {
         "Wikidata": "",
         "upload": false
@@ -18629,6 +18997,14 @@
         "upload": false
       },
       "Sandy Spring Museum, Equity in Metadata Project - 2009.0028.0019b (Gift of John S. Lea, Jr.)": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Sandy Spring Museum, Equity in Metadata Project - 2009.0028.0028 (Gift of John S. Lea, Jr.)": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Sandy Spring Museum, Equity in Metadata Project - 2013.0008.0001 (Gift of Catherine Brown)": {
         "Wikidata": "",
         "upload": false
       },
@@ -18656,6 +19032,18 @@
         "Wikidata": "Q7586874",
         "upload": false
       },
+      "St. Mary's College of Maryland (http://library.smcm.edu/archives/) and Historic Sotterley, Inc": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "St. Mary's College of Maryland (http://library.smcm.edu/archives/) and Historic Sotterley, Inc. (http://www.sotterley.org)": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "St. Mary's College of Maryland and Historic Sotterley, Inc": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Star-Spangled Banner Flag House": {
         "Wikidata": "Q3073214",
         "upload": false
@@ -18666,6 +19054,10 @@
       },
       "Talbot County Free Library": {
         "Wikidata": "Q69478586",
+        "upload": false
+      },
+      "The American Sugar Refining Company": {
+        "Wikidata": "",
         "upload": false
       },
       "The Baltimore Museum of Art": {
@@ -18721,6 +19113,10 @@
         "upload": false
       },
       "Washington County Museum of Fine Arts": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Webb, Alice, 1945-2022": {
         "Wikidata": "",
         "upload": false
       },
@@ -19892,10 +20288,6 @@
         "Wikidata": "Q4947982",
         "upload": false
       },
-      "General Artemas Ward Museum": {
-        "Wikidata": "",
-        "upload": false
-      },
       "General Artemas Ward Museum, Harvard University": {
         "Wikidata": "",
         "upload": false
@@ -20001,6 +20393,10 @@
         "upload": false
       },
       "Robbins Library of Philosophy, Harvard University": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Slavic Division, Widener Library, Harvard University": {
         "Wikidata": "",
         "upload": false
       },
@@ -21032,6 +21428,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "St. Louis County Library": {
+        "Wikidata": "",
+        "upload": false
+      },
       "St. Louis Daily Globe-Democrat through Missouri Digital Heritage": {
         "Wikidata": "",
         "upload": false
@@ -21308,6 +21708,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "University of Kansas Libraries": {
+        "Wikidata": "",
+        "upload": false
+      },
       "University of Missiouri Digital Library Production Services through Missouri Digital Heritage": {
         "Wikidata": "",
         "upload": false
@@ -21510,6 +21914,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Belleville Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Benedictine University": {
         "Wikidata": "Q4887352",
         "upload": false
@@ -21702,7 +22110,15 @@
         "Wikidata": "",
         "upload": false
       },
+      "Gail Borden Public Library District; Dahlquist and Lutzow Architects": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Gail Borden Public Library District; Elgin Academy": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Gail Borden Public Library District; Elgin Area Chamber of Commerce; Elgin Development Group": {
         "Wikidata": "",
         "upload": false
       },
@@ -21710,7 +22126,15 @@
         "Wikidata": "",
         "upload": false
       },
+      "Gail Borden Public Library District; Elgin Area Historical Society; Elgin Chamber of Commerce": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Gail Borden Public Library District; Elgin Council of Churches": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Gail Borden Public Library District; Elgin Daily Courier-News": {
         "Wikidata": "",
         "upload": false
       },
@@ -21718,7 +22142,19 @@
         "Wikidata": "",
         "upload": false
       },
+      "Gail Borden Public Library District; Elgin Genealogical Society; Elgin Area Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Gail Borden Public Library District; Elgin Patriotic Memorial Association": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Gail Borden Public Library District; Elgin Woman's Club": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Gail Borden Public Library District; Gifford Park Association": {
         "Wikidata": "",
         "upload": false
       },
@@ -21726,8 +22162,20 @@
         "Wikidata": "",
         "upload": false
       },
+      "Gail Borden Public Library District; League of Women Voters": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Galena Public Library District": {
         "Wikidata": "Q69964928",
+        "upload": false
+      },
+      "Galesburg Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Galesburg Public Library Galesburg Public Library": {
+        "Wikidata": "",
         "upload": false
       },
       "Garrett-Evangelical Theological Seminary": {
@@ -21752,6 +22200,10 @@
       },
       "Harper College": {
         "Wikidata": "Q2983593",
+        "upload": false
+      },
+      "Hayner Public Library": {
+        "Wikidata": "",
         "upload": false
       },
       "Henderson County Historical Society Museum - Raritan, Illinois": {
@@ -22118,6 +22570,10 @@
         "Wikidata": "Q3945126",
         "upload": false
       },
+      "Sallie Logan Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Sallie Logan Public Library, Murphysboro, Illinois": {
         "Wikidata": "",
         "upload": false
@@ -22246,6 +22702,14 @@
         "Wikidata": "Q69474752",
         "upload": false
       },
+      "Williamsville Public Library & Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Williamsville Public Library & Museum Williamsville Public Library & Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Wilmette Public Library": {
         "Wikidata": "Q8022716",
         "upload": false
@@ -22338,6 +22802,10 @@
       },
       "B. Joan Keefer Genealogy and Local History Center, Huntington City-Township Public Library": {
         "Wikidata": "Q69861873",
+        "upload": false
+      },
+      "B. Joan Keefer Genealogy and Local History Center, Huntington City-Township Public Library Source": {
+        "Wikidata": "",
         "upload": false
       },
       "B. Joan Keefer Genealogy and Local History Center, Huntington City-Township Public LibrarySource": {
@@ -22580,8 +23048,8 @@
         "Wikidata": "Q69475148",
         "upload": false
       },
-      "d": {
-        "Wikidata": "",
+      "DHPA Bridge Survey": {
+        "Wikidata": "Q58020564",
         "upload": false
       },
       "Danville Center Township Public Library": {
@@ -22598,10 +23066,6 @@
       },
       "DePauw University": {
         "Wikidata": "Q1179599",
-        "upload": false
-      },
-      "DHPA Bridge Survey": {
-        "Wikidata": "Q58020564",
         "upload": false
       },
       "Dick, Adam": {
@@ -22852,6 +23316,98 @@
         "Wikidata": "",
         "upload": false
       },
+      "IPFW Walter E. Helmke Library": {
+        "Wikidata": "Q5975426",
+        "upload": true
+      },
+      "IU Indianapolis (Campus). University Library": {
+        "Wikidata": "Q5975426",
+        "upload": true
+      },
+      "IU Indianapolis (Campus). University Library. Ruth Lilly Special Collections and Archives": {
+        "Wikidata": "Q5975426",
+        "upload": true
+      },
+      "IU Indianapolis (Campus). University Library. Special Collections and Archives": {
+        "Wikidata": "Q79671108",
+        "upload": true
+      },
+      "IU Indianapolis. Department of Anthropology": {
+        "Wikidata": "Q5975426",
+        "upload": true
+      },
+      "IU Indianapolis. Department of History": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "IU Indianapolis. School of Liberal Arts": {
+        "Wikidata": "Q5975426",
+        "upload": true
+      },
+      "IU Indianapolis. University Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "IU Indianapolis. University Library. Ruth Lilly Special Collections and Archives": {
+        "Wikidata": "Q5975426",
+        "upload": true
+      },
+      "IU Indianapolis. University Library. Special Collections and Archives": {
+        "Wikidata": "Q79671108",
+        "upload": true
+      },
+      "IUPUI (Campus). Herron Art Library, University Library": {
+        "Wikidata": "Q97570005",
+        "upload": true
+      },
+      "IUPUI (Campus). School of Liberal Arts": {
+        "Wikidata": "Q5975426",
+        "upload": true
+      },
+      "IUPUI (Campus). University Library": {
+        "Wikidata": "Q5975426",
+        "upload": true
+      },
+      "IUPUI (Campus). University Library. Ruth Lilly Special Collections and Archives": {
+        "Wikidata": "Q5975426",
+        "upload": true
+      },
+      "IUPUI (Campus). University Library. Special Collections and Archives": {
+        "Wikidata": "Q79671108",
+        "upload": true
+      },
+      "IUPUI (Campus). University Library/ Herron Library": {
+        "Wikidata": "Q97570005",
+        "upload": true
+      },
+      "IUPUI (Campus).\u200f School of Liberal Arts": {
+        "Wikidata": "Q5975426",
+        "upload": true
+      },
+      "IUPUI (Campus).\u200f \u200eUniversity Library.\u200f \u200eSpecial Collections and Archives": {
+        "Wikidata": "Q79671108",
+        "upload": true
+      },
+      "IUPUI (Campus).\u200f \u200eUniversity Library.\u200f \u200eSpecial Collections and Archives\u200f": {
+        "Wikidata": "Q79671108",
+        "upload": true
+      },
+      "IUPUI Department of Anthropology": {
+        "Wikidata": "Q5975426",
+        "upload": true
+      },
+      "IUPUI Department of History": {
+        "Wikidata": "Q5975426",
+        "upload": true
+      },
+      "IUPUI University Library": {
+        "Wikidata": "Q5975426",
+        "upload": true
+      },
+      "IUPUI University Library Ruth Lilly Special Collections and Archives": {
+        "Wikidata": "Q5975426",
+        "upload": true
+      },
       "Indaina State Library": {
         "Wikidata": "Q14688462",
         "upload": true
@@ -22932,11 +23488,11 @@
         "Wikidata": "Q30289636",
         "upload": true
       },
-      "Indiana State Libary": {
+      "Indiana State LIbrary": {
         "Wikidata": "Q14688462",
         "upload": true
       },
-      "Indiana State LIbrary": {
+      "Indiana State Libary": {
         "Wikidata": "Q14688462",
         "upload": true
       },
@@ -23028,10 +23584,6 @@
         "Wikidata": "Q172732",
         "upload": false
       },
-      "indianapolis Motor Speedway": {
-        "Wikidata": "Q172732",
-        "upload": false
-      },
       "Indianapolis Museum of Art Archives": {
         "Wikidata": "",
         "upload": false
@@ -23092,96 +23644,12 @@
         "Wikidata": "Q11287618",
         "upload": false
       },
-      "IPFW Walter E. Helmke Library": {
-        "Wikidata": "Q5975426",
-        "upload": true
-      },
       "Irvington Historical Society": {
         "Wikidata": "Q115779375",
         "upload": true
       },
       "Irvington Historical Society (Irvington, Indianapolis, Ind)": {
         "Wikidata": "Q115779375",
-        "upload": true
-      },
-      "IU Indianapolis (Campus). University Library": {
-        "Wikidata": "Q5975426",
-        "upload": true
-      },
-      "IU Indianapolis (Campus). University Library. Ruth Lilly Special Collections and Archives": {
-        "Wikidata": "Q5975426",
-        "upload": true
-      },
-      "IU Indianapolis (Campus). University Library. Special Collections and Archives": {
-        "Wikidata": "Q79671108",
-        "upload": true
-      },
-      "IU Indianapolis. Department of Anthropology": {
-        "Wikidata": "Q5975426",
-        "upload": true
-      },
-      "IU Indianapolis. School of Liberal Arts": {
-        "Wikidata": "Q5975426",
-        "upload": true
-      },
-      "IU Indianapolis. University Library. Ruth Lilly Special Collections and Archives": {
-        "Wikidata": "Q5975426",
-        "upload": true
-      },
-      "IU Indianapolis. University Library. Special Collections and Archives": {
-        "Wikidata": "Q79671108",
-        "upload": true
-      },
-      "IUPUI (Campus). Herron Art Library, University Library": {
-        "Wikidata": "Q97570005",
-        "upload": true
-      },
-      "IUPUI (Campus). School of Liberal Arts": {
-        "Wikidata": "Q5975426",
-        "upload": true
-      },
-      "IUPUI (Campus). University Library": {
-        "Wikidata": "Q5975426",
-        "upload": true
-      },
-      "IUPUI (Campus). University Library. Ruth Lilly Special Collections and Archives": {
-        "Wikidata": "Q5975426",
-        "upload": true
-      },
-      "IUPUI (Campus). University Library. Special Collections and Archives": {
-        "Wikidata": "Q79671108",
-        "upload": true
-      },
-      "IUPUI (Campus). University Library/ Herron Library": {
-        "Wikidata": "Q97570005",
-        "upload": true
-      },
-      "IUPUI (Campus).\u200f School of Liberal Arts": {
-        "Wikidata": "Q5975426",
-        "upload": true
-      },
-      "IUPUI (Campus).\u200f \u200eUniversity Library.\u200f \u200eSpecial Collections and Archives": {
-        "Wikidata": "Q79671108",
-        "upload": true
-      },
-      "IUPUI (Campus).\u200f \u200eUniversity Library.\u200f \u200eSpecial Collections and Archives\u200f": {
-        "Wikidata": "Q79671108",
-        "upload": true
-      },
-      "IUPUI Department of Anthropology": {
-        "Wikidata": "Q5975426",
-        "upload": true
-      },
-      "IUPUI Department of History": {
-        "Wikidata": "Q5975426",
-        "upload": true
-      },
-      "IUPUI University Library": {
-        "Wikidata": "Q5975426",
-        "upload": true
-      },
-      "IUPUI University Library Ruth Lilly Special Collections and Archives": {
-        "Wikidata": "Q5975426",
         "upload": true
       },
       "Jacob, Andrew": {
@@ -23200,15 +23668,15 @@
         "Wikidata": "Q69475602",
         "upload": false
       },
+      "Jeffersonville Township Public LIbrary": {
+        "Wikidata": "Q69475602",
+        "upload": false
+      },
       "Jeffersonville Township Public Lbrary": {
         "Wikidata": "Q69475602",
         "upload": false
       },
       "Jeffersonville Township Public Libary": {
-        "Wikidata": "Q69475602",
-        "upload": false
-      },
-      "Jeffersonville Township Public LIbrary": {
         "Wikidata": "Q69475602",
         "upload": false
       },
@@ -23248,11 +23716,11 @@
         "Wikidata": "Q69475002",
         "upload": false
       },
-      "LaFourest, Judith": {
+      "LAST TAPS: Civil War Soldier Obituaries Published in Howard County, Indiana, Area Newspapers": {
         "Wikidata": "",
         "upload": false
       },
-      "LAST TAPS: Civil War Soldier Obituaries Published in Howard County, Indiana, Area Newspapers": {
+      "LaFourest, Judith": {
         "Wikidata": "",
         "upload": false
       },
@@ -23272,6 +23740,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "LiLincoln Financial Foundation Collection, Allen County Public Library, Fort Wayne, Indiana": {
+        "Wikidata": "Q69475181",
+        "upload": false
+      },
       "Library of Congress": {
         "Wikidata": "Q131454",
         "upload": true
@@ -23283,10 +23755,6 @@
       "Library of Congress.\u200f \u200ePrints and Photographs Division": {
         "Wikidata": "Q66812256",
         "upload": true
-      },
-      "LiLincoln Financial Foundation Collection, Allen County Public Library, Fort Wayne, Indiana": {
-        "Wikidata": "Q69475181",
-        "upload": false
       },
       "Lincoln Financial Foundation Collection, Allen County Public Library, Fort Wayne, Indiana": {
         "Wikidata": "Q69475181",
@@ -23412,6 +23880,10 @@
         "Wikidata": "Q30258153",
         "upload": false
       },
+      "NCPL Weldon Collection": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Nappanee Public Library": {
         "Wikidata": "Q69475116",
         "upload": false
@@ -23425,10 +23897,6 @@
         "upload": false
       },
       "Native American Museum": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "NCPL Weldon Collection": {
         "Wikidata": "",
         "upload": false
       },
@@ -23616,10 +24084,6 @@
         "Wikidata": "",
         "upload": false
       },
-      "Shake Learning Resource Center Vincennes University Library": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Sisters of Providence of Saint Mary-of-the-Woods, Indiana": {
         "Wikidata": "Q3977434",
         "upload": false
@@ -23764,10 +24228,6 @@
         "Wikidata": "Q69475525",
         "upload": false
       },
-      "Vincennes University Archives": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Vincennes University, Bryon R. Lewis Historical Library": {
         "Wikidata": "Q112270143",
         "upload": false
@@ -23831,6 +24291,14 @@
       "Yun, Boyeon": {
         "Wikidata": "Q16892258",
         "upload": false
+      },
+      "d": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "indianapolis Motor Speedway": {
+        "Wikidata": "Q172732",
+        "upload": false
       }
     },
     "upload": false
@@ -23848,6 +24316,10 @@
       },
       "Agawam Public Library": {
         "Wikidata": "Q69862581",
+        "upload": false
+      },
+      "Allen, Jno. R. (John R.), former owner": {
+        "Wikidata": "",
         "upload": false
       },
       "American Medical Association": {
@@ -23890,6 +24362,10 @@
         "Wikidata": "Q4754626",
         "upload": false
       },
+      "Andral, G. (Gabriel), 1797-1876, editor": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Andre B. Sobocinski": {
         "Wikidata": "",
         "upload": false
@@ -23908,6 +24384,10 @@
       },
       "Annisquam Historical Society": {
         "Wikidata": "Q72382654",
+        "upload": false
+      },
+      "Aretaeus, of Cappadocia. Works": {
+        "Wikidata": "",
         "upload": false
       },
       "Armed Forces Institute of Pathology": {
@@ -23966,6 +24446,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Association of American Art Students and the Thomas J. Watson Library, Metropolitan Museum of Art": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Assumption College Library": {
         "Wikidata": "",
         "upload": false
@@ -23990,8 +24474,20 @@
         "Wikidata": "",
         "upload": false
       },
+      "Baillie\u0300re, Hippolyte, publisher": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Barnstable High School-Innovation Learning Library": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Barre Historical Society": {
         "Wikidata": "Q72205575",
+        "upload": false
+      },
+      "Bates Block, Edward, 1874-1932, former owner": {
+        "Wikidata": "",
         "upload": false
       },
       "Baxter, Sylvester": {
@@ -24002,12 +24498,32 @@
         "Wikidata": "Q3695687",
         "upload": false
       },
+      "Baynard, Edward, 1641": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Bazire, P. Victor (Pierre Victor), translator": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Beaman Memorial Library": {
         "Wikidata": "",
         "upload": false
       },
       "Bedford Public Library": {
         "Wikidata": "Q4879182",
+        "upload": false
+      },
+      "Bedford, Gunning S., 1806-1870, editor and translator": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Bell, Andrew, 1726-1809, engraver": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Bell, Charles, Sir, 1774-1842, author": {
+        "Wikidata": "",
         "upload": false
       },
       "Bellingham Public Library": {
@@ -24028,6 +24544,14 @@
       },
       "Berkley Public Library": {
         "Wikidata": "Q69862643",
+        "upload": false
+      },
+      "Beth Israel Deaconess Medical Center": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Beverly Hospital": {
+        "Wikidata": "",
         "upload": false
       },
       "Beverly Public Library": {
@@ -24054,7 +24578,19 @@
         "Wikidata": "Q4917553",
         "upload": false
       },
+      "Black, Adam, 1784-1874, bookseller": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Blackwood, William, 1776-1834, publisher": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Blandford Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Borcheim, Louis E., 1837-1887, former owner": {
         "Wikidata": "",
         "upload": false
       },
@@ -24094,6 +24630,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Boxford Historic Document Center": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Boylston Public Library": {
         "Wikidata": "Q69862762",
         "upload": false
@@ -24118,6 +24658,10 @@
         "Wikidata": "Q3446076",
         "upload": false
       },
+      "Brighton High School Library": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Brimfield Public Library": {
         "Wikidata": "Q69477461",
         "upload": false
@@ -24126,12 +24670,28 @@
         "Wikidata": "Q69477464",
         "upload": false
       },
+      "Brookline High School": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Brooks Free Library": {
         "Wikidata": "Q69477730",
         "upload": false
       },
       "Brown University Library": {
         "Wikidata": "Q22341583",
+        "upload": false
+      },
+      "Brown, Thomas, 1778-1820. Treatise on the philosophy of the human mind": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Bunce, A. H. (Allen Hamilton), 1889-1965, former owner": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Burges & James, printer": {
+        "Wikidata": "",
         "upload": false
       },
       "Burlington Public Library": {
@@ -24178,6 +24738,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Calhoun, A. W. (Abner Wellborn), 1846-1910, former owner": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Cambridge Public Library": {
         "Wikidata": "Q69477479",
         "upload": false
@@ -24198,8 +24762,16 @@
         "Wikidata": "",
         "upload": false
       },
+      "Carey & Hart, publisher": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Carl Sandburg Home National Historic Site": {
         "Wikidata": "Q5040758",
+        "upload": false
+      },
+      "Carnegie Library of Atlanta, former owner": {
+        "Wikidata": "",
         "upload": false
       },
       "Carver Public Library": {
@@ -24214,7 +24786,27 @@
         "Wikidata": "Q387656",
         "upload": false
       },
+      "Cathedral High School": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Cauvin, Joseph, assistant editor": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Centers for Medicare & Medicaid Services Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Cerise, docteur (Laurent Alexandre Philibert Cerisi), 1809-1869": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Chaille\u0301, Stanford E. (Stanford Emerson), 1830-1911. Professional services of Dr. Richardson": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Chance, Frank, 1826-1897, translator": {
         "Wikidata": "",
         "upload": false
       },
@@ -24231,6 +24823,14 @@
         "upload": false
       },
       "Charles Stuart Kennedy; Lorenz Zimmerman": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Charlestown High School": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Charlton Public Library": {
         "Wikidata": "",
         "upload": false
       },
@@ -24274,6 +24874,14 @@
         "Wikidata": "",
         "upload": false
       },
+      "Clark University": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Clarke, John, active approximately 1730-1755, publisher": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Clement C. Maxwell Library at Bridgewater State University": {
         "Wikidata": "",
         "upload": false
@@ -24286,6 +24894,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Colhoun, Samuel, 1787-1841": {
+        "Wikidata": "",
+        "upload": false
+      },
       "College of the Holy Cross Archives and Special Collections": {
         "Wikidata": "",
         "upload": false
@@ -24294,15 +24906,35 @@
         "Wikidata": "Q5149897",
         "upload": false
       },
+      "Comfort, Aaron, 1791-1862, publisher": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Concord Free Public Library": {
         "Wikidata": "Q69477533",
+        "upload": false
+      },
+      "Condie, D. Francis (David Francis), 1796-1875": {
+        "Wikidata": "",
         "upload": false
       },
       "Confederated Salish & Kootenai Tribes of the Flathead Reservation, Montana": {
         "Wikidata": "",
         "upload": false
       },
+      "Connecticut College Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Cooper, Astley, Sir, 1768-1841. Anatomy of the thymus gland": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Cushing Whitney Medical Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Cushing, Harvey, 1869-1939, former owner": {
         "Wikidata": "",
         "upload": false
       },
@@ -24318,7 +24950,15 @@
         "Wikidata": "",
         "upload": false
       },
+      "Delahaye, Adrien, publisher": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Dentistry - University of Toronto": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Derby, Hasket, 1835-1914, translator": {
         "Wikidata": "",
         "upload": false
       },
@@ -24326,8 +24966,16 @@
         "Wikidata": "Q69862892",
         "upload": false
       },
+      "Dighton-Rehoboth Regional School District": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Digital Transgender Archive": {
         "Wikidata": "Q36885603",
+        "upload": false
+      },
+      "Dill, Vincent, Jr., stereotyper": {
+        "Wikidata": "",
         "upload": false
       },
       "Donald Custis": {
@@ -24347,10 +24995,6 @@
         "upload": false
       },
       "Duke University Medical Center Library": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Duverney, M. (Jacques-Franc\u0327ois-Marie), 1661-1748": {
         "Wikidata": "",
         "upload": false
       },
@@ -24386,12 +25030,20 @@
         "Wikidata": "Q5330688",
         "upload": false
       },
+      "Easton Historical Society & Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Edward A. Olson Company": {
         "Wikidata": "",
         "upload": false
       },
       "Eldredge Public Library": {
         "Wikidata": "Q69477494",
+        "upload": false
+      },
+      "Elliot, Charles, -1790, publisher": {
+        "Wikidata": "",
         "upload": false
       },
       "Elms College": {
@@ -24403,6 +25055,10 @@
         "upload": false
       },
       "Emmanuel College, Cardinal Cushing Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Emory College. Library, former owner": {
         "Wikidata": "",
         "upload": false
       },
@@ -24438,12 +25094,20 @@
         "Wikidata": "Q274131",
         "upload": false
       },
+      "Fagan, J. (John), stereotyper": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Fall River Public Library": {
         "Wikidata": "Q69477626",
         "upload": false
       },
       "Falmouth Public Library": {
         "Wikidata": "Q69477627",
+        "upload": false
+      },
+      "Farre, J. R. (John Richard), 1775-1862, contributing author": {
+        "Wikidata": "",
         "upload": false
       },
       "Faulkner Hospital, Ingersoll Bowditch Medical Library": {
@@ -24459,6 +25123,10 @@
         "upload": false
       },
       "Fenway Living History Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Ficklen, J. B. (Joseph Burwell), 1830-1886, former owner": {
         "Wikidata": "",
         "upload": false
       },
@@ -24558,6 +25226,14 @@
         "Wikidata": "",
         "upload": false
       },
+      "Geddings, E. (Eli), 1799-1878, former owner": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "George F. Nesbitt & Co., printer": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Georgetown Peabody Library": {
         "Wikidata": "Q69477659",
         "upload": false
@@ -24570,6 +25246,10 @@
         "Wikidata": "Q11203476",
         "upload": false
       },
+      "Gihon, Albert Leary, 1833-1901, contributing author": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Gill Historical Commission": {
         "Wikidata": "",
         "upload": false
@@ -24579,6 +25259,10 @@
         "upload": false
       },
       "Gloucester Lyceum and Sawyer Free Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Goddard, Paul B. (Paul Beck), 1811-1866": {
         "Wikidata": "",
         "upload": false
       },
@@ -24602,6 +25286,10 @@
         "Wikidata": "Q69477687",
         "upload": false
       },
+      "Great Britain Department of Science and Art": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Great Smoky Mountains": {
         "Wikidata": "Q1360486",
         "upload": false
@@ -24610,8 +25298,20 @@
         "Wikidata": "Q2077144",
         "upload": false
       },
+      "Green, Duff, 1791-1875, stereotyper and publisher": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Greenfield Public Library": {
         "Wikidata": "Q69494588",
+        "upload": false
+      },
+      "Grigg, Elliot & Co., publisher": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Grigg, John, 1792-1864, bookseller": {
+        "Wikidata": "",
         "upload": false
       },
       "Griswold Memorial Library": {
@@ -24619,6 +25319,10 @@
         "upload": false
       },
       "Hadley Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Haller, Albrecht von, 1708-1777, editor": {
         "Wikidata": "",
         "upload": false
       },
@@ -24630,8 +25334,20 @@
         "Wikidata": "",
         "upload": false
       },
+      "Hardwicke, Robert, publisher": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Harpers Ferry Center": {
         "Wikidata": "Q30304014",
+        "upload": false
+      },
+      "Harrild, Thomas, printer": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Harris, H. F. (Henry Fauntleroy), 1867-1926, former owner": {
+        "Wikidata": "",
         "upload": false
       },
       "Harry Butowsky Collection": {
@@ -24654,6 +25370,10 @@
         "Wikidata": "Q69477733",
         "upload": false
       },
+      "Hauser, William, 1812-1880, former owner": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Haverhill Public Library": {
         "Wikidata": "",
         "upload": false
@@ -24662,7 +25382,19 @@
         "Wikidata": "",
         "upload": false
       },
+      "Hays, Isaac, 1796-1879, editor": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Hays, Isaac, 1796-1879, translator": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Health Sciences Library, University of North Carolina at Chapel Hill": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Henry C. Lea (Firm), publisher": {
         "Wikidata": "",
         "upload": false
       },
@@ -24675,6 +25407,14 @@
         "upload": false
       },
       "Herman, Jan K": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Higginbotham, J. J., bookseller": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Highley, Samuel, publisher": {
         "Wikidata": "",
         "upload": false
       },
@@ -24694,7 +25434,15 @@
         "Wikidata": "Q29410510",
         "upload": false
       },
+      "Hobbs, Richard H., stereotyper": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Holbrook Junior-Senior High School": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Holcroft, Thomas, 1745-1809, translator": {
         "Wikidata": "",
         "upload": false
       },
@@ -24707,6 +25455,14 @@
         "upload": false
       },
       "Hopedale Jr. - Sr. High School": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Horner, William E. (William Edmonds), 1793-1853, editor": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Howard, Henry A. (Henry Allen), 1823-1891, former owner": {
         "Wikidata": "",
         "upload": false
       },
@@ -24731,6 +25487,10 @@
         "upload": false
       },
       "Intermountain Region Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "International Foundation for Art Research and the Thomas J. Watson Library at The Metropolitan Museum of Art": {
         "Wikidata": "",
         "upload": false
       },
@@ -24794,12 +25554,20 @@
         "Wikidata": "",
         "upload": false
       },
+      "John Churchill (Firm), publisher": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Joliet Junior College Library": {
         "Wikidata": "",
         "upload": false
       },
       "Jonathan Bourne Public Library": {
         "Wikidata": "Q16892922",
+        "upload": false
+      },
+      "Joseph Gwilt, Thomas Hardwick": {
+        "Wikidata": "",
         "upload": false
       },
       "Kim Barrett Memorial Library, Hospital for Special Surgery": {
@@ -24810,7 +25578,15 @@
         "Wikidata": "",
         "upload": false
       },
+      "La Faye, Georges de, 1699-1781": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Lakeville Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Langley, Batty, 1696-1751.; Gibbs, James, 1682-1754": {
         "Wikidata": "",
         "upload": false
       },
@@ -24870,6 +25646,10 @@
         "Wikidata": "Q69477820",
         "upload": false
       },
+      "Lewis, William, 1708-1781, translator": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Lexington High School": {
         "Wikidata": "",
         "upload": false
@@ -24884,6 +25664,10 @@
       },
       "Lincoln Public Library": {
         "Wikidata": "Q58055491",
+        "upload": false
+      },
+      "Lincoln Town Archives": {
+        "Wikidata": "",
         "upload": false
       },
       "Little Red Shop Museum": {
@@ -24902,6 +25686,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Longman, Brown, Green, and Longmans, publisher": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Longmeadow Historial Society": {
         "Wikidata": "",
         "upload": false
@@ -24914,7 +25702,15 @@
         "Wikidata": "Q2075832",
         "upload": false
       },
+      "Lowell High School": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Lowell Mason House": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Lowell Parks & Conservation Trust": {
         "Wikidata": "",
         "upload": false
       },
@@ -24986,11 +25782,19 @@
         "Wikidata": "",
         "upload": false
       },
+      "Martin, James Ranald, 1796-1874": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Mary Taylor": {
         "Wikidata": "",
         "upload": false
       },
       "Maryland Pharmacists Association": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Massachusetts Board of Library Commissioners": {
         "Wikidata": "",
         "upload": false
       },
@@ -25040,6 +25844,10 @@
       },
       "McGill University Library": {
         "Wikidata": "Q6801308",
+        "upload": false
+      },
+      "Means, Olin S., 1833-1862, former owner": {
+        "Wikidata": "",
         "upload": false
       },
       "MedChi, The Maryland State Medical Society": {
@@ -25114,6 +25922,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Milner and Sowerby, publisher": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Monson Free Library": {
         "Wikidata": "",
         "upload": false
@@ -25128,10 +25940,6 @@
       },
       "Montana State Library": {
         "Wikidata": "Q30268156",
-        "upload": false
-      },
-      "Montana State Water Conservation Board": {
-        "Wikidata": "",
         "upload": false
       },
       "Montana Teachers' Retirement System": {
@@ -25170,6 +25978,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Morell, Thomas, 1703-1784, abridger": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Morrill Memorial Library": {
         "Wikidata": "Q69863288",
         "upload": false
@@ -25178,11 +25990,23 @@
         "Wikidata": "Q69477983",
         "upload": false
       },
+      "Mott, Valentine, 1785-1865": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Mount Wachusett Community College, LaChance Library": {
         "Wikidata": "",
         "upload": false
       },
+      "Mt. Washington Historical Commission": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Mugar Memorial Library, Boston University": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Mumford, Edward William, 1812-1858, engraver": {
         "Wikidata": "",
         "upload": false
       },
@@ -25254,6 +26078,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Noanett Garden Club": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Noble & Cooley Center for Historic Preservation": {
         "Wikidata": "",
         "upload": false
@@ -25318,6 +26146,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Oakley Country Club": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Ohio University Libraries": {
         "Wikidata": "Q58243476",
         "upload": false
@@ -25326,11 +26158,19 @@
         "Wikidata": "",
         "upload": false
       },
+      "Olmsted, John C. (John Cooke), 1851-1928, former owner": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Osborne, Thomas DeCourcey, 1844- (joint author)": {
         "Wikidata": "",
         "upload": false
       },
       "Otis Historical Archives": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Ottley, Drewry": {
         "Wikidata": "",
         "upload": false
       },
@@ -25362,6 +26202,10 @@
         "Wikidata": "Q69862877",
         "upload": false
       },
+      "Pennock, C. W. (Caspar Wistar), 1799-1867, contributing author": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Perkins School for the Blind": {
         "Wikidata": "Q114071",
         "upload": false
@@ -25378,11 +26222,23 @@
         "Wikidata": "Q1432645",
         "upload": true
       },
+      "Phillips, James (Bookseller), printer": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Picot, Jean-Franc\u0327ois, 1731-1791?, publisher": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Pierre Finck": {
         "Wikidata": "",
         "upload": false
       },
       "Pine Manor College, Annenberg Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Piquer, Andres, 1711-1772": {
         "Wikidata": "",
         "upload": false
       },
@@ -25398,6 +26254,14 @@
         "Wikidata": "",
         "upload": false
       },
+      "Poirrier, C., author": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Pottery and Glass Publishing Co. and the Thomas J. Watson Library, The Metropolitan Museum of Art": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Provincetown Arts Press": {
         "Wikidata": "",
         "upload": false
@@ -25410,8 +26274,28 @@
         "Wikidata": "",
         "upload": false
       },
+      "Quain, Richard, 1800-1887": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Raenerius, Joannes, active 16th century": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Randolph, J. (Jacob), 1796-1848, editor": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Raynham Public Library": {
         "Wikidata": "Q69478134",
+        "upload": false
+      },
+      "Read, W., engraver": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Read, William, active 1817-1842, engraver": {
+        "Wikidata": "",
         "upload": false
       },
       "Reading Public Library": {
@@ -25422,7 +26306,19 @@
         "Wikidata": "",
         "upload": false
       },
+      "Reese, David Meredith, 1800-1861, editor": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Regis College Archives": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Reuben Hoar Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Revere, John, 1787-1847, translator": {
         "Wikidata": "",
         "upload": false
       },
@@ -25438,7 +26334,23 @@
         "Wikidata": "",
         "upload": false
       },
+      "Roberts, Stewart R. (Stewart Ralph), 1878-1941, former owner": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Rodgers, Robert L., former owner": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Roger, Henri, 1809-1891, author": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Roslindale Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Rotheram, John, 1751-1804": {
         "Wikidata": "",
         "upload": false
       },
@@ -25490,6 +26402,10 @@
         "Wikidata": "Q3695750",
         "upload": false
       },
+      "Samuel S. & William Wood (Firm), publisher": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Sandwich Town Archives": {
         "Wikidata": "",
         "upload": false
@@ -25522,8 +26438,16 @@
         "Wikidata": "Q69861306",
         "upload": false
       },
+      "Sheddon, Alex, illustrator": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Sherborn Library": {
         "Wikidata": "Q69478204",
+        "upload": false
+      },
+      "Shrewsbury Public Library": {
+        "Wikidata": "",
         "upload": false
       },
       "Silver Special Collections Library, University of Vermont": {
@@ -25540,6 +26464,10 @@
       },
       "Simon Fairfield Public Library": {
         "Wikidata": "Q7518715",
+        "upload": false
+      },
+      "Skinner, George Wilhelm": {
+        "Wikidata": "",
         "upload": false
       },
       "Society of the Arts": {
@@ -25594,6 +26522,10 @@
         "Wikidata": "Q7581060",
         "upload": false
       },
+      "Spruce Technologies": {
+        "Wikidata": "",
+        "upload": false
+      },
       "St John's Lutheran Church": {
         "Wikidata": "",
         "upload": false
@@ -25618,6 +26550,18 @@
         "Wikidata": "",
         "upload": false
       },
+      "Stitt, A. A., printer": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Stockdale, John Joseph, 1770-1847, publisher": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Stodder, Samuel, stereotyper": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Stoneham Public Library": {
         "Wikidata": "Q7619190",
         "upload": false
@@ -25627,6 +26571,10 @@
         "upload": false
       },
       "Storrs Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Story, G. (George), 1738-1818, printer": {
         "Wikidata": "",
         "upload": false
       },
@@ -25658,6 +26606,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Swinney, Myles, printer": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Taft Public Library": {
         "Wikidata": "Q69492131",
         "upload": false
@@ -25666,8 +26618,16 @@
         "Wikidata": "",
         "upload": false
       },
+      "Teachers' Retirement System": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Thayer Public Library": {
         "Wikidata": "Q69477451",
+        "upload": false
+      },
+      "The Cape Playhouse": {
+        "Wikidata": "",
         "upload": false
       },
       "The College of Physicians of Philadelphia Historical Medical Library": {
@@ -25738,6 +26698,14 @@
         "Wikidata": "Q2471216",
         "upload": false
       },
+      "Thomas, Robert P. (Robert Pennell), 1821-1864, editor": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Thomson, William, 1819-1883, contributing author": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Thoreau Society Collections at the Thoreau Institute at Walden Woods": {
         "Wikidata": "",
         "upload": false
@@ -25762,6 +26730,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Town of Belchertown": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Town of Boxford": {
         "Wikidata": "",
         "upload": false
@@ -25775,6 +26747,10 @@
         "upload": false
       },
       "Town of Fairhaven, Massachusetts": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Town of Holliston MA": {
         "Wikidata": "",
         "upload": false
       },
@@ -25867,6 +26843,10 @@
         "upload": false
       },
       "Tyringham Historical Commission": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "U.S. Department of Agriculture, National Agricultural Library": {
         "Wikidata": "",
         "upload": false
       },
@@ -26034,6 +27014,14 @@
         "Wikidata": "Q7958788",
         "upload": false
       },
+      "Wadsworth, Daniel, 1771-1848, former owner": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Walpole High School": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Walpole Historical Society": {
         "Wikidata": "",
         "upload": false
@@ -26050,11 +27038,23 @@
         "Wikidata": "Q69863525",
         "upload": false
       },
+      "Watkins, Jonathan Hill, 1818-1897, former owner": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Wayland Free Public Library": {
         "Wikidata": "Q69863527",
         "upload": false
       },
+      "Weaver, J. Calvin (John Calvin), 1879-1958, former owner": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Webster Family Library of Veterinary Medicine": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Welch, Thomas B., 1814-1874, engraver": {
         "Wikidata": "",
         "upload": false
       },
@@ -26150,6 +27150,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "William Blackwood and Sons, publisher": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Williams College Libraries": {
         "Wikidata": "",
         "upload": false
@@ -26222,6 +27226,40 @@
     "institutions": {
       "Getty Research Institute": {
         "Wikidata": "Q11203476",
+        "upload": false
+      }
+    },
+    "upload": false
+  },
+  "Jewish Heritage and History Hub": {
+    "Wikidata": "",
+    "institutions": {
+      "American Jewish Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "American Sephardi Federation": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Leo Baeck Institute": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Leo Baeck Research Institute": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "The Blavatnik Archive": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "YIVO Institute for Jewish Research": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Yeshiva University Museum": {
+        "Wikidata": "",
         "upload": false
       }
     },
@@ -26350,6 +27388,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Cranbrook Center for Collections and Research": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Detroit Historical Society": {
         "Wikidata": "Q30257995",
         "upload": false
@@ -26394,7 +27436,15 @@
         "Wikidata": "",
         "upload": false
       },
-      "Oakland County Historical Resources": {
+      "Paw Paw District Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Rochester Hills Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Saugatuck Douglas History Center": {
         "Wikidata": "",
         "upload": false
       },
@@ -26432,6 +27482,10 @@
   "Minnesota Digital Library": {
     "Wikidata": "Q83878485",
     "institutions": {
+      "1933-04-28": {
+        "Wikidata": "",
+        "upload": false
+      },
       "American Craft Council": {
         "Wikidata": "Q4743559",
         "upload": false
@@ -26624,10 +27678,6 @@
         "Wikidata": "",
         "upload": false
       },
-      "Freeborn County Historical Museum": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Geological Society of Minnesota": {
         "Wikidata": "",
         "upload": false
@@ -26676,11 +27726,11 @@
         "Wikidata": "Q530512",
         "upload": true
       },
-      "Hennepin History Museum": {
+      "Hennepin Healthcare History Center": {
         "Wikidata": "",
         "upload": false
       },
-      "Hennepin Medical History Center": {
+      "Hennepin History Museum": {
         "Wikidata": "",
         "upload": false
       },
@@ -26713,6 +27763,10 @@
         "upload": false
       },
       "Icelandic Hekla Club": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Institute for Advanced Study, University of Minnesota": {
         "Wikidata": "",
         "upload": false
       },
@@ -27212,6 +28266,10 @@
         "Wikidata": "Q2495874",
         "upload": true
       },
+      "University of Minnesota Duluth, Kathryn A. Martin Library, University Archives": {
+        "Wikidata": "",
+        "upload": false
+      },
       "University of Minnesota Libraries": {
         "Wikidata": "Q7895799",
         "upload": true
@@ -27307,6 +28365,276 @@
     },
     "upload": false
   },
+  "Mississippi Digital Library": {
+    "Wikidata": "",
+    "institutions": {
+      "Alcorn State University": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Alcorn state University": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Amite County Historical and Genealogical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Beauvoir: The Jefferson Davis Home and Presidential Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Billups-Garth Archives, Columbus-Lowndes Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Billups-Garth Archives, Local History Collection, Columbus-Lowndes Public Library System": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Billups-Garth Archives, Local History Department, Columbus-Lowndes Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Billups-Garth Archives, Local History Department, Columbus-Lowndes Public Library System": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Billups-Garth archives, Local History Department, Columbus-Lowndes Public Library System": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Blue Mountain Christian University": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Blue Mountain Christian University..": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Camp Van Dorn World War II Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Canton Public Library, Madison County Library System": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Carnegie Public Library of Clarksdale and Coahoma County": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Catholic Diocese of Jackson": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Delta State University Archives and Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "First Regional Library System": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "From the Estate of Arlin Warren": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "From the World War II scrapbook of George Soper": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "From the estate of Arlin Warren": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Garvin H. Johnston Library, Pearl River Community College": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Gulf Park College for Women": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Gulfport Museum of History": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Hancock County Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Hattiesburg Area Historical Society and Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Item housed at Billups-Garth Archives, Local History Department, Columbus-Lowndes Public Library System": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Item housed at Hancock County Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Item housed at Pontotoc County Library, Dixie Regional Library System": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Item housed at Pontotoc County Library, Dixie Regional Library system": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Item housed at Robinson-Carpenter Memorial Library, Bolivar County Library System": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Laurel-Jones County Library, Laurel-Jones County Public Library System, Inc": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Lauren Rogers Museum of Art": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Lee Itawamba Library System": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Library of Hattiesburg, Petal, and Forrest County": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Local History and Genealogy Collections, Biloxi Public Library, Harrison County Library System": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Marion County Courthouse": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "McLendon Library, Hinds Community College": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Mississippi Armed Forces Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Mississippi Department of Archives and History": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Mississippi Federation of Women's Clubs": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Mississippi Gulf Coast Community College": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Mississippi Library Commission": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Mississippi University for Women Archives": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Northwest Mississippi Community College": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Ohr-O'Keefe Museum of Art": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Old Courthouse Museum, Tishomingo County Historical and Genealogical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Oren Dunn City Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Part of a collection purchased at an estate sale by Josie Valentine. Collection includes 90 negatives & proofs with names & addresses. Photos were taken at Camp Van Dorn": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Part of a collection purchased at an estate sale by Josie Valentine. Collection includes 90 negatives and proofs with names and addresses. Photos were taken at Camp Van Dorn": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Part of a collection purchased at an estate sale by Josie Valentine. Photos were taken at Camp Van Dorn. Collection includes 90 negatives and proofs with names and addresses": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Philadelphia-Neshoba County Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Pontotoc County Library, Dixie Regional Library System": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Pontotoc County Library, Dixie Regional Library System.": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Purchased on E-Bay": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Robinson-Carpenter Memorial Library, Bolivar County Library System": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Singing River Genealogy and Local History Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "South Mississippi Genealogical and Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Special Collections and University Archives, Henry T. Sampson Library, Jackson State University": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Special Collections, University Libraries, University of Southern Mississippi": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "State Law Library of Mississippi": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Sunflower County Library System": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "The University of Mississippi": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "This jewelry box was made for Janis Whitehead by an Austrian prosoner of war at Camp Van dorn, MS in 1945. The box is now in the possession of Olivia Whitehead of Woodville, MS": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Tippah County Archives": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Tippah County Historical and Genealogical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Walter Anderson Museum of Art": {
+        "Wikidata": "",
+        "upload": false
+      }
+    },
+    "upload": false
+  },
   "Mountain West Digital Library": {
     "Wikidata": "Q18391337",
     "institutions": {
@@ -27341,10 +28669,6 @@
       "Center for Asian Pacific Studies, University of Oregon": {
         "Wikidata": "Q65385681",
         "upload": true
-      },
-      "City of Mapleton (Utah)": {
-        "Wikidata": "",
-        "upload": false
       },
       "Daughters of the Utah Pioneers, Cedar City (UT)": {
         "Wikidata": "",
@@ -27430,23 +28754,15 @@
         "Wikidata": "",
         "upload": false
       },
-      "Lewiston City (UT) Public Library": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Life Story Library Foundation": {
         "Wikidata": "",
         "upload": false
       },
-      "Logan (UT) Public Library": {
+      "Mapleton (UT)": {
         "Wikidata": "",
         "upload": false
       },
       "Marriott-Slaterville (UT) City": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Mendon (UT)": {
         "Wikidata": "",
         "upload": false
       },
@@ -27470,15 +28786,7 @@
         "Wikidata": "",
         "upload": false
       },
-      "Newton Town (UT) Library": {
-        "Wikidata": "",
-        "upload": false
-      },
       "North Bingham County (ID) District Library": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "North Logan City (UT) Library": {
         "Wikidata": "",
         "upload": false
       },
@@ -27626,12 +28934,12 @@
         "Wikidata": "Q21016297",
         "upload": false
       },
-      "Utah State Library": {
-        "Wikidata": "Q21189104",
+      "Utah State Archives": {
+        "Wikidata": "",
         "upload": false
       },
-      "Utah State University - Merrill-Cazier Library": {
-        "Wikidata": "",
+      "Utah State Library": {
+        "Wikidata": "Q21189104",
         "upload": false
       },
       "Utah Territorial Statehouse State Park Museum": {
@@ -28076,6 +29384,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Avery County Historical Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Badin Historic Museum": {
         "Wikidata": "",
         "upload": false
@@ -28310,6 +29622,10 @@
       },
       "Davidson College": {
         "Wikidata": "Q2902978",
+        "upload": false
+      },
+      "Davidson County Historical Museum": {
+        "Wikidata": "",
         "upload": false
       },
       "Davidson County Public Library System": {
@@ -28604,6 +29920,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "History Museum of Burke County": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Hocutt-Ellington Memorial Library (Clayton, N.C.)": {
         "Wikidata": "",
         "upload": false
@@ -28680,6 +30000,10 @@
         "Wikidata": "Q6535654",
         "upload": false
       },
+      "Lewisville Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Liberty Public Library": {
         "Wikidata": "Q104443095",
         "upload": false
@@ -28693,6 +30017,10 @@
         "upload": false
       },
       "Little River Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Little Theatre of Winston-Salem": {
         "Wikidata": "",
         "upload": false
       },
@@ -28733,6 +30061,10 @@
         "upload": false
       },
       "Martin Memorial Public Library (Williamston, N.C.)": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Mary Potter Alumni Club": {
         "Wikidata": "",
         "upload": false
       },
@@ -28836,10 +30168,6 @@
         "Wikidata": "Q6966772",
         "upload": false
       },
-      "National Council of Negro Women, Inc. Durham Section": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Neuse Regional Library": {
         "Wikidata": "Q69481951",
         "upload": false
@@ -28881,6 +30209,14 @@
         "upload": false
       },
       "North Carolina National Guard Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "North Carolina Peanut Growers Association, Inc": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "North Carolina Pottery Center": {
         "Wikidata": "",
         "upload": false
       },
@@ -29124,6 +30460,10 @@
         "Wikidata": "Q7416258",
         "upload": false
       },
+      "Sanford Lions Club": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Sanford Woman's Club": {
         "Wikidata": "",
         "upload": false
@@ -29165,6 +30505,10 @@
         "upload": false
       },
       "Southwestern Community College": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Springfield Friends Meeting": {
         "Wikidata": "",
         "upload": false
       },
@@ -29288,6 +30632,10 @@
         "Wikidata": "Q69493421",
         "upload": false
       },
+      "W. B. Wicker Alumni": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Wachovia Historical Society": {
         "Wikidata": "",
         "upload": false
@@ -29341,6 +30689,10 @@
         "upload": false
       },
       "Wendell Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "West Point on the Eno": {
         "Wikidata": "",
         "upload": false
       },
@@ -29414,11 +30766,11 @@
         "Wikidata": "",
         "upload": false
       },
-      "Ancestry": {
+      "Adams County Historical Society": {
         "Wikidata": "",
         "upload": false
       },
-      "Archdiocese of Seattle": {
+      "Ancestry": {
         "Wikidata": "",
         "upload": false
       },
@@ -29479,10 +30831,6 @@
         "upload": false
       },
       "Blue Mountain Heritage Society": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Blue Sky Gallery": {
         "Wikidata": "",
         "upload": false
       },
@@ -29550,10 +30898,6 @@
         "Wikidata": "",
         "upload": false
       },
-      "City of Portland Archives": {
-        "Wikidata": "",
-        "upload": false
-      },
       "City of Sumas, Washington": {
         "Wikidata": "",
         "upload": false
@@ -29606,11 +30950,11 @@
         "Wikidata": "",
         "upload": false
       },
-      "Darrington Historical Society": {
+      "Daughters of the Pioneers of Washington State": {
         "Wikidata": "",
         "upload": false
       },
-      "Daughters of the Pioneers of Washington State": {
+      "Davenport Public Library": {
         "Wikidata": "",
         "upload": false
       },
@@ -29658,23 +31002,11 @@
         "Wikidata": "",
         "upload": false
       },
-      "Edmonds Historical Society and Museum": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Elijah Hasan": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Ellensburg Public Library": {
         "Wikidata": "",
         "upload": false
       },
       "Enumclaw Plateau Historical Society": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Everett Herald": {
         "Wikidata": "",
         "upload": false
       },
@@ -29746,15 +31078,15 @@
         "Wikidata": "",
         "upload": false
       },
-      "Granite Falls Historical Society": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Grant County Museum": {
         "Wikidata": "",
         "upload": false
       },
       "Greater Kent Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Green River College": {
         "Wikidata": "",
         "upload": false
       },
@@ -29771,10 +31103,6 @@
         "upload": false
       },
       "Harney County Library": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Heart Mountain Wyoming Foundation": {
         "Wikidata": "",
         "upload": false
       },
@@ -29819,14 +31147,6 @@
         "upload": false
       },
       "Japanese American Film Preservation Project": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Japanese American Museum of Oregon": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Japanese American Museum of San Jose": {
         "Wikidata": "",
         "upload": false
       },
@@ -29902,6 +31222,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Lincoln County Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Longview Public Library": {
         "Wikidata": "",
         "upload": false
@@ -29942,6 +31266,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Mazamas": {
+        "Wikidata": "",
+        "upload": false
+      },
       "McCoy Valley Museum, Oakesdale Historical Society": {
         "Wikidata": "Q113488678",
         "upload": true
@@ -29970,10 +31298,6 @@
         "Wikidata": "",
         "upload": false
       },
-      "Monroe Historical Society": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Moran Prairie Washington State Grange #161": {
         "Wikidata": "",
         "upload": false
@@ -29986,15 +31310,15 @@
         "Wikidata": "",
         "upload": false
       },
-      "Multnomah County Library": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Museum of Flight": {
         "Wikidata": "",
         "upload": false
       },
       "Museum of History & Industry (MOHAI)": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Museum of Northwest Art": {
         "Wikidata": "",
         "upload": false
       },
@@ -30102,18 +31426,6 @@
         "Wikidata": "Q7101346",
         "upload": true
       },
-      "Oregon State University Libraries": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Pacific Citizen": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Pacific Northwest Naval Air Museum": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Pacific University": {
         "Wikidata": "",
         "upload": false
@@ -30143,10 +31455,6 @@
         "upload": false
       },
       "Port Angeles Public Library": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Portland State University": {
         "Wikidata": "",
         "upload": false
       },
@@ -30183,6 +31491,10 @@
         "upload": false
       },
       "Ridgefield Heritage Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Ritzville Public Library, East Adams Library District": {
         "Wikidata": "",
         "upload": false
       },
@@ -30270,15 +31582,7 @@
         "Wikidata": "",
         "upload": false
       },
-      "Snohomish Historical Society": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Snoqualmie Valley Historical Society": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "South Bay Japanese American Citizens League": {
         "Wikidata": "",
         "upload": false
       },
@@ -30297,10 +31601,6 @@
       "Staley Museum": {
         "Wikidata": "Q113488761",
         "upload": true
-      },
-      "Stanwood Area Historical Society": {
-        "Wikidata": "",
-        "upload": false
       },
       "State Library of Oregon": {
         "Wikidata": "",
@@ -30346,6 +31646,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Tillamook Air Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Timberland Regional Library": {
         "Wikidata": "",
         "upload": false
@@ -30383,6 +31687,10 @@
         "upload": true
       },
       "University of Idaho": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "University of Oregon Libraries": {
         "Wikidata": "",
         "upload": false
       },
@@ -30459,6 +31767,10 @@
         "upload": false
       },
       "Western Oregon University": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Western Washington University": {
         "Wikidata": "",
         "upload": false
       },
@@ -30588,20 +31900,8 @@
         "Wikidata": "",
         "upload": false
       },
-      "Stillwater Public Library, Stillwater, Oklahoma": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "University of Central Oklahoma Library": {
-        "Wikidata": "",
-        "upload": false
-      },
       "University of Oklahoma Libraries": {
         "Wikidata": "Q73644768",
-        "upload": false
-      },
-      "University of Tulsa - McFarlin Library": {
-        "Wikidata": "",
         "upload": false
       }
     },
@@ -30630,6 +31930,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Central Ohio Fire Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Cincinnati and Hamilton County Public Library": {
         "Wikidata": "",
         "upload": false
@@ -30643,6 +31947,10 @@
         "upload": true
       },
       "Cleveland State University": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Clintonville Woman's Club": {
         "Wikidata": "",
         "upload": false
       },
@@ -30677,10 +31985,6 @@
       "Kent State University": {
         "Wikidata": "Q1473615",
         "upload": true
-      },
-      "Kent State University Libraries": {
-        "Wikidata": "",
-        "upload": false
       },
       "Kenyon College": {
         "Wikidata": "Q1797768",
@@ -30720,6 +32024,10 @@
       },
       "Ohio History Connection": {
         "Wikidata": "Q3349886",
+        "upload": false
+      },
+      "Ohio University": {
+        "Wikidata": "",
         "upload": false
       },
       "Ohio University Libraries": {
@@ -30822,7 +32130,15 @@
   "PA Digital": {
     "Wikidata": "Q83878501",
     "institutions": {
+      "Abington Senior High School": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Abington Township Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Academy of Natural Sciences of Drexel University": {
         "Wikidata": "",
         "upload": false
       },
@@ -31022,7 +32338,7 @@
         "Wikidata": "Q69489784",
         "upload": false
       },
-      "Friends Historical Library of Swarthmore College": {
+      "Free Library of Philadelphia - Joseph E. Coleman Northwest Regional Library": {
         "Wikidata": "",
         "upload": false
       },
@@ -31047,10 +32363,6 @@
         "upload": false
       },
       "Greene-Dreher Historical Society": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Haverford College Quaker and Special Collections and Friends Historical Library of Swarthmore College": {
         "Wikidata": "",
         "upload": false
       },
@@ -31082,6 +32394,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Julia R. Masterman Demonstration School": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Juniata College": {
         "Wikidata": "",
         "upload": false
@@ -31091,6 +32407,10 @@
         "upload": false
       },
       "Kiski School": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Kittanning Public Library": {
         "Wikidata": "",
         "upload": false
       },
@@ -31122,6 +32442,10 @@
         "Wikidata": "Q622137",
         "upload": false
       },
+      "Ligonier Valley Library": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Lock Haven University of Pennsylvania": {
         "Wikidata": "Q6665223",
         "upload": false
@@ -31146,6 +32470,10 @@
         "Wikidata": "Q69963070",
         "upload": false
       },
+      "Mechanicsburg Area Senior High School": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Media Historic Archives Commission": {
         "Wikidata": "",
         "upload": false
@@ -31163,6 +32491,14 @@
         "upload": false
       },
       "Milanof-Schock Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Miller Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Miller Library at Keystone College": {
         "Wikidata": "",
         "upload": false
       },
@@ -31227,6 +32563,10 @@
         "upload": false
       },
       "Old Economy Village - Archives": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Old Economy Village \u2013 Archives": {
         "Wikidata": "",
         "upload": false
       },
@@ -31306,6 +32646,10 @@
         "Wikidata": "Q7300541",
         "upload": false
       },
+      "Ridley Park Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Rockwood Area Historical and Genealogical Society": {
         "Wikidata": "",
         "upload": false
@@ -31338,12 +32682,20 @@
         "Wikidata": "Q7458274",
         "upload": false
       },
+      "Sewickley Township Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Sisters of St. Joseph of Baden": {
         "Wikidata": "",
         "upload": false
       },
       "Slippery Rock University": {
         "Wikidata": "Q7540904",
+        "upload": false
+      },
+      "Somerset County Library": {
+        "Wikidata": "",
         "upload": false
       },
       "Springs Historical Society": {
@@ -31415,6 +32767,10 @@
         "upload": false
       },
       "Uniontown Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Unionville High School": {
         "Wikidata": "",
         "upload": false
       },
@@ -31544,6 +32900,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Buffalo Bill Museum and Grave": {
+        "Wikidata": "",
+        "upload": false
+      },
       "CU Art Museum, University of Colorado Boulder": {
         "Wikidata": "",
         "upload": false
@@ -31624,6 +32984,10 @@
         "Wikidata": "Q69470221",
         "upload": false
       },
+      "East High School Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Estes Park Museum": {
         "Wikidata": "",
         "upload": false
@@ -31672,6 +33036,10 @@
         "Wikidata": "Q5774674",
         "upload": false
       },
+      "History Jackson Hole": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Hotchkiss-Crawford Historical Society": {
         "Wikidata": "",
         "upload": false
@@ -31684,7 +33052,7 @@
         "Wikidata": "",
         "upload": false
       },
-      "Lafayette Miners Museum": {
+      "Lafayette History Museum": {
         "Wikidata": "",
         "upload": false
       },
@@ -31820,10 +33188,6 @@
         "Wikidata": "Q58036452",
         "upload": true
       },
-      "University of Colorado Colorado Springs. Kraemer Family Library": {
-        "Wikidata": "",
-        "upload": false
-      },
       "University of Denver": {
         "Wikidata": "",
         "upload": false
@@ -31870,6 +33234,10 @@
         "Wikidata": "Q69865102",
         "upload": false
       },
+      "America's Black Holocaust Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Angie W. Cox Public Library": {
         "Wikidata": "",
         "upload": false
@@ -31883,6 +33251,10 @@
         "upload": false
       },
       "Ashland Historical Society Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Belleville Public Library (Wisconsin)": {
         "Wikidata": "",
         "upload": false
       },
@@ -31982,11 +33354,19 @@
         "Wikidata": "",
         "upload": false
       },
+      "Edgerton Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Edgewood College": {
         "Wikidata": "Q5337885",
         "upload": false
       },
       "Elkhart Lake Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Fond du Lac Public Library": {
         "Wikidata": "",
         "upload": false
       },
@@ -32010,11 +33390,19 @@
         "Wikidata": "",
         "upload": false
       },
+      "Hedberg Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Hortonville Public Library": {
         "Wikidata": "Q69865436",
         "upload": false
       },
       "Iowa County Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Jacobsens Museum": {
         "Wikidata": "",
         "upload": false
       },
@@ -32118,6 +33506,14 @@
         "Wikidata": "Q6806307",
         "upload": false
       },
+      "Menomonee Falls Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Middleton Area Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Milton Public Library": {
         "Wikidata": "",
         "upload": false
@@ -32127,6 +33523,10 @@
         "upload": false
       },
       "Milwaukee County Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Milwaukee Institute of Art & Design": {
         "Wikidata": "",
         "upload": false
       },
@@ -32143,6 +33543,10 @@
         "upload": false
       },
       "Mineral Point Library Archives": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Montello Public Library": {
         "Wikidata": "",
         "upload": false
       },
@@ -32302,6 +33706,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Sun Prairie Historical Library & Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Sun Prairie Public Library": {
         "Wikidata": "",
         "upload": false
@@ -32311,6 +33719,10 @@
         "upload": false
       },
       "Three Lakes Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Tomah Area Historical Society and Museum": {
         "Wikidata": "",
         "upload": false
       },
@@ -32420,14 +33832,6 @@
         "Wikidata": "",
         "upload": false
       },
-      "Freer Gallery of Art and Arthur M. Sackler Gallery": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Freer Gallery of Art and Arthur M. Sackler Gallery Archives": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Human Studies Film Archives": {
         "Wikidata": "Q5937570",
         "upload": false
@@ -32492,6 +33896,14 @@
         "Wikidata": "Q148584",
         "upload": false
       },
+      "National Museum of Asian Art": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "National Museum of Asian Art Archives": {
+        "Wikidata": "",
+        "upload": false
+      },
       "National Museum of the American Indian": {
         "Wikidata": "",
         "upload": false
@@ -32534,92 +33946,12 @@
   "South Carolina Digital Library": {
     "Wikidata": "Q83878510",
     "institutions": {
-      "600 dpi, 24-bit, sRGB, color, Epson Expression 10000 XL Scanner. Archival Master file is a TIFF. JPG images digitally enhanced with Adobe Photoshop CS6": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "A. E. Staley Mfg. Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "A. J. Lindemann & Hoverson Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Abbott Laboratories": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Abraham Lincoln Birthplace National Historical Park": {
         "Wikidata": "Q181471",
         "upload": false
       },
-      "Abram Cox Stove Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Acme Packing Company Incorporated": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Airy Fairy": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Alaga Syrup": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "All-Timer Quality Aluminum": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Allen University": {
         "Wikidata": "Q49041",
-        "upload": false
-      },
-      "Aluminum Goods Manufacturing Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "American Bakeries Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "American Beauty": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "American Can Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "American Gas Association": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "American Gas Machine Co.;Queen Stove Works, Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "American Institute of Baking, Chicago, Illinois": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "American Kitchen Products": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "American Meat Institute": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "American Pop Corn Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "American Sugar Refining Company": {
-        "Wikidata": "",
         "upload": false
       },
       "Andersonville National Historic Site": {
@@ -32634,47 +33966,7 @@
         "Wikidata": "",
         "upload": false
       },
-      "Angelus Campfire Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Arm & Hammer, New York": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Arm & Hammer, New York Cow Brand Baking Soda, Church and Dwight Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Arm & Hammer, New York Cow Brand, Church and Dwight Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Armour": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Armour and Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Arvin Industries, Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Associated Salmon Packers": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Association of Hawaiian Pineapple Canners, San Francisco, California": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Avery Research Center at the College of Charleston": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Baker's": {
         "Wikidata": "",
         "upload": false
       },
@@ -32688,10 +33980,6 @@
       },
       "Beaufort County Library": {
         "Wikidata": "Q69490334",
-        "upload": false
-      },
-      "Belknap Hardware and Manufacturing Co., Incorporated": {
-        "Wikidata": "",
         "upload": false
       },
       "Belle W. Baruch Foundation": {
@@ -32718,24 +34006,8 @@
         "Wikidata": "",
         "upload": false
       },
-      "Berlin Mills Company": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Betty Crocker": {
         "Wikidata": "Q4898793",
-        "upload": false
-      },
-      "Birds Eye Brand": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Birmingham Gas Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Blue Ribbon": {
-        "Wikidata": "",
         "upload": false
       },
       "Bob Campbell Geology Museum": {
@@ -32750,43 +34022,7 @@
         "Wikidata": "",
         "upload": false
       },
-      "Bond Bread": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Borden": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Borden's Eagle Brand": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Borden's Evaporated Milk": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Borden-Wieland": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Brazil Nut Advertising Fund": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Brer Rabbit": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Brockton Public Market": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Brookgreen Gardens, www.brookgreen.org": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Burnham & Morrill Co": {
         "Wikidata": "",
         "upload": false
       },
@@ -32794,47 +34030,7 @@
         "Wikidata": "",
         "upload": false
       },
-      "Calavo Growers of California": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "California Associated Raisin Co., Fresno, California": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "California Fruit Grower Exchange": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "California Fruit Growers Exchange": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "California Fruit Growers Exchange, Bert L. White Company, Los Angeles, California": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "California Fruit Growers Exchange, Los Angeles, California": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "California Prune and Apricot Growers Assn., San Jose, Cal": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Caloric": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Calumet Baking Powder Co, General Foods": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Calumet Baking Powder Co., Chicago, Illinois": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Calumet Baking Powder Company": {
+      "CLEM": {
         "Wikidata": "",
         "upload": false
       },
@@ -32842,24 +34038,8 @@
         "Wikidata": "",
         "upload": false
       },
-      "Campbell's": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Canned Salmon Industry": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Carl Sandburg Home National Historic Site": {
         "Wikidata": "Q5040758",
-        "upload": false
-      },
-      "Carnation Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Carnation Milk": {
-        "Wikidata": "",
         "upload": false
       },
       "Catholic Diocese of Charleston Archives": {
@@ -32867,30 +34047,6 @@
         "upload": false
       },
       "Cayce Historical Museum, South Carolina": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Certo": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Charles B. Knox Co., Johnstown, New York": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Charles B. Knox Gelatine Co., Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Charles B. Knox Gelatine Co., Inc, Johnstown, New York": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Charles B. Knox Gelatine Co., Inc., Johnstown, New York, Montreal, Canada": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Charles Gulden, Inc": {
         "Wikidata": "",
         "upload": false
       },
@@ -32938,22 +34094,6 @@
         "Wikidata": "",
         "upload": false
       },
-      "Chicago Flexible Shaft Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Chicken of the Sea": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Chr. Hansen's Laboratory, Inc.;The Junket Folks": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Church & Dwight Co., Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
       "City of Charleston": {
         "Wikidata": "",
         "upload": false
@@ -32986,6 +34126,18 @@
         "Wikidata": "",
         "upload": false
       },
+      "Clemson University LibrariesClemson University Libraries": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Clemson University LibrariesClemson University Libraries Special Collections and Archives": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Clemson University LibrariesSouth Carolina Department of Parks, Recreation and Tourism": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Coastal Carolina Universitiy": {
         "Wikidata": "",
         "upload": false
@@ -32999,10 +34151,6 @@
         "upload": false
       },
       "Coastal Carolina University, University Archives and Special Collections": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Cobb Preserving Co": {
         "Wikidata": "",
         "upload": false
       },
@@ -33031,6 +34179,10 @@
         "upload": false
       },
       "College of Charleston Libraries": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "College of Charleston Libraries,College of Charleston Libraries": {
         "Wikidata": "",
         "upload": false
       },
@@ -33082,68 +34234,16 @@
         "Wikidata": "",
         "upload": false
       },
-      "Cookware Company of America": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Corn Products Refining Co": {
         "Wikidata": "Q19063655",
-        "upload": false
-      },
-      "Corn Products Refining Company": {
-        "Wikidata": "",
         "upload": false
       },
       "Cowpens National Battlefield": {
         "Wikidata": "",
         "upload": false
       },
-      "Cribben and Sexton Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Crisco": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Crosley": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Crown Cork & Seal Co., Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Curtice Brothers Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Deepfreeze;Motor Products Corporation": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Del Monte": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Delmonico Foods, Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Detroit Stove Wks": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Diamond Walnuts": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Dorchester County Library": {
         "Wikidata": "Q69490371",
-        "upload": false
-      },
-      "Dr. Price's Vanilla": {
-        "Wikidata": "",
         "upload": false
       },
       "Drayton Hall: A National Historic Trust Site": {
@@ -33154,22 +34254,6 @@
         "Wikidata": "Q5306874",
         "upload": false
       },
-      "Dromedary": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Dutch Tea Rusk Co., Holland MI": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Edicraft;Edison;The Longacre Press, Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Edison General Electric Appliance Company, Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Edisto Island Historic Preservation Society": {
         "Wikidata": "Q30265623",
         "upload": false
@@ -33178,27 +34262,11 @@
         "Wikidata": "",
         "upload": false
       },
-      "Enterprise": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Erskine College": {
         "Wikidata": "Q5395822",
         "upload": false
       },
       "Erskine College Library, Department of Archives and Special Collections": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Estate Stove Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Evaporated Milk Association": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "F. G. Vogt & Sons, Inc": {
         "Wikidata": "",
         "upload": false
       },
@@ -33214,10 +34282,6 @@
         "Wikidata": "",
         "upload": false
       },
-      "Fels-Naptha": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Florence County Library System, http://www.florencelibrary.org/wordpress": {
         "Wikidata": "",
         "upload": false
@@ -33230,7 +34294,7 @@
         "Wikidata": "Q1438683",
         "upload": false
       },
-      "Fort Sumter National Monument and Charles Pinckney National Historic Site": {
+      "Fort Sumter National Monument and Charles Pinckney National Historic SiteNational Park Service": {
         "Wikidata": "",
         "upload": false
       },
@@ -33246,39 +34310,7 @@
         "Wikidata": "",
         "upload": false
       },
-      "Frank E. Davis Fish Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Franklin Granulated Sugar": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "French's": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Friends of the Hunley": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Frigidaire": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Frigidaire Division, General Motors Corporation": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Frigidaire;Delco-Light Company;General Motors Corporation": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Frosted Food Sales Corporation": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Fruit Dispatch Company, New York": {
         "Wikidata": "",
         "upload": false
       },
@@ -33286,15 +34318,7 @@
         "Wikidata": "",
         "upload": false
       },
-      "Furman University Libraries; Limestone College": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Furman University, James B. Duke Library": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Furst-McNess Co": {
         "Wikidata": "",
         "upload": false
       },
@@ -33302,28 +34326,8 @@
         "Wikidata": "",
         "upload": false
       },
-      "Gebhardt Chili Powder Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Gebhardt's": {
-        "Wikidata": "",
-        "upload": false
-      },
       "General Baking Company": {
         "Wikidata": "Q45164110",
-        "upload": false
-      },
-      "General Electric": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "General Electric Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "General Electric Kitchen Institute": {
-        "Wikidata": "",
         "upload": false
       },
       "General Foods Corp": {
@@ -33336,10 +34340,6 @@
       },
       "General Mills": {
         "Wikidata": "Q629998",
-        "upload": false
-      },
-      "General Mills, Inc": {
-        "Wikidata": "",
         "upload": false
       },
       "Georgetown Countbrary": {
@@ -33374,19 +34374,7 @@
         "Wikidata": "Q15221656",
         "upload": false
       },
-      "Godchaux Sugars": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Gold Medal, Softasilk the Cake Flour, Minneapolis, Minnesota": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Good Housekeeping Institute": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Great Smoky Mountains National Park": {
+      "Great Smoky Mountains National ParkNational Park Service": {
         "Wikidata": "",
         "upload": false
       },
@@ -33394,64 +34382,8 @@
         "Wikidata": "Q30257990",
         "upload": false
       },
-      "Greenville County Library System, Carolina First South Carolina Room": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Greenville County Library, Carolina First South Carolina Room": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Greenwood County Library System": {
         "Wikidata": "Q69490453",
-        "upload": false
-      },
-      "Griswold": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Gulden's": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Gunther Beer": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "H. C. Cole Milling Co., Omega Flour, Chester, Illinois": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "H. J. Heinz": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "H.J. Heinz Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Hawaiian Pineapple Company, Honolulu, Hawaii": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Hearth Club Baking Powder, Rumford Chemical Works, Rumford, Rhode Island": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Hecker H-O Division of Hecker Products Corporation": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Heinz": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Herb-Ox": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Hershey's": {
-        "Wikidata": "",
         "upload": false
       },
       "Historic Charleston Foundation": {
@@ -33462,7 +34394,7 @@
         "Wikidata": "",
         "upload": false
       },
-      "Home Economics Institute;Westinghouse Electric & Manufacturing Co": {
+      "Horry County Memorial Library": {
         "Wikidata": "",
         "upload": false
       },
@@ -33478,83 +34410,7 @@
         "Wikidata": "",
         "upload": false
       },
-      "Hulman and Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "I. J. Grass Noodle Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Igleheart Brothers": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Igleheart Brothers, Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Igleheart Brothers, Incorporated, Evansville, Indiana": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Interstate Cotton Oil Refining Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Iowa Dairy Industry Commission": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "J. P. Dieter Company, Chicago, Illinois": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Jacques Mfg. Co., Chicago, Illinois": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Jean Lafitte National Historical Park and Preserve": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Jell-O": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Joan of Arc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "John Behrmann Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "John F. Jelke Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "John Hancock Mutual Life Insurance Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "John Henry McCray papers, 1929-1989; University of South Carolina. South Caroliniana Library": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "John Morrell & Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Joseph Tetley & Co., Inc., New York": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "K. C. Baking Powder": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "K. C. Baking Powder, Chicago, Illinois": {
         "Wikidata": "",
         "upload": false
       },
@@ -33562,87 +34418,15 @@
         "Wikidata": "",
         "upload": false
       },
-      "Kane & Harcus Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Kane and Harcus": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Karo": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Kellogg Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Kellogg's": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Kemp's": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Kerr": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Kerr Research and Educational Department": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Kewaskum Utensil Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "KingTaste": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Kingan and Co": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Kings Mountain National Military Park": {
         "Wikidata": "Q1121121",
         "upload": false
       },
-      "Kitchen Aid": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Knox Gelatine": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Knudsen Dairy Products": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Kraft": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Kraft Foods Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Kraft-Phenix Cheese Corporation": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "La Rosa": {
+      "Kings Mountain National Military ParkNational Park Service": {
         "Wikidata": "",
         "upload": false
       },
       "Lake Hartwell Country": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Land O'Lakes": {
         "Wikidata": "",
         "upload": false
       },
@@ -33654,14 +34438,6 @@
         "Wikidata": "",
         "upload": false
       },
-      "Laswon Seafood Market": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Leonard": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Lexington County Museum (S.C.)": {
         "Wikidata": "",
         "upload": false
@@ -33670,15 +34446,11 @@
         "Wikidata": "Q69490393",
         "upload": false
       },
-      "Libby's 100 Foods": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Library of Congress": {
         "Wikidata": "",
         "upload": false
       },
-      "Life Magazine": {
+      "Lincoln High School Preservation Alumni Association, Incorporated": {
         "Wikidata": "",
         "upload": false
       },
@@ -33686,23 +34458,7 @@
         "Wikidata": "",
         "upload": false
       },
-      "Lysol": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Maine Development Commission": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Mapleine": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Margaretta Childs Archives at Historic Charleston Foundation": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Marion Harris Neil": {
         "Wikidata": "",
         "upload": false
       },
@@ -33718,107 +34474,15 @@
         "Wikidata": "",
         "upload": false
       },
-      "Maxwell House, Brooklyn, New York": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Maytag": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "McConnon & Co": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Mepkin Abbey": {
         "Wikidata": "Q6817822",
-        "upload": false
-      },
-      "Merrell-Soul Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Metropolitan Life Insurance Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Metropolitan Life Insurance Company Press": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Metropolitan Life Insurance Company, New York": {
-        "Wikidata": "",
         "upload": false
       },
       "Middleton Place Foundation": {
         "Wikidata": "",
         "upload": false
       },
-      "Miller & Hart": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Milnot": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Minnesota Valley Canning Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Minute Tapioca Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Minute Tapioca Co., Inc., Orange, Massachesetts General Foods": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Minute Tapioca Co., Inc., Orange, Massachusetts": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Minute Tapioca Co., Inc., Orange, Massachusetts, General Foods": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Minute Tapioca Company Inc., Orange, Massachusetts": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Mirro-Matic": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Modern Electric": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Monarch": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Monarch Electric, Malleable Iron Range Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Montgomery Ward": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Morell Ham": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Morris College (Sumter, S.C.)": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Mouli Manufacturing Corp": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Mueller": {
         "Wikidata": "",
         "upload": false
       },
@@ -33830,99 +34494,23 @@
         "Wikidata": "Q1545718",
         "upload": false
       },
-      "National Aluminum Manufacturing Co": {
-        "Wikidata": "",
-        "upload": false
-      },
       "National Biscuit Company": {
         "Wikidata": "Q6970999",
-        "upload": false
-      },
-      "National Cranberry Association": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "National Dairy Council": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "National Frozen Food Locker Association": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "National Live Stock and Meat Board": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "National Live Stock and Meat Board Department of Meat Merchandising, Home Economics and Nutrition": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "National Park Service": {
-        "Wikidata": "",
         "upload": false
       },
       "National Park Service Southeast Regional Office": {
         "Wikidata": "",
         "upload": false
       },
-      "National Park Service Water Resources Division": {
+      "National Park Service Water Resources DivisionNational Park Service": {
         "Wikidata": "",
         "upload": false
       },
-      "National Pressure Cooker Company": {
+      "National Park ServiceFort Sumter and Fort Moultrie National Historical Park": {
         "Wikidata": "",
         "upload": false
       },
-      "National Presto": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "National Starch Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Nestle": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "New England Fresh Egg Institute": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Niagara Litho Co., Buffalo": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Nordic Ware": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Norge": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "North Carolina State Parks": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Northwestern Consolodated Milling Co., Minneapolis, Minnesota": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Northwestern Yeast Co., Chicago, Illinois": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Nusoy": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Oak Farms": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Occident Flour": {
+      "North Carolina State ParksNational Park Service": {
         "Wikidata": "",
         "upload": false
       },
@@ -33934,30 +34522,6 @@
         "Wikidata": "",
         "upload": false
       },
-      "Oleomargarine": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Omega": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Oriental": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "P. Co., Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Parkay;Kraft Cheese Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Parowax": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Patriots Point Naval and Maritime Museum": {
         "Wikidata": "",
         "upload": false
@@ -33966,76 +34530,12 @@
         "Wikidata": "",
         "upload": false
       },
-      "Penick & Ford Ltd., Incorporated": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Perfection Stove Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Pet Milk": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Pet Milk Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Pet Milk Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Philadelphia Inter-State Dairy Council, Philadelphia, Pennsylvania": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Piggly Wiggly Bird Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Pillsbury Flour Mills Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Pillsbury Food Products, Minneapolis, Minnesota": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Pillsbury Home Service Center": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Pillsbury Mills, Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Plant Flour Mills Co., St. Louis, Missouri": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Planters": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Plymouth Rock, New York": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Portable Kitchens Division of Hamlin Products, Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Poultry & Egg National Board": {
+      "Pickens County Register of Deeds": {
         "Wikidata": "",
         "upload": false
       },
       "Presbyterian College": {
         "Wikidata": "Q7240768",
-        "upload": false
-      },
-      "Prince Golden": {
-        "Wikidata": "",
         "upload": false
       },
       "Private Collection": {
@@ -34051,14 +34551,6 @@
         "upload": false
       },
       "Private Collector": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Private Collector 016;Ruddy,Drew (photographer)": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Private Collector 021": {
         "Wikidata": "",
         "upload": false
       },
@@ -34078,62 +34570,6 @@
         "Wikidata": "Q61994223",
         "upload": false
       },
-      "Proctor & Gamble": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Proctor & Gamble Bakery Service": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Producers Creamery Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Quaker Oats": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Quality Press, Milwaukee": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "R. B. Davis Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "R. T. French Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "R. U. Delapenha & Co., Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Rath's Black Hawk": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Rawleigh": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Remington Arms Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Republic Metalware Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Reynolds Metals Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Richard Hellmann, Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Richland County Public Library": {
         "Wikidata": "Q69490423",
         "upload": false
@@ -34146,91 +34582,15 @@
         "Wikidata": "",
         "upload": false
       },
-      "Richmond-Chase Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Robertshaw Thermostat Company": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Royal Baking Powder Co": {
         "Wikidata": "Q7373783",
-        "upload": false
-      },
-      "Royal Baking Powder Co., New York": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Royal Baking Powder Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Royal Baking Powder, New York": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Royal Baking Powder, Standard Brands Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Royal Baking Powder, Standare Brands Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Rumford Chemical Works": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Rumford Chemical Works, Providence, Rhode Island": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Rumford Company, Rumford, Rhode Island": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Russell-Miller Milling Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Rutherford Food Corporation": {
-        "Wikidata": "",
         "upload": false
       },
       "SCIAA Collection": {
         "Wikidata": "",
         "upload": false
       },
-      "Schmidt's": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Sealtest": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Sears Roebuck and Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Sears, Roebuck & Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Servel": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Shefford": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Shull's Bakery, Marysville, Pennsylvania": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Silver-Seal Century Metalcraft Corporation": {
+      "SCSP": {
         "Wikidata": "",
         "upload": false
       },
@@ -34238,19 +34598,7 @@
         "Wikidata": "",
         "upload": false
       },
-      "Skelgas": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Snow King Baking Powder Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Soft Wheat Millers' Association, Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "South Carolina Agricultural Experiment Station Clemson Agricultural College": {
+      "South Caorlina State Library": {
         "Wikidata": "",
         "upload": false
       },
@@ -34278,12 +34626,16 @@
         "Wikidata": "",
         "upload": false
       },
-      "South Carolina Historical Society": {
-        "Wikidata": "Q7566605",
+      "South Carolina Department of Parks, Recreation and TourismClemson University LibrariesSouth Carolina Department of Parks, Recreation and Tourism": {
+        "Wikidata": "",
         "upload": false
       },
-      "South Carolina Historical Society; Furman University Libraries": {
+      "South Carolina Department of Parks, Recreation and TourismNational Park Service": {
         "Wikidata": "",
+        "upload": false
+      },
+      "South Carolina Historical Society": {
+        "Wikidata": "Q7566605",
         "upload": false
       },
       "South Carolina Library Association": {
@@ -34295,6 +34647,14 @@
         "upload": false
       },
       "South Carolina Library Association;Richland County Public Library (S.C.);Public libraries--South Carolina--Richland County;Radio frequency identification systems": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "South Carolina STate Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "South Carolina State Commission of Forestry": {
         "Wikidata": "",
         "upload": false
       },
@@ -34326,19 +34686,7 @@
         "Wikidata": "",
         "upload": false
       },
-      "Southern Cotton Oil Trading Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Southern Rice Institute": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Southern Wesleyan University Rickman Library": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Sparkle": {
         "Wikidata": "",
         "upload": false
       },
@@ -34346,43 +34694,7 @@
         "Wikidata": "Q30258374",
         "upload": false
       },
-      "Spry": {
-        "Wikidata": "",
-        "upload": false
-      },
       "St. Matthew's Lutheran Church": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Staley's": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Standard Brands Incorporated": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Standard Brands Incorporated, New York": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Standard Brands Incorporated, Royal": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Standard Brands Incorporated. Fleischmann's Yeast": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Standard Milling": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Star-Kist;French Sardine Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "StillImage": {
         "Wikidata": "",
         "upload": false
       },
@@ -34398,79 +34710,7 @@
         "Wikidata": "Q4994410",
         "upload": false
       },
-      "Sunbeam": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Sunbeam Corporation": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Sunshine Biscuits, Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Super Main Cook-Ware": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Superfex Perfection Stove Company Superfex Perfection Stove Company Superfex Perfection Stove Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Swans Down;Igleheart Brothers, Incorporated;Calumet;General Foods Corporation": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Swift & Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Swift and Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Abner Royce Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Aluminum Cooking Utensil Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The American Beauty Macaroni Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The American Sugar Refining Corporation": {
-        "Wikidata": "",
-        "upload": false
-      },
       "The Athenaeum Press at Coastal Carolina University": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Battle Creek Food Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Battle Creek Food Co.;Parks Milling & Baking Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Best Foods, Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Borden Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Borden Sales Company, Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Capital City Products Co": {
         "Wikidata": "",
         "upload": false
       },
@@ -34490,87 +34730,7 @@
         "Wikidata": "",
         "upload": false
       },
-      "The Club Aluminum Company": {
-        "Wikidata": "",
-        "upload": false
-      },
       "The Colleton County Museum,Walterboro, (S.C.),Colleton County Museum, Walterboro, S.C. www.colletoncounty.org/museum": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Colonial Salt Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Corn Products Refining Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Crosley Corporation": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Dangler Stove & Mfg. Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The E. Kahn's Sons Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Electrical League of Cleveland": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Enterprise Aluminum Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Fleischmann Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The H. A. Wilson Co. Mfr": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Hipolite Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Jell-O Company, Inc., Le Roy, New York": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Jell-O Company, Inc., Le Roy, New York; General Foods Corporation": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Junket Folks": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Meyer Sanitary Milk Company;Walter C. White Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Modern Kitchen Bureau": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Mystery Chef": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Procter & Gamble Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Procter & Gamle Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Proctor & Gamble Co": {
         "Wikidata": "",
         "upload": false
       },
@@ -34610,31 +34770,7 @@
         "Wikidata": "",
         "upload": false
       },
-      "The Sugar Institute, Inc.;American Sugar Refining Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Swartzbaugh Manufacturing Co": {
-        "Wikidata": "",
-        "upload": false
-      },
       "The University of South Carolina Lancaster, Native American Studies Center": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Wesson Oil and Snowdrift People": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "The Wm. Schluderberg - T. J. Kurdle Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Tip-Top Bread": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Town Talk Bread": {
         "Wikidata": "",
         "upload": false
       },
@@ -34642,47 +34778,11 @@
         "Wikidata": "",
         "upload": false
       },
-      "Traubee Products, Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Trinity Episcopal Cathedral, Columbia, S.C": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Trunz": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "U. S. Department of Agriculture": {
-        "Wikidata": "",
-        "upload": false
-      },
       "U.S. Department of Agriculture": {
         "Wikidata": "Q501542",
         "upload": false
       },
-      "United Fruit Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "United Fruit Company Bananas, Distributed by Fruit Dispatch Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "United Fruit Company, New York": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "United States of America Office of Price Administration": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Univeristy of South Carolina. South Caroliniana Library": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Universal Gas Range": {
         "Wikidata": "",
         "upload": false
       },
@@ -34743,6 +34843,10 @@
         "upload": false
       },
       "University of South Carolina Libraries. South Caroliniana Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "University of South Carolina Spartanburg Campus": {
         "Wikidata": "",
         "upload": false
       },
@@ -34846,23 +34950,7 @@
         "Wikidata": "",
         "upload": false
       },
-      "Valier & Spies Milling Corp": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Voorhees College, Wright Potts Library": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Walter Baker & Co., Ltd": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Walter Baker & Company, Inc.;General Foods Corporation": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Ward's Tip-Top Bread": {
         "Wikidata": "",
         "upload": false
       },
@@ -34878,87 +34966,11 @@
         "Wikidata": "",
         "upload": false
       },
-      "Warren Baker & Co., Ltd": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Wear-Ever": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Weber Grill": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Welch's": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Wengert Hardware Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Wesson": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Wesson Oil & Snowdrift People": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "West Bend Aluminum Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Westinghouse": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Westinghouse Electric": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Westinghouse Electric Corporation": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Westinghouse Electric and Manufacturing Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Wheat Flour Institute": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Wheatena": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "White Baking Company": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "White House Evaporated Milk;A&P Tea Co": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Wilson Milk": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Winthrop University": {
         "Wikidata": "Q8026588",
         "upload": false
       },
       "Wofford College, Sandor Tezler Library": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Woman's World Magazine Co., Inc": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Wonder Pan": {
         "Wikidata": "",
         "upload": false
       },
@@ -34969,6 +34981,10 @@
       "http://waring.library.musc.edu": {
         "Wikidata": "",
         "upload": false
+      },
+      "wsparks@statelibrary.sc.gov": {
+        "Wikidata": "",
+        "upload": false
       }
     },
     "upload": false
@@ -34977,10 +34993,6 @@
     "Wikidata": "Q83878512",
     "institutions": {
       "Boynton Beach City Library Archives": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Broward College Archives & Special Collections": {
         "Wikidata": "",
         "upload": false
       },
@@ -35009,10 +35021,6 @@
         "upload": false
       },
       "Florida Southern College": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Florida State College at Jacksonville": {
         "Wikidata": "",
         "upload": false
       },
@@ -35110,6 +35118,10 @@
   "Texas Digital Library": {
     "Wikidata": "Q30289389",
     "institutions": {
+      "Baylor University Libraries": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Houston Public Library": {
         "Wikidata": "",
         "upload": false
@@ -35156,15 +35168,7 @@
         "Wikidata": "",
         "upload": false
       },
-      "Comm, Marketing, and Business Dev. The New York Public Library": {
-        "Wikidata": "",
-        "upload": false
-      },
       "Dorot Jewish Division. The New York Public Library": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "External, not an NYPL item, it comes from some other institution. (LEGACY; Please do not use). The New York Public Library": {
         "Wikidata": "",
         "upload": false
       },
@@ -35209,10 +35213,6 @@
         "upload": false
       },
       "Rare Book Division. The New York Public Library": {
-        "Wikidata": "",
-        "upload": false
-      },
-      "Reserve Film and Video Collection. The New York Public Library": {
         "Wikidata": "",
         "upload": false
       },
@@ -35304,6 +35304,10 @@
       },
       "Allen Public Library": {
         "Wikidata": "Q30257868",
+        "upload": false
+      },
+      "Alpha Delta Pi of Gamma Upsilon": {
+        "Wikidata": "",
         "upload": false
       },
       "Alvin Community College": {
@@ -35538,6 +35542,10 @@
         "Wikidata": "Q137547073",
         "upload": false
       },
+      "Center for Big Bend Studies": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Center for the Advancement and Study of Early Texas Art": {
         "Wikidata": "",
         "upload": false
@@ -35592,6 +35600,10 @@
       },
       "City of Lakeway": {
         "Wikidata": "Q974112",
+        "upload": false
+      },
+      "City of Lewisville": {
+        "Wikidata": "",
         "upload": false
       },
       "City of Quanah": {
@@ -35656,6 +35668,10 @@
       },
       "Corpus Christi Museum of Science and History": {
         "Wikidata": "Q17511249",
+        "upload": false
+      },
+      "County Line Magazine": {
+        "Wikidata": "",
         "upload": false
       },
       "Courthouse-on-the-Square Museum": {
@@ -35750,6 +35766,10 @@
         "Wikidata": "Q69491580",
         "upload": false
       },
+      "Del Mar College": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Delta County Public Library": {
         "Wikidata": "Q104429802",
         "upload": false
@@ -35776,10 +35796,6 @@
       },
       "Dr. Pepper Museum": {
         "Wikidata": "Q25421126",
-        "upload": false
-      },
-      "Dr. Pound Historical Farmstead": {
-        "Wikidata": "",
         "upload": false
       },
       "Dublin Historical Museum": {
@@ -35846,6 +35862,10 @@
         "Wikidata": "Q137547072",
         "upload": false
       },
+      "Eula Hunt Beck Florence Public Library": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Euless Public Library": {
         "Wikidata": "Q69969089",
         "upload": false
@@ -35868,6 +35888,10 @@
       },
       "Fannin County Museum of History": {
         "Wikidata": "Q107321906",
+        "upload": false
+      },
+      "Farmersville Historical Society": {
+        "Wikidata": "",
         "upload": false
       },
       "Fayette Public Library, Museum and Archives": {
@@ -36098,6 +36122,14 @@
         "Wikidata": "",
         "upload": false
       },
+      "Herman Brown Free Library": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Hidalgo County Historical Commission": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Higgins Public Library": {
         "Wikidata": "Q69492256",
         "upload": false
@@ -36194,7 +36226,15 @@
         "Wikidata": "",
         "upload": false
       },
+      "Kaufman County Library": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Kemah Historical Society": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Kennedale Public Library": {
         "Wikidata": "",
         "upload": false
       },
@@ -36390,6 +36430,10 @@
         "Wikidata": "Q1932075",
         "upload": false
       },
+      "Mineola Historical Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Mineola Landmark Commission": {
         "Wikidata": "",
         "upload": false
@@ -36444,6 +36488,10 @@
       },
       "Nancy Carol Roberts Memorial Library": {
         "Wikidata": "Q69492314",
+        "upload": false
+      },
+      "Nanticoke Historic Preservation Alliance": {
+        "Wikidata": "",
         "upload": false
       },
       "National Cowboy and Western Heritage Museum": {
@@ -36542,7 +36590,7 @@
         "Wikidata": "",
         "upload": false
       },
-      "Panhandle Archeological Society": {
+      "Panhandle Archaeological Society of Texas": {
         "Wikidata": "",
         "upload": false
       },
@@ -36574,6 +36622,10 @@
         "Wikidata": "Q100304802",
         "upload": false
       },
+      "Pilot Point Community Library": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Pioneer City County Museum": {
         "Wikidata": "Q137462717",
         "upload": false
@@ -36594,6 +36646,10 @@
         "Wikidata": "Q69492594",
         "upload": false
       },
+      "Pound House Farmstead": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Prairie View A&M University": {
         "Wikidata": "Q3306469",
         "upload": false
@@ -36608,6 +36664,10 @@
       },
       "Private Collection of Bouncer Goin": {
         "Wikidata": "Q83878505",
+        "upload": false
+      },
+      "Private Collection of Brenda Lincke Fisseler": {
+        "Wikidata": "",
         "upload": false
       },
       "Private Collection of C.K. And Marjorie Burns Collection": {
@@ -36630,12 +36690,20 @@
         "Wikidata": "Q83878505",
         "upload": false
       },
+      "Private Collection of David Lindsey": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Private Collection of Dillard Williams and Mary Callaway": {
         "Wikidata": "Q83878505",
         "upload": false
       },
       "Private Collection of Dr. George E. Keaton, Jr": {
         "Wikidata": "Q83878505",
+        "upload": false
+      },
+      "Private Collection of Dr. Teresa Marrero": {
+        "Wikidata": "",
         "upload": false
       },
       "Private Collection of E. M. Adams": {
@@ -36686,6 +36754,10 @@
         "Wikidata": "Q83878505",
         "upload": false
       },
+      "Private Collection of Levi H. Davis": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Private Collection of M. M. Davis": {
         "Wikidata": "Q83878505",
         "upload": false
@@ -36730,6 +36802,10 @@
         "Wikidata": "Q83878505",
         "upload": false
       },
+      "Private Collection of Sharon Smith": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Private Collection of T. B. Willis": {
         "Wikidata": "Q83878505",
         "upload": false
@@ -36746,8 +36822,16 @@
         "Wikidata": "Q83878505",
         "upload": false
       },
+      "Private Collection of the Donnell Family": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Private Collection of the Ellis and Blanton Families": {
         "Wikidata": "Q83878505",
+        "upload": false
+      },
+      "Private Collection of the Hardin Family": {
+        "Wikidata": "",
         "upload": false
       },
       "Private Collection of the Koenig Family": {
@@ -36756,6 +36840,14 @@
       },
       "Private Collection of the Litzler Family": {
         "Wikidata": "Q83878505",
+        "upload": false
+      },
+      "Private Collection of the Luis and Iris A. Dovalina Family": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Private Collection of the Petrisky Family": {
+        "Wikidata": "",
         "upload": false
       },
       "Private Collection of the Raymond B. Holbrook Family": {
@@ -36776,6 +36868,18 @@
       },
       "Private Collection of the Wensowitch Family": {
         "Wikidata": "Q83878505",
+        "upload": false
+      },
+      "Private Collection of the Whaley Family": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Private Collection of the Whitehead Family": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "Rainbow Garden Club of North Texas": {
+        "Wikidata": "",
         "upload": false
       },
       "Rains County Library": {
@@ -36850,6 +36954,10 @@
         "Wikidata": "Q69970484",
         "upload": false
       },
+      "Sam Bell Maxey House State Historic Site": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Sam Houston High School": {
         "Wikidata": "Q7407640",
         "upload": false
@@ -36900,6 +37008,10 @@
       },
       "Schulenburg Public Library": {
         "Wikidata": "Q69492548",
+        "upload": false
+      },
+      "Scottish Rite Hospital for Children": {
+        "Wikidata": "",
         "upload": false
       },
       "Shamrock Public Library": {
@@ -37250,6 +37362,10 @@
         "Wikidata": "",
         "upload": false
       },
+      "Tom Lea Institute": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Tomball Museum Center": {
         "Wikidata": "",
         "upload": false
@@ -37414,6 +37530,10 @@
         "Wikidata": "Q69492344",
         "upload": false
       },
+      "West Side Port Arthur": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Westbank Community Library District": {
         "Wikidata": "Q69492293",
         "upload": false
@@ -37422,11 +37542,19 @@
         "Wikidata": "",
         "upload": false
       },
+      "Weston Heritage Guild": {
+        "Wikidata": "",
+        "upload": false
+      },
       "Wharton County Library": {
         "Wikidata": "Q69492198",
         "upload": false
       },
       "White Settlement Historical Museum": {
+        "Wikidata": "",
+        "upload": false
+      },
+      "White Settlement Public Library": {
         "Wikidata": "",
         "upload": false
       },


### PR DESCRIPTION
Regenerates `src/main/resources/wiki/institutions_v2.json` against the current DPLA index, so the upload-eligibility + Wikidata-QID registry reflects the institution (dataProvider) and hub (provider) names present in the latest aggregation.

## How it was generated

A composite aggregation over `provider.name.not_analyzed` × `dataProvider.name.not_analyzed` enumerated every unique (provider, dataProvider) pair, reconciled against the current file:

- **Added** index entries missing from the file, as `{"Wikidata": "", "upload": false}`.
- **Removed** entries no longer in the index **only when their `Wikidata` is empty** — every entry carrying a QID was preserved (a name may have drifted slightly and the QID is worth recovering by hand).
- **Preserved** all retained entries' existing `upload` and `Wikidata` verbatim — no opt-in flipped, no QID dropped.
- A hub is removed only if it is absent from the index **and** neither it nor any surviving institution carries a QID.

The file is byte-faithful to the existing convention (2-space indent, ASCII-escaped, plain-sorted keys, fixed key order), so the diff is purely semantic. (It also normalizes the one hub — Indiana Memory — whose institution keys weren't sorted.)

## Change summary

- **Hubs: 46 → 48.** Added **Jewish Heritage and History Hub** and **Mississippi Digital Library** (both already aggregating in the index). None removed — *District Digital* and *University of Washington* have dropped from the index but were kept because their institutions carry QIDs.
- **Institutions: +461 added, −432 removed, 139 dropped-from-index but kept (carry a QID).** Net 9,309 → 9,338.

### ⚠️ One thing to review

**South Carolina Digital Library accounts for −371 of the 432 removals** (it added only +22). All 371 had empty `Wikidata`, so the rule treats them as safe to drop, but a swing that large looks like a wholesale dataProvider-naming change (or shrinkage) in this index rather than ordinary drift. They're recoverable from git history and none carried a QID, but worth confirming this is expected before merge.

Generated by `tools/regen_institutions.py` (dpla/ingest-wikimedia#327).
