### PR TITLE
Fix ingest_hub.py script

### DIFF
--- a/ingest_python_scripts/launch_ingest.py
+++ b/ingest_python_scripts/launch_ingest.py
@@ -168,9 +168,10 @@ def list_deliveries(bucket: str) -> list[str]:
                 continue
             entry = m.group(1)
 
-        # Only keep entries that contain an ISO date (YYYY-MM-DD); non-dated
-        # entries like "archive/" are not valid delivery candidates.
-        if re.search(r"\d{4}-\d{2}-\d{2}", entry):
+        # Only keep entries that look like a date delivery — either ISO format
+        # (YYYY-MM-DD) or a plain 8-digit date string (MMDDYYYY / YYYYMMDD).
+        # Non-dated entries like "archive/" are skipped.
+        if re.search(r"\d{4}-\d{2}-\d{2}|\d{8}", entry):
             dated.append(entry)
 
     return sorted(dated, reverse=True)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR modifies the `list_deliveries()` function in `ingest_python_scripts/launch_ingest.py` to broaden the delivery-candidate filter. The function now accepts S3 delivery entries matching either ISO date format (`YYYY-MM-DD`) **or** plain 8-digit date strings (e.g., `YYYYMMDD` or `MMDDYYYY`), whereas previously it only recognized the ISO format. Non-dated entries such as folders named "archive/" continue to be filtered out.

The change updates both the regex pattern (from `r"\d{4}-\d{2}-\d{2}"` to `r"\d{4}-\d{2}-\d{2}|\d{8}"`) and the explanatory comments to reflect the new behavior.

## Impact

- **Lines changed:** +4 / -3
- **Scope:** Utility script only (local/EC2 use)
- **No special operational requirements:** No pipeline trigger, redeployment, environment variable changes, migrations, infrastructure changes, API modifications, or security implications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->