### PR TITLE
Additional python script fixes

### DIFF
--- a/ingest_python_scripts/check_ingest.py
+++ b/ingest_python_scripts/check_ingest.py
@@ -39,6 +39,8 @@ from datetime import datetime
 
 # ---------- config ----------
 DATA_ROOT = "/home/ec2-user/data"
+I3_HOME   = "/home/ec2-user/ingestion3"
+OAI_LOGS  = f"{I3_HOME}/logs"
 STAGES = ("harvest", "mapping", "enrichment", "jsonl")
 HUB_RE = re.compile(r"^[a-z0-9_-]+$")
 
@@ -202,14 +204,17 @@ fi
 
 echo "===STAGE_FIRST==="
 # First matching log line for each stage (whole line — Python extracts timestamp).
+# Using sequential greps (not a for loop) to avoid bash line-continuation issues
+# when the script is run via base64-decoded pipe.
 if [ -f "$LOG" ]; then
-  for kw in "OaiMultiPageResponseBuilder|OaiRequestInfo|HarvestEntry|OaiHarvester|ApiHarvester|FileHarvester|harvest started|:arrow_forward: .* harvest" \\
-            "MappingEntry|IngestRemap|mapping started|:arrow_forward: .* mapping" \\
-            "EnrichEntry|enrichment started|:arrow_forward: .* enrichment" \\
-            "JsonlEntry|jsonl started|:arrow_forward: .* jsonl"; do
-    grep -m1 -E "$kw" "$LOG" 2>/dev/null
-    echo "---ENDFIRSTSTAGE---"
-  done
+  grep -m1 -E "OaiMultiPageResponseBuilder|OaiRequestInfo|HarvestEntry|OaiHarvester|ApiHarvester|FileHarvester|LocalOaiHarvester|harvest started" "$LOG" 2>/dev/null
+  echo "---ENDFIRSTSTAGE---"
+  grep -m1 -E "MappingEntry|IngestRemap|mapping started" "$LOG" 2>/dev/null
+  echo "---ENDFIRSTSTAGE---"
+  grep -m1 -E "EnrichEntry|enrichment started" "$LOG" 2>/dev/null
+  echo "---ENDFIRSTSTAGE---"
+  grep -m1 -E "JsonlEntry|jsonl started" "$LOG" 2>/dev/null
+  echo "---ENDFIRSTSTAGE---"
 fi
 
 echo "===STAGE_RECENT==="
@@ -220,8 +225,14 @@ fi
 
 echo "===PROGRESS_LINES==="
 # Last 30 OAI request lines — used for progress + pacing parsing.
+# Check both the main Spark log and the OaiHarvestLogger file (localoai hubs).
 if [ -f "$LOG" ]; then
   tail -300 "$LOG" 2>/dev/null | grep -E "OaiRequestInfo|Loading page" | tail -30
+fi
+OAI_LOG=$(ls -t {OAI_LOGS}/oai-harvest-{hub}-*.log 2>/dev/null | head -1)
+if [ -n "$OAI_LOG" ]; then
+  echo "===OAI_HARVEST_LOG==="
+  tail -30 "$OAI_LOG" 2>/dev/null
 fi
 
 echo "===STAGES_DONE==="
@@ -293,6 +304,15 @@ def parse_first_stage_timestamps(stage_first: str) -> dict:
 
 
 def extract_log_timestamp(line: str) -> str | None:
+    """Extract HH:MM:SS from a log line.
+
+    Handles both the Spark log format (HH:MM:SS at start of line) and the
+    OaiHarvestLogger ISO format (yyyy-MM-ddTHH:MM:SS).
+    """
+    # ISO datetime: 2026-06-23T13:52:30 — extract the time part after 'T'
+    m = re.search(r"\d{4}-\d{2}-\d{2}T(\d{2}:\d{2}:\d{2})", line)
+    if m:
+        return m.group(1)
     m = re.search(r"\b(\d{2}:\d{2}:\d{2})\b", line)
     return m.group(1) if m else None
 
@@ -332,12 +352,23 @@ def stage_runtime_seconds(stage_first_ts, log_mtime):
 
 
 # ---- progress + pacing — handles multiple OAI log shapes ----
+# Shape 1: Spark log   "OaiRequestInfo(...,Some(cursor),Some(total))"
 PROGRESS_TRAILING_PAIR_RE = re.compile(r"Some\((\d+)\)\s*,\s*Some\((\d+)\)\s*\)\s*$")
+# Shape 2: older Spark "t(total):cursor"
 PROGRESS_TOKEN_RE = re.compile(r"t\((\d+)\):(\d+)")
+# Shape 3: OaiHarvestLogger file  "... | cursor=N | total=N | ..."
+OAI_LOGGER_RE = re.compile(r"cursor=(\d+).*\btotal=(\d+)")
 
 
 def parse_oai_progress_from_line(line: str):
-    """Return (current, total) from a single OaiRequestInfo line."""
+    """Return (current, total) from a single OAI log line.
+
+    Handles both the Spark log format (OaiRequestInfo toString) and the
+    structured OaiHarvestLogger format (cursor=N | total=N).
+    """
+    m = OAI_LOGGER_RE.search(line)
+    if m:
+        return int(m.group(1)), int(m.group(2))
     m = PROGRESS_TRAILING_PAIR_RE.search(line)
     if m:
         return int(m.group(1)), int(m.group(2))
@@ -474,6 +505,11 @@ def render(hub, harvest_type, endpoint, sections):
 
     # CURRENT STAGE
     progress_lines = sections.get("PROGRESS_LINES", "")
+    # For localoai hubs, supplement with the dedicated OaiHarvestLogger file which
+    # has structured cursor=/total= fields even when the Spark log doesn't.
+    oai_harvest_lines = sections.get("OAI_HARVEST_LOG", "")
+    if oai_harvest_lines and not progress_lines.strip():
+        progress_lines = oai_harvest_lines
     stage_recent = sections.get("STAGE_RECENT", "")
     stage_first_ts = parse_first_stage_timestamps(sections.get("STAGE_FIRST", ""))
     log_mtime = next(

--- a/ingest_python_scripts/check_ingest.py
+++ b/ingest_python_scripts/check_ingest.py
@@ -201,20 +201,20 @@ if [ -f "$LOG" ]; then
 else
   echo "(no log file)"
 fi
+echo "ec2_now=$(date '+%H:%M:%S')"
 
 echo "===STAGE_FIRST==="
-# First matching log line for each stage (whole line — Python extracts timestamp).
-# Using sequential greps (not a for loop) to avoid bash line-continuation issues
-# when the script is run via base64-decoded pipe.
+# Output one HH:MM:SS timestamp per stage (or blank line if stage not started).
+# Timestamps are extracted in bash with grep -oE so Python just gets clean strings.
 if [ -f "$LOG" ]; then
-  grep -m1 -E "OaiMultiPageResponseBuilder|OaiRequestInfo|HarvestEntry|OaiHarvester|ApiHarvester|FileHarvester|LocalOaiHarvester|harvest started" "$LOG" 2>/dev/null
-  echo "---ENDFIRSTSTAGE---"
-  grep -m1 -E "MappingEntry|IngestRemap|mapping started" "$LOG" 2>/dev/null
-  echo "---ENDFIRSTSTAGE---"
-  grep -m1 -E "EnrichEntry|enrichment started" "$LOG" 2>/dev/null
-  echo "---ENDFIRSTSTAGE---"
-  grep -m1 -E "JsonlEntry|jsonl started" "$LOG" 2>/dev/null
-  echo "---ENDFIRSTSTAGE---"
+  grep -m1 -E "OaiMultiPageResponseBuilder|OaiRequestInfo|HarvestEntry|OaiHarvester|ApiHarvester|FileHarvester|LocalOaiHarvester|harvest started" "$LOG" 2>/dev/null | grep -oE '[0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}' | head -1
+  echo "---"
+  grep -m1 -E "MappingEntry|IngestRemap|mapping started" "$LOG" 2>/dev/null | grep -oE '[0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}' | head -1
+  echo "---"
+  grep -m1 -E "EnrichEntry|enrichment started" "$LOG" 2>/dev/null | grep -oE '[0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}' | head -1
+  echo "---"
+  grep -m1 -E "JsonlEntry|jsonl started" "$LOG" 2>/dev/null | grep -oE '[0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}' | head -1
+  echo "---"
 fi
 
 echo "===STAGE_RECENT==="
@@ -288,18 +288,15 @@ def detect_current_stage(stage_recent: str) -> str | None:
 
 def parse_first_stage_timestamps(stage_first: str) -> dict:
     """STAGE_FIRST has 4 entries (harvest, mapping, enrichment, jsonl)
-    separated by '---ENDFIRSTSTAGE---'. Each entry is a full log line;
-    we extract the first HH:MM:SS we find anywhere on that line."""
+    separated by '---'. Each entry is a bare HH:MM:SS extracted by bash
+    grep -oE, or an empty line if that stage hasn't started yet."""
     timestamps = {}
-    chunks = stage_first.split("---ENDFIRSTSTAGE---")
-    ts_re = re.compile(r"\b(\d{2}:\d{2}:\d{2})\b")
+    chunks = stage_first.split("---")
+    ts_re = re.compile(r"^\d{2}:\d{2}:\d{2}$")
     for stage, chunk in zip(STAGES, chunks):
-        chunk = chunk.strip()
-        if not chunk:
-            continue
-        m = ts_re.search(chunk)
-        if m:
-            timestamps[stage] = m.group(1)
+        ts = chunk.strip()
+        if ts_re.match(ts):
+            timestamps[stage] = ts
     return timestamps
 
 
@@ -512,10 +509,9 @@ def render(hub, harvest_type, endpoint, sections):
         progress_lines = oai_harvest_lines
     stage_recent = sections.get("STAGE_RECENT", "")
     stage_first_ts = parse_first_stage_timestamps(sections.get("STAGE_FIRST", ""))
-    log_mtime = next(
-        (ln.split("=", 1)[1] for ln in sections.get("LOGINFO", "").splitlines() if ln.startswith("mtime=")),
-        None,
-    )
+    loginfo_lines = sections.get("LOGINFO", "").splitlines()
+    log_mtime = next((ln.split("=", 1)[1] for ln in loginfo_lines if ln.startswith("mtime=")), None)
+    ec2_now   = next((ln.split("=", 1)[1] for ln in loginfo_lines if ln.startswith("ec2_now=")), None)
 
     lines.append("")
     lines.append("CURRENT STAGE")
@@ -533,7 +529,9 @@ def render(hub, harvest_type, endpoint, sections):
                 if stage_start:
                     stage_start_was_inferred = True
 
-            runtime_s = stage_runtime_seconds(stage_start, log_mtime)
+            # Prefer EC2 current time for "running for" — more accurate than log mtime.
+            now_ref = f"2000-01-01 {ec2_now}" if ec2_now else log_mtime
+            runtime_s = stage_runtime_seconds(stage_start, now_ref)
             lines.append(f"  Stage:     {c(YELLOW, current_stage)}")
             if stage_start:
                 suffix = " (approx — based on recent log window)" if stage_start_was_inferred else ""

--- a/ingest_python_scripts/check_ingest.py
+++ b/ingest_python_scripts/check_ingest.py
@@ -405,6 +405,22 @@ def parse_harvest_pacing(progress_lines: str, n_points: int = 30):
     return (o1 - o0) / dt
 
 
+def get_progress_lines(sections: dict) -> str:
+    """Return the best available OAI progress lines from parsed SSM sections.
+
+    Prefers PROGRESS_LINES (Spark log OaiRequestInfo entries). Falls back to
+    OAI_HARVEST_LOG (OaiHarvestLogger file) when PROGRESS_LINES is empty —
+    this is the common case for localoai hubs where the Spark log doesn't
+    carry cursor/total info.
+    """
+    progress = sections.get("PROGRESS_LINES", "")
+    if not progress.strip():
+        oai = sections.get("OAI_HARVEST_LOG", "")
+        if oai:
+            return oai
+    return progress
+
+
 def earliest_timestamp_in_lines(lines: str):
     earliest = None
     earliest_secs = None
@@ -501,12 +517,7 @@ def render(hub, harvest_type, endpoint, sections):
                 lines.append(f"  {ln}")
 
     # CURRENT STAGE
-    progress_lines = sections.get("PROGRESS_LINES", "")
-    # For localoai hubs, supplement with the dedicated OaiHarvestLogger file which
-    # has structured cursor=/total= fields even when the Spark log doesn't.
-    oai_harvest_lines = sections.get("OAI_HARVEST_LOG", "")
-    if oai_harvest_lines and not progress_lines.strip():
-        progress_lines = oai_harvest_lines
+    progress_lines = get_progress_lines(sections)
     stage_recent = sections.get("STAGE_RECENT", "")
     stage_first_ts = parse_first_stage_timestamps(sections.get("STAGE_FIRST", ""))
     loginfo_lines = sections.get("LOGINFO", "").splitlines()
@@ -579,7 +590,7 @@ def render(hub, harvest_type, endpoint, sections):
 
 def derive_summary(is_running, sections, harvest_type):
     done_count = len([ln for ln in sections.get("STAGES_DONE", "").splitlines() if ln.strip()])
-    progress_lines = sections.get("PROGRESS_LINES", "")
+    progress_lines = get_progress_lines(sections)
     stage_recent = sections.get("STAGE_RECENT", "")
 
     if is_running:

--- a/ingest_python_scripts/community-webs/check_cw.py
+++ b/ingest_python_scripts/community-webs/check_cw.py
@@ -24,6 +24,7 @@ import re
 import subprocess
 import sys
 import time
+from datetime import datetime
 
 # ---------- config ----------
 REGION      = "us-east-1"
@@ -154,6 +155,19 @@ if [ -f "{INGEST_LOG}" ]; then
 else
   echo "(no log)"
 fi
+echo "ec2_now=$(date '+%H:%M:%S')"
+
+echo "===STAGE_FIRST==="
+if [ -f "{INGEST_LOG}" ]; then
+  grep -m1 -E "HarvestEntry|FileHarvester|harvest started" "{INGEST_LOG}" 2>/dev/null | grep -oE '[0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}' | head -1
+  echo "---"
+  grep -m1 -E "MappingEntry|IngestRemap|mapping started" "{INGEST_LOG}" 2>/dev/null | grep -oE '[0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}' | head -1
+  echo "---"
+  grep -m1 -E "EnrichEntry|enrichment started" "{INGEST_LOG}" 2>/dev/null | grep -oE '[0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}' | head -1
+  echo "---"
+  grep -m1 -E "JsonlEntry|jsonl started" "{INGEST_LOG}" 2>/dev/null | grep -oE '[0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}' | head -1
+  echo "---"
+fi
 
 echo "===STAGE_RECENT==="
 if [ -f "{INGEST_LOG}" ]; then
@@ -228,6 +242,51 @@ def detect_current_stage(stage_recent):
                 if kw in line:
                     return stage
     return None
+
+
+def parse_first_stage_timestamps(stage_first: str) -> dict:
+    timestamps = {}
+    chunks = stage_first.split("---")
+    ts_re = re.compile(r"^\d{2}:\d{2}:\d{2}$")
+    for stage, chunk in zip(STAGES, chunks):
+        ts = chunk.strip()
+        if ts_re.match(ts):
+            timestamps[stage] = ts
+    return timestamps
+
+
+def hms_to_seconds(hms: str) -> int:
+    h, m, s = (int(x) for x in hms.split(":"))
+    return h * 3600 + m * 60 + s
+
+
+def fmt_duration(seconds) -> str:
+    if seconds is None or seconds < 0:
+        return "?"
+    seconds = int(seconds)
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    if h: return f"{h}h {m}m"
+    if m: return f"{m}m {s}s"
+    return f"{s}s"
+
+
+def stage_runtime_seconds(stage_first_ts, now_ref):
+    if not stage_first_ts or not now_ref:
+        return None
+    try:
+        ref_dt = datetime.strptime(now_ref, "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return None
+    try:
+        stage_t = datetime.strptime(stage_first_ts, "%H:%M:%S").time()
+    except ValueError:
+        return None
+    stage_dt = datetime.combine(ref_dt.date(), stage_t)
+    delta = (ref_dt - stage_dt).total_seconds()
+    if delta < 0:
+        delta += 86400
+    return int(delta)
 
 
 def parse_process_lines(proc_text):
@@ -330,6 +389,12 @@ def render(sections):
     # CURRENT STAGE
     stage_recent = sections.get("STAGE_RECENT", "")
     current_stage = detect_current_stage(stage_recent)
+    stage_first_ts = parse_first_stage_timestamps(sections.get("STAGE_FIRST", ""))
+    loginfo_lines = sections.get("LOGINFO", "").splitlines()
+    log_mtime = next((ln.split("=", 1)[1] for ln in loginfo_lines if ln.startswith("mtime=")), None)
+    ec2_now   = next((ln.split("=", 1)[1] for ln in loginfo_lines if ln.startswith("ec2_now=")), None)
+    now_ref   = f"2000-01-01 {ec2_now}" if ec2_now else log_mtime
+
     lines.append("")
     lines.append("CURRENT STAGE")
     if not is_running:
@@ -337,11 +402,17 @@ def render(sections):
     elif not current_stage:
         lines.append(c(YELLOW, "  Could not infer current stage from log."))
     else:
-        lines.append(f"  Stage:    {c(YELLOW, current_stage)}")
-        if current_stage == "harvest":
-            lines.append(c(DIM, "  Progress: (file-based harvest — no offset to parse)"))
+        stage_start = stage_first_ts.get(current_stage)
+        runtime_s = stage_runtime_seconds(stage_start, now_ref)
+        lines.append(f"  Stage:     {c(YELLOW, current_stage)}")
+        if stage_start:
+            lines.append(f"  Started:   {stage_start}   (running for {fmt_duration(runtime_s)})")
         else:
-            lines.append(c(DIM, "  Progress: (not derivable for Spark stages from log alone)"))
+            lines.append("  Started:   (no stage-start marker found in log)")
+        if current_stage == "harvest":
+            lines.append(c(DIM, "  Progress:  (file-based harvest — no offset to parse)"))
+        else:
+            lines.append(c(DIM, "  Progress:  (not derivable for Spark stages from log alone)"))
 
     # DISK USAGE
     disk_text = sections.get("DISK", "").strip()

--- a/ingest_python_scripts/hub_preflight.py
+++ b/ingest_python_scripts/hub_preflight.py
@@ -701,8 +701,8 @@ def _check_local_path_endpoint(path):
     exists, is a directory (or file), and is non-empty. Catches the
     'CommunityWebsHarvester NPE' class of bug where the conf endpoint
     points at a stale or missing directory."""
-    info(f"Endpoint: {path}")
-    info("Type:     file-based (local path on EC2)")
+    info(f"Delivery path: {path}")
+    info("Type:          file-based (local path on EC2)")
 
     # Catch dev paths leaking into production conf — saves an SSM round-trip
     # and gives a much clearer error than "path does not exist on the box".
@@ -772,8 +772,8 @@ def _check_local_path_endpoint_current_month(path):
     """For harvest.type='file' hubs: confirm the endpoint dir exists, has data,
     AND has at least one file dated within the current YYYY-MM. Catches
     'pointed at last month's preprocessed data, never updated' bugs."""
-    info(f"Endpoint: {path}")
-    info("Type:     file — checking for current-month data")
+    info(f"Delivery path: {path}")
+    info("Type:          file — checking for current-month data")
 
     # Reject obvious dev paths first (Mac homedirs, /var/folders, etc.).
     dev_path_patterns = [
@@ -848,8 +848,8 @@ def _check_s3_endpoint(s3_path):
     list the bucket/prefix, verify there's at least one object, AND flag if
     the latest entry is from the current YYYY-MM. Driven entirely by the conf
     endpoint — no hardcoded mapping."""
-    info(f"Endpoint: {s3_path}")
-    info("Type:     file-based (S3) — checking for current-month delivery")
+    info(f"Delivery path: {s3_path}")
+    info("Type:          file-based (S3) — checking for current-month delivery")
     try:
         result = subprocess.run(
             ["aws", "s3", "ls", s3_path,
@@ -893,12 +893,12 @@ def _check_s3_endpoint(s3_path):
 
 
 def check_endpoint(endpoint, is_api=False, harvest_type=None):
-    header("6. Endpoint reachability")
+    ht = (harvest_type or "").lower()
+    section_title = "6. Delivery path check" if ht == "file" else "6. Endpoint reachability"
+    header(section_title)
     if not endpoint:
         warn("No endpoint to check (pass --hub or enter one at the prompt).")
         return True  # non-blocking
-
-    ht = (harvest_type or "").lower()
     OAI_TYPES = ("oai", "localoai")
     API_TYPES = ("api",)
     FILE_TYPES = ("file",)
@@ -1078,7 +1078,8 @@ def main():
             # Anything that's not in OAI_TYPES and not file-based gets API treatment.
             if not is_api and harvest_type and harvest_type not in OAI_TYPES and harvest_type != "file":
                 is_api = True
-            print(f"Endpoint: {endpoint}  (from conf, type={harvest_type or 'unknown'})")
+            label = "Delivery path" if harvest_type == "file" else "Endpoint"
+            print(f"{label}: {endpoint}  (from conf, type={harvest_type or 'unknown'})")
         else:
             print(f"Endpoint: (not found in {CONF_PATH} for hub '{hub}')")
     else:

--- a/ingest_python_scripts/launch_ingest.py
+++ b/ingest_python_scripts/launch_ingest.py
@@ -147,6 +147,27 @@ def get_current_endpoint(hub: str) -> str:
 
 
 # ── S3 delivery helpers ───────────────────────────────────────────────────────
+def _sortable_date(entry: str) -> str:
+    """Return a YYYYMMDD string for sorting delivery entry names newest-first.
+
+    Handles three formats found in hub buckets:
+      YYYY-MM-DD  (ISO, with dashes)   → strip dashes
+      YYYYMMDD    (8 digits, year first) → keep as-is
+      MMDDYYYY    (8 digits, month first, e.g. Georgia) → reorder to YYYYMMDD
+    """
+    m = re.search(r"(\d{4})-(\d{2})-(\d{2})", entry)
+    if m:
+        return m.group(1) + m.group(2) + m.group(3)
+    m = re.search(r"(\d{8})", entry)
+    if m:
+        s = m.group(1)
+        # If the first 4 digits are a plausible year, it's YYYYMMDD; else MMDDYYYY.
+        if 1900 <= int(s[:4]) <= 2099:
+            return s
+        return s[4:] + s[:4]  # MMDDYYYY → YYYYMMDD
+    return entry
+
+
 def list_deliveries(bucket: str) -> list[str]:
     """Return all top-level entries (folders and files) in the bucket, sorted newest-first.
 
@@ -174,7 +195,7 @@ def list_deliveries(bucket: str) -> list[str]:
         if re.search(r"\d{4}-\d{2}-\d{2}|\d{8}", entry):
             dated.append(entry)
 
-    return sorted(dated, reverse=True)
+    return sorted(dated, key=_sortable_date, reverse=True)
 
 
 # ── file-hub pre-flight ───────────────────────────────────────────────────────

--- a/ingest_python_scripts/launch_ingest.py
+++ b/ingest_python_scripts/launch_ingest.py
@@ -158,7 +158,9 @@ def _sortable_date(entry: str) -> str:
     m = re.search(r"(\d{4})-(\d{2})-(\d{2})", entry)
     if m:
         return m.group(1) + m.group(2) + m.group(3)
-    m = re.search(r"(\d{8})", entry)
+    # Require a plausible 4-digit year (19xx or 20xx) in either the YYYYMMDD
+    # or MMDDYYYY position to avoid treating arbitrary 8-digit numbers as dates.
+    m = re.search(r"((?:19|20)\d{6}|\d{4}(?:19|20)\d{2})", entry)
     if m:
         s = m.group(1)
         # If the first 4 digits are a plausible year, it's YYYYMMDD; else MMDDYYYY.
@@ -192,7 +194,7 @@ def list_deliveries(bucket: str) -> list[str]:
         # Only keep entries that look like a date delivery — either ISO format
         # (YYYY-MM-DD) or a plain 8-digit date string (MMDDYYYY / YYYYMMDD).
         # Non-dated entries like "archive/" are skipped.
-        if re.search(r"\d{4}-\d{2}-\d{2}|\d{8}", entry):
+        if re.search(r"\d{4}-\d{2}-\d{2}|(?:19|20)\d{6}|\d{4}(?:19|20)\d{2}", entry):
             dated.append(entry)
 
     return sorted(dated, key=_sortable_date, reverse=True)

--- a/ingest_python_scripts/launch_ingest.py
+++ b/ingest_python_scripts/launch_ingest.py
@@ -250,6 +250,11 @@ def main() -> None:
         choices=VALID_RESUME_STEPS,
         help="Resume from a specific step instead of running the full pipeline.",
     )
+    parser.add_argument(
+        "--harvest-only",
+        action="store_true",
+        help="Only run the harvest step (skip mapping/enrichment/jsonl/S3 sync).",
+    )
     args = parser.parse_args()
 
     hub = (args.hub or input("Hub: ")).strip().lower()
@@ -287,7 +292,14 @@ def main() -> None:
             file_hub_preflight(hub, bucket)
 
     # Launch.
-    extra = f" --resume-from {args.resume_from}" if args.resume_from else ""
+    if args.harvest_only and args.resume_from:
+        sys.exit("--harvest-only and --resume-from are mutually exclusive.")
+    if args.harvest_only:
+        extra = " --harvest-only"
+    elif args.resume_from:
+        extra = f" --resume-from {args.resume_from}"
+    else:
+        extra = ""
     invocation = f"bash {SCRIPTS_DIR}/ingest.sh {hub}{extra}"
     inner = (
         'sudo -u ec2-user bash -lc "'

--- a/ingest_python_scripts/launch_ingest.py
+++ b/ingest_python_scripts/launch_ingest.py
@@ -214,14 +214,14 @@ def file_hub_preflight(hub: str, bucket: str) -> None:
     if len(deliveries) > 5:
         print(f"    … and {len(deliveries) - 5} older")
 
-    print(f"\nCurrent i3.conf endpoint for {hub}:")
+    print(f"\nCurrent i3.conf delivery path for {hub}:")
     print(f"  {get_current_endpoint(hub)}")
 
     # Suggest the most recent dated delivery (always first after list_deliveries sort).
     latest = deliveries[0]
     suggested = f"s3://{bucket}/{latest}"
     print(f"""
-⚠️  Before continuing, make sure i3.conf is pointing at the right delivery:
+⚠️  Before continuing, make sure i3.conf is pointing at the right delivery path:
 
     {hub}.harvest.endpoint = "{suggested}"
 

--- a/ingest_python_scripts/nara/check_nara.py
+++ b/ingest_python_scripts/nara/check_nara.py
@@ -25,6 +25,7 @@ import re
 import subprocess
 import sys
 import time
+from datetime import datetime
 
 # ---------- config ----------
 REGION      = "us-east-1"
@@ -50,6 +51,9 @@ INSTANCE_ID = _env.get("INGEST_INSTANCE_ID", "")
 LOG_DIR     = "/home/ec2-user"
 DATA_ROOT   = "/home/ec2-user/data"
 NARA_DATA   = f"{DATA_ROOT}/nara"
+
+# Stages that produce _SUCCESS/_MANIFEST in Spark output dirs
+PIPELINE_STAGES = ("mapping", "enrichment", "jsonl")
 
 STAGE_KEYWORDS = {
     "jsonl":        ["JsonlEntry", "jsonl complete", ":white_check_mark: jsonl"],
@@ -159,6 +163,22 @@ if [ -n "$LOG_PATH" ] && [ -f "$LOG_PATH" ]; then
 else
   echo "(no log)"
 fi
+echo "ec2_now=$(date '+%H:%M:%S')"
+
+echo "===STAGE_FIRST==="
+LOG_PATH=$(ls -t {log_glob} 2>/dev/null | head -1 || true)
+if [ -n "$LOG_PATH" ] && [ -f "$LOG_PATH" ]; then
+  grep -m1 -E "HarvestEntry|FileHarvester|Preprocessing|harvest started" "$LOG_PATH" 2>/dev/null | grep -oE '[0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}' | head -1
+  echo "---"
+  grep -m1 -E "NaraMergeUtil|merge started" "$LOG_PATH" 2>/dev/null | grep -oE '[0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}' | head -1
+  echo "---"
+  grep -m1 -E "MappingEntry|IngestRemap|mapping started" "$LOG_PATH" 2>/dev/null | grep -oE '[0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}' | head -1
+  echo "---"
+  grep -m1 -E "EnrichEntry|enrichment started" "$LOG_PATH" 2>/dev/null | grep -oE '[0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}' | head -1
+  echo "---"
+  grep -m1 -E "JsonlEntry|jsonl started" "$LOG_PATH" 2>/dev/null | grep -oE '[0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}' | head -1
+  echo "---"
+fi
 
 echo "===STAGE_RECENT==="
 LOG_PATH=$(ls -t {log_glob} 2>/dev/null | head -1 || true)
@@ -176,6 +196,21 @@ if [ -n "$LATEST" ]; then
 else
   echo "(none)"
 fi
+
+echo "===STAGES_DONE==="
+CUTOFF=$(date -d '48 hours ago' +%s)
+for stage in mapping enrichment jsonl; do
+  STAGE_DIR="{NARA_DATA}/$stage"
+  LATEST=$(ls -1dt $STAGE_DIR/*/ 2>/dev/null | head -1 | sed 's:/$::')
+  if [ -n "$LATEST" ] && [ -f "$LATEST/_SUCCESS" ]; then
+    SUCCESS_EPOCH=$(stat -c '%Y' "$LATEST/_SUCCESS" 2>/dev/null || echo 0)
+    if [ "$SUCCESS_EPOCH" -lt "$CUTOFF" ]; then continue; fi
+    MTIME=$(stat -c '%y' "$LATEST/_SUCCESS" 2>/dev/null | cut -d'.' -f1)
+    MANIFEST=""
+    [ -f "$LATEST/_MANIFEST" ] && MANIFEST=$(grep -i 'record count' "$LATEST/_MANIFEST" 2>/dev/null | head -1 | tr -d '\\n')
+    echo "$stage|$MTIME|$MANIFEST"
+  fi
+done
 
 echo "===DISK==="
 for d in harvest originalRecords; do
@@ -220,6 +255,54 @@ def detect_current_stage(stage_recent):
                 if kw in line:
                     return stage
     return None
+
+
+NARA_STAGES = ("harvest", "merge", "mapping", "enrichment", "jsonl")
+
+
+def parse_first_stage_timestamps(stage_first: str) -> dict:
+    timestamps = {}
+    chunks = stage_first.split("---")
+    ts_re = re.compile(r"^\d{2}:\d{2}:\d{2}$")
+    for stage, chunk in zip(NARA_STAGES, chunks):
+        ts = chunk.strip()
+        if ts_re.match(ts):
+            timestamps[stage] = ts
+    return timestamps
+
+
+def hms_to_seconds(hms: str) -> int:
+    h, m, s = (int(x) for x in hms.split(":"))
+    return h * 3600 + m * 60 + s
+
+
+def fmt_duration(seconds) -> str:
+    if seconds is None or seconds < 0:
+        return "?"
+    seconds = int(seconds)
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    if h: return f"{h}h {m}m"
+    if m: return f"{m}m {s}s"
+    return f"{s}s"
+
+
+def stage_runtime_seconds(stage_first_ts, now_ref):
+    if not stage_first_ts or not now_ref:
+        return None
+    try:
+        ref_dt = datetime.strptime(now_ref, "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return None
+    try:
+        stage_t = datetime.strptime(stage_first_ts, "%H:%M:%S").time()
+    except ValueError:
+        return None
+    stage_dt = datetime.combine(ref_dt.date(), stage_t)
+    delta = (ref_dt - stage_dt).total_seconds()
+    if delta < 0:
+        delta += 86400
+    return int(delta)
 
 
 def parse_process_lines(proc_text):
@@ -290,9 +373,36 @@ def render(sections):
         else:
             lines.append("  " + c(GREEN, proc_text.splitlines()[0]))
 
+    # COMPLETED STAGES
+    lines.append("")
+    lines.append("COMPLETED STAGES (this run)")
+    done_lines = [ln for ln in sections.get("STAGES_DONE", "").splitlines() if ln.strip()]
+    if not done_lines:
+        lines.append(c(DIM, "  (none yet this run)"))
+    else:
+        for ln in done_lines:
+            parts = ln.split("|", 2)
+            if len(parts) == 3:
+                stage, mtime, manifest = parts
+                manifest = re.sub(
+                    r"(\d[\d,]*)",
+                    lambda m: f"{int(m.group(1).replace(',', '')):,}",
+                    manifest.strip(),
+                    count=1,
+                )
+                lines.append(f"  {c(GREEN, stage):<22} done {mtime}   {manifest}")
+            else:
+                lines.append(f"  {ln}")
+
     # CURRENT STAGE
     stage_recent = sections.get("STAGE_RECENT", "")
     current_stage = detect_current_stage(stage_recent)
+    stage_first_ts = parse_first_stage_timestamps(sections.get("STAGE_FIRST", ""))
+    loginfo_lines = sections.get("LOGINFO", "").splitlines()
+    log_mtime = next((ln.split("=", 1)[1] for ln in loginfo_lines if ln.startswith("mtime=")), None)
+    ec2_now   = next((ln.split("=", 1)[1] for ln in loginfo_lines if ln.startswith("ec2_now=")), None)
+    now_ref   = f"2000-01-01 {ec2_now}" if ec2_now else log_mtime
+
     lines.append("")
     lines.append("CURRENT STAGE")
     if not is_running:
@@ -300,11 +410,17 @@ def render(sections):
     elif not current_stage:
         lines.append(c(YELLOW, "  Could not infer current stage from log."))
     else:
-        lines.append(f"  Stage:    {c(YELLOW, current_stage)}")
-        if current_stage in ("harvest", "merge"):
-            lines.append(c(DIM, "  Progress: (file-based — no offset to parse)"))
+        stage_start = stage_first_ts.get(current_stage)
+        runtime_s = stage_runtime_seconds(stage_start, now_ref)
+        lines.append(f"  Stage:     {c(YELLOW, current_stage)}")
+        if stage_start:
+            lines.append(f"  Started:   {stage_start}   (running for {fmt_duration(runtime_s)})")
         else:
-            lines.append(c(DIM, "  Progress: (not derivable for Spark stages from log alone)"))
+            lines.append("  Started:   (no stage-start marker found in log)")
+        if current_stage in ("harvest", "merge"):
+            lines.append(c(DIM, "  Progress:  (file-based — no offset to parse)"))
+        else:
+            lines.append(c(DIM, "  Progress:  (not derivable for Spark stages from log alone)"))
 
     # LATEST MERGED HARVEST
     merge_text = sections.get("MERGE_SUMMARY", "").strip()

--- a/ingest_python_scripts/nara/copy_nara.py
+++ b/ingest_python_scripts/nara/copy_nara.py
@@ -237,7 +237,7 @@ def main():
         confirm(f"Files already exist in {dst}. Overwrite/re-sync anyway?", default_yes=False)
 
     count = ssm_run(
-        f"aws s3 ls {src_quoted} --profile {NARA_PROFILE} | wc -l",
+        f"AWS_SHARED_CREDENTIALS_FILE=/home/ec2-user/.aws/credentials && export AWS_SHARED_CREDENTIALS_FILE &&aws s3 ls {src_quoted} --profile {NARA_PROFILE} | wc -l",
         timeout_seconds=30,
     ).strip()
     print(f"  Found {count} file(s) in {src}")
@@ -251,6 +251,7 @@ def main():
 
     sync_cmd = (
         f"set -e && "
+        f"AWS_SHARED_CREDENTIALS_FILE=/home/ec2-user/.aws/credentials && export AWS_SHARED_CREDENTIALS_FILE &&"  # SSM overrides this; restore default ~/.aws/credentials
         f"echo 'Step 1/4: Creating temp dir...' && "
         f"mkdir -p {tmp_dir} && "
         f"echo 'Step 2/4: Downloading from ngc-storage01...' && "

--- a/ingest_python_scripts/smithsonian/check_status_smithsonian.py
+++ b/ingest_python_scripts/smithsonian/check_status_smithsonian.py
@@ -1,25 +1,17 @@
 #!/usr/bin/env python3
 """
-Smithsonian ingest status — works regardless of which stage is currently
-running. Walks the full Smithsonian workflow and reports the state of each:
+Check on a running (or recently finished) Smithsonian ingest.
 
-    Stage 1: Download from s3://dpla-hub-si/<DATE>/
-    Stage 2: Preprocessing (fix-si.sh — gunzip recompress + xmll split)
-    Stage 3: Conf endpoint matches the latest delivery
-    Stage 4: Harvest (harvest.sh smithsonian)
-    Stage 5: Pipeline (mapping → enrichment → jsonl via ingest.sh --skip-harvest)
-    Stage 6: S3 sync (jsonl in s3://dpla-master-dataset/smithsonian/jsonl/)
-
-For each stage, prints one of:
-    [DONE] / [RUNNING] / [PENDING] / [SKIPPED]
-
-Plus a "current stage" summary with relevant log tail and a "next action"
-suggestion so you know what to do next.
+Reports the things that matter while you're waiting:
+  - Whether harvest.sh or ingest.sh is still alive, and for how long.
+  - Which stages have completed (with record counts).
+  - Which stage is currently running, when it started, and (for harvest)
+    how far through it we are.
 
 Usage:
-    python3 check_status_smithsonian.py            # auto-detect latest delivery
-    python3 check_status_smithsonian.py --date 2026-04-03   # specific delivery
-    python3 check_status_smithsonian.py --watch    # refresh every 60s
+    python3 check_status_smithsonian.py            # one-shot
+    python3 check_status_smithsonian.py --watch    # refresh every 30s
+    python3 check_status_smithsonian.py --watch 60 # custom interval
 """
 
 import argparse
@@ -33,6 +25,21 @@ import time
 from datetime import datetime
 
 # ---------- config ----------
+DATA_ROOT    = "/home/ec2-user/data/smithsonian"
+HARVEST_LOG  = "/home/ec2-user/data/si-harvest.log"
+PIPELINE_LOG = "/home/ec2-user/data/smithsonian-ingest.log"
+
+STAGES = ("harvest", "mapping", "enrichment", "jsonl")
+
+STAGE_KEYWORDS = {
+    "jsonl":      ["JsonlEntry", "jsonl complete"],
+    "enrichment": ["EnrichEntry", "enrichment complete"],
+    "mapping":    ["MappingEntry", "IngestRemap", "mapping complete"],
+    "harvest":    ["SiFileHarvester", "Harvested"],
+}
+PIPELINE_STAGE_REGEX = "MappingEntry|IngestRemap|EnrichEntry|JsonlEntry|mapping complete|enrichment complete|jsonl complete"
+
+
 def _load_dotenv():
     cfg = {}
     env_file = os.path.normpath(
@@ -54,22 +61,10 @@ _env = _load_dotenv()
 INSTANCE_ID = _env.get("INGEST_INSTANCE_ID", "")
 AWS_PROFILE = os.environ.get("AWS_PROFILE", "dpla")
 
-S3_DELIVERY_BUCKET = "dpla-hub-si"
-S3_OUTPUT_BUCKET = "dpla-master-dataset"
-HUB_S3_NAME = "smithsonian"
-
-DATA_ROOT = "/home/ec2-user/data/smithsonian"
-HARVEST_LOG = "/home/ec2-user/data/si-harvest.log"
-PIPELINE_LOG = "/home/ec2-user/data/smithsonian-ingest.log"
-CONF_PATH_BOX = "/home/ec2-user/ingestion3-conf/i3.conf"
-
-S3_DATE_RE = re.compile(r"PRE\s+(\d{4}-\d{2}-\d{2})/")
-S3_FOLDER_DATE_RE = re.compile(r"PRE\s+(\d{8})[-_]")
-
 
 # ---------- AWS / SSM ----------
 def aws(args):
-    profile = [] if any(a.startswith("--profile") for a in args) else ["--profile", "dpla"]
+    profile = [] if any(a.startswith("--profile") for a in args) else ["--profile", AWS_PROFILE]
     result = subprocess.run(["aws"] + profile + args, capture_output=True, text=True)
     if result.returncode != 0:
         raise RuntimeError(f"aws {' '.join(args)} failed:\n{result.stderr.strip()}")
@@ -111,481 +106,343 @@ def ssm_run(shell_cmd, timeout_seconds=60, poll_seconds=4):
         "--output", "text",
     ])
     if status != "Success":
-        raise RuntimeError(f"SSM ended with status {status}.\nSTDOUT:\n{output}")
+        try:
+            stderr = aws([
+                "ssm", "get-command-invocation",
+                "--command-id", cmd_id,
+                "--instance-id", INSTANCE_ID,
+                "--query", "StandardErrorContent",
+                "--output", "text",
+            ])
+        except Exception:
+            stderr = "(could not fetch stderr)"
+        raise RuntimeError(f"SSM ended with status {status}.\nStdout:\n{output}\nStderr:\n{stderr}")
     return output
 
 
-# ---------- helpers ----------
-def aws_s3_ls(s3_path):
-    try:
-        result = subprocess.run(
-            ["aws", "s3", "ls", s3_path, "--profile", AWS_PROFILE],
-            capture_output=True, text=True, timeout=30,
-        )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return ""
-    return result.stdout if result.returncode == 0 else ""
+# ---------- bash payload ----------
+def build_status_script():
+    return f"""
+echo "===PROCESS==="
+HARVEST_PIDS=$(pgrep -f 'harvest\\.sh smithsonian' 2>/dev/null || true)
+PIPELINE_PIDS=$(pgrep -f 'ingest\\.sh smithsonian' 2>/dev/null || true)
+if [ -n "$HARVEST_PIDS" ]; then
+  for p in $HARVEST_PIDS; do ps -o pid=,etime=,cmd= -p $p 2>/dev/null; done
+elif [ -n "$PIPELINE_PIDS" ]; then
+  for p in $PIPELINE_PIDS; do ps -o pid=,etime=,cmd= -p $p 2>/dev/null; done
+else
+  echo "(none)"
+fi
+
+echo "===LOGINFO==="
+HARVEST_RUNNING=$(pgrep -f 'harvest\\.sh smithsonian' 2>/dev/null || true)
+PIPELINE_RUNNING=$(pgrep -f 'ingest\\.sh smithsonian' 2>/dev/null || true)
+if [ -n "$HARVEST_RUNNING" ]; then
+  ACTIVE_LOG="{HARVEST_LOG}"
+elif [ -n "$PIPELINE_RUNNING" ]; then
+  ACTIVE_LOG="{PIPELINE_LOG}"
+else
+  ACTIVE_LOG=$(ls -t {HARVEST_LOG} {PIPELINE_LOG} 2>/dev/null | head -1)
+fi
+if [ -n "$ACTIVE_LOG" ] && [ -f "$ACTIVE_LOG" ]; then
+  echo "log=$ACTIVE_LOG"
+  echo "mtime=$(stat -c '%y' "$ACTIVE_LOG" 2>/dev/null | cut -d'.' -f1)"
+fi
+echo "ec2_now=$(date '+%H:%M:%S')"
+
+echo "===STAGE_FIRST==="
+HLOG="{HARVEST_LOG}"
+PLOG="{PIPELINE_LOG}"
+[ -f "$HLOG" ] && grep -m1 -E 'SiFileHarvester|Harvested' "$HLOG" 2>/dev/null | grep -oE '[0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}' | head -1
+echo "---"
+[ -f "$PLOG" ] && grep -m1 -E 'MappingEntry|IngestRemap' "$PLOG" 2>/dev/null | grep -oE '[0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}' | head -1
+echo "---"
+[ -f "$PLOG" ] && grep -m1 -E 'EnrichEntry' "$PLOG" 2>/dev/null | grep -oE '[0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}' | head -1
+echo "---"
+[ -f "$PLOG" ] && grep -m1 -E 'JsonlEntry' "$PLOG" 2>/dev/null | grep -oE '[0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}' | head -1
+echo "---"
+
+echo "===STAGE_RECENT==="
+PLOG="{PIPELINE_LOG}"
+[ -f "$PLOG" ] && tail -200 "$PLOG" 2>/dev/null | grep -E "{PIPELINE_STAGE_REGEX}" | tail -10
+
+echo "===PROGRESS_LINES==="
+HLOG="{HARVEST_LOG}"
+[ -f "$HLOG" ] && tail -100 "$HLOG" 2>/dev/null | grep -E 'SiFileHarvester.*Harvested' | tail -5
+
+echo "===STAGES_DONE==="
+CUTOFF=$(date -d '48 hours ago' +%s)
+for stage in harvest mapping enrichment jsonl; do
+  STAGE_DIR="{DATA_ROOT}/$stage"
+  LATEST=$(ls -1dt $STAGE_DIR/*/ 2>/dev/null | head -1 | sed 's:/$::')
+  if [ -n "$LATEST" ] && [ -f "$LATEST/_SUCCESS" ]; then
+    SUCCESS_EPOCH=$(stat -c '%Y' "$LATEST/_SUCCESS" 2>/dev/null || echo 0)
+    if [ "$SUCCESS_EPOCH" -lt "$CUTOFF" ]; then continue; fi
+    MTIME=$(stat -c '%y' "$LATEST/_SUCCESS" 2>/dev/null | cut -d'.' -f1)
+    MANIFEST=""
+    [ -f "$LATEST/_MANIFEST" ] && MANIFEST=$(grep -i 'record count' "$LATEST/_MANIFEST" 2>/dev/null | head -1 | tr -d '\\n')
+    echo "$stage|$MTIME|$MANIFEST"
+  fi
+done
+""".strip()
 
 
-def find_latest_ia_delivery():
-    out = aws_s3_ls(f"s3://{S3_DELIVERY_BUCKET}/")
-    dates = [m.group(1) for m in (S3_DATE_RE.search(line) for line in out.splitlines()) if m]
-    return sorted(dates)[-1] if dates else None
-
-
-def s3_jsonl_folders():
-    out = aws_s3_ls(f"s3://{S3_OUTPUT_BUCKET}/{HUB_S3_NAME}/jsonl/")
-    return [m.group(1) for line in out.splitlines() for m in [S3_FOLDER_DATE_RE.search(line)] if m]
-
-
-def parse_kv(text):
-    """Parse simple key=value lines into a dict."""
-    out = {}
-    for line in text.splitlines():
-        if "=" in line:
-            k, v = line.split("=", 1)
-            out[k.strip()] = v.strip()
-    return out
-
-
-def parse_sections(out):
+# ---------- parsers ----------
+def parse_sections(out: str) -> dict:
     sections = {}
     current = None
     buf = []
     for line in out.splitlines():
         m = re.match(r"^===(\w+)===$", line.strip())
         if m:
-            if current:
+            if current is not None:
                 sections[current] = "\n".join(buf).rstrip()
             current = m.group(1)
             buf = []
         else:
             buf.append(line)
-    if current:
+    if current is not None:
         sections[current] = "\n".join(buf).rstrip()
     return sections
 
 
-# ---------- bash payload ----------
-def build_status_script(date):
-    """Single SSM call that gathers state for all six stages."""
-    download_dir = f"{DATA_ROOT}/originalRecords/{date}"
-    return f"""
-echo "===DOWNLOAD==="
-DIR="{download_dir}"
-if [ -d "$DIR" ]; then
-  echo "exists=yes"
-  echo "xml_gz_count=$(find "$DIR" -maxdepth 1 -name '*.xml.gz' -type f 2>/dev/null | wc -l)"
-  echo "size=$(du -sh "$DIR" 2>/dev/null | cut -f1)"
-  echo "mtime=$(stat -c '%y' "$DIR" 2>/dev/null | cut -d'.' -f1)"
-else
-  echo "exists=no"
-fi
-
-echo "===PREPROCESS==="
-if [ -d "$DIR/original_backup" ]; then
-  echo "preprocessed=yes"
-  echo "backup_count=$(find "$DIR/original_backup" -maxdepth 1 -name '*.xml.gz' -type f 2>/dev/null | wc -l)"
-  echo "preprocess_mtime=$(stat -c '%y' "$DIR/original_backup" 2>/dev/null | cut -d'.' -f1)"
-else
-  echo "preprocessed=no"
-fi
-
-echo "===CONF==="
-grep '^smithsonian\\.harvest\\.endpoint' {CONF_PATH_BOX} 2>/dev/null || echo "(no smithsonian endpoint in conf)"
-
-echo "===PROCESSES==="
-pgrep -af 'fix-si\\.sh|harvest\\.sh smithsonian|ingest\\.sh smithsonian|s3 sync.*dpla-hub-si' || echo "(no smithsonian processes)"
-
-echo "===HARVEST==="
-LATEST=$(ls -1dt {DATA_ROOT}/harvest/*/ 2>/dev/null | head -1 | sed 's:/$::')
-if [ -n "$LATEST" ]; then
-  echo "path=$LATEST"
-  echo "mtime=$(stat -c '%y' "$LATEST" 2>/dev/null | cut -d'.' -f1)"
-  echo "success=$([ -f "$LATEST/_SUCCESS" ] && echo yes || echo no)"
-  [ -f "$LATEST/_MANIFEST" ] && echo "manifest=$(grep -i 'record count' "$LATEST/_MANIFEST" 2>/dev/null | head -1 | tr -d '\\n')"
-else
-  echo "exists=no"
-fi
-
-echo "===MAPPING==="
-LATEST=$(ls -1dt {DATA_ROOT}/mapping/*/ 2>/dev/null | head -1 | sed 's:/$::')
-if [ -n "$LATEST" ]; then
-  echo "path=$LATEST"
-  echo "success=$({{ [ -f "$LATEST/_SUCCESS" ] || [ -f "$LATEST/_MANIFEST" ]; }} && echo yes || echo no)"
-  echo "mtime=$(stat -c '%y' "$LATEST" 2>/dev/null | cut -d'.' -f1)"
-  [ -f "$LATEST/_MANIFEST" ] && echo "manifest=$(grep -i 'record count' "$LATEST/_MANIFEST" 2>/dev/null | head -1 | tr -d '\\n')"
-else
-  echo "exists=no"
-fi
-
-echo "===ENRICHMENT==="
-LATEST=$(ls -1dt {DATA_ROOT}/enrichment/*/ 2>/dev/null | head -1 | sed 's:/$::')
-if [ -n "$LATEST" ]; then
-  echo "path=$LATEST"
-  echo "success=$([ -f "$LATEST/_SUCCESS" ] && echo yes || echo no)"
-  echo "mtime=$(stat -c '%y' "$LATEST" 2>/dev/null | cut -d'.' -f1)"
-  [ -f "$LATEST/_MANIFEST" ] && echo "manifest=$(grep -i 'record count' "$LATEST/_MANIFEST" 2>/dev/null | head -1 | tr -d '\\n')"
-else
-  echo "exists=no"
-fi
-
-echo "===JSONL==="
-LATEST=$(ls -1dt {DATA_ROOT}/jsonl/*/ 2>/dev/null | head -1 | sed 's:/$::')
-if [ -n "$LATEST" ]; then
-  echo "path=$LATEST"
-  echo "success=$([ -f "$LATEST/_SUCCESS" ] && echo yes || echo no)"
-  echo "mtime=$(stat -c '%y' "$LATEST" 2>/dev/null | cut -d'.' -f1)"
-  [ -f "$LATEST/_MANIFEST" ] && echo "manifest=$(grep -i 'record count' "$LATEST/_MANIFEST" 2>/dev/null | head -1 | tr -d '\\n')"
-else
-  echo "exists=no"
-fi
-
-echo "===HARVEST_LOG==="
-[ -f {HARVEST_LOG} ] && tail -15 {HARVEST_LOG} 2>/dev/null || echo "(no harvest log)"
-
-echo "===PIPELINE_LOG==="
-[ -f {PIPELINE_LOG} ] && tail -15 {PIPELINE_LOG} 2>/dev/null || echo "(no pipeline log)"
-""".strip()
+def detect_current_stage(sections: dict, is_harvest_running: bool, is_pipeline_running: bool) -> str | None:
+    if is_harvest_running:
+        return "harvest"
+    if is_pipeline_running:
+        stage_recent = sections.get("STAGE_RECENT", "")
+        for line in reversed(stage_recent.splitlines()):
+            for stage, keywords in STAGE_KEYWORDS.items():
+                if stage == "harvest":
+                    continue
+                for kw in keywords:
+                    if kw in line:
+                        return stage
+    return None
 
 
-# ---------- stage analysis ----------
-DONE = "[DONE]"
-RUNNING = "[RUNNING]"
-PENDING = "[PENDING]"
-WARN = "[WARN]"
-STALE = "[STALE]"   # output exists but is from a previous run, not the current one
+def parse_first_stage_timestamps(stage_first: str) -> dict:
+    timestamps = {}
+    chunks = stage_first.split("---")
+    ts_re = re.compile(r"^\d{2}:\d{2}:\d{2}$")
+    for stage, chunk in zip(STAGES, chunks):
+        ts = chunk.strip()
+        if ts_re.match(ts):
+            timestamps[stage] = ts
+    return timestamps
 
 
-def parse_dir_timestamp(path):
-    """Extract YYYYMMDDHHMMSS from a Spark output dir name.
-    Dir names look like '20260429_191232-smithsonian-OriginalRecord.avro'.
-    Returns int(YYYYMMDDHHMMSS) for easy comparison, or None."""
-    if not path:
-        return None
-    name = os.path.basename(path)
-    m = re.match(r"^(\d{8})_(\d{6})", name)
-    return int(m.group(1) + m.group(2)) if m else None
+def hms_to_seconds(hms: str) -> int:
+    h, m, s = (int(x) for x in hms.split(":"))
+    return h * 3600 + m * 60 + s
 
 
-def parse_record_count(manifest_str):
-    """Pull the integer out of a manifest string like 'Record count: 7832993'."""
-    if not manifest_str:
-        return None
-    m = re.search(r"(\d[\d,]*)", manifest_str)
-    if not m:
+def fmt_duration(seconds) -> str:
+    if seconds is None or seconds < 0:
+        return "?"
+    seconds = int(seconds)
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    if h: return f"{h}h {m}m"
+    if m: return f"{m}m {s}s"
+    return f"{s}s"
+
+
+def stage_runtime_seconds(stage_first_ts, now_ref):
+    if not stage_first_ts or not now_ref:
         return None
     try:
-        return int(m.group(1).replace(",", ""))
+        ref_dt = datetime.strptime(now_ref, "%Y-%m-%d %H:%M:%S")
     except ValueError:
         return None
+    try:
+        stage_t = datetime.strptime(stage_first_ts, "%H:%M:%S").time()
+    except ValueError:
+        return None
+    stage_dt = datetime.combine(ref_dt.date(), stage_t)
+    delta = (ref_dt - stage_dt).total_seconds()
+    if delta < 0:
+        delta += 86400
+    return int(delta)
 
 
-# Smithsonian historically lands in the millions of records. Anything below
-# this is almost certainly a partial/failed harvest, not a real one.
-SMITHSONIAN_MIN_PLAUSIBLE_RECORDS = 100_000
-
-
-def analyze(date, sections):
-    """Return a list of {stage, status, detail, current} dicts."""
-    download = parse_kv(sections.get("DOWNLOAD", ""))
-    preprocess = parse_kv(sections.get("PREPROCESS", ""))
-    conf = sections.get("CONF", "").strip()
-    procs = sections.get("PROCESSES", "").strip()
-    harvest = parse_kv(sections.get("HARVEST", ""))
-    mapping = parse_kv(sections.get("MAPPING", ""))
-    enrichment = parse_kv(sections.get("ENRICHMENT", ""))
-    jsonl = parse_kv(sections.get("JSONL", ""))
-
-    # Detect which processes are currently running.
-    running_download = "s3 sync" in procs and "dpla-hub-si" in procs
-    running_preprocess = "fix-si.sh" in procs
-    running_harvest = "harvest.sh smithsonian" in procs
-    running_pipeline = "ingest.sh smithsonian" in procs
-
-    stages = []
-
-    # Stage 1: Download
-    if running_download:
-        s = RUNNING
-        d = "aws s3 sync still in flight"
-    elif download.get("exists") == "yes":
-        s = DONE
-        d = f"{download.get('xml_gz_count', '?')} files, {download.get('size', '?')} (mtime {download.get('mtime', '?')})"
-    else:
-        s = PENDING
-        d = f"no folder at {DATA_ROOT}/originalRecords/{date}"
-    stages.append({"name": f"Stage 1/6: Download from s3://dpla-hub-si/{date}/", "status": s, "detail": d})
-
-    # Stage 2: Preprocess
-    if running_preprocess:
-        s = RUNNING
-        d = "fix-si.sh in flight (NMNHBOTANY can take ~6 min)"
-    elif preprocess.get("preprocessed") == "yes":
-        s = DONE
-        d = f"original_backup/ has {preprocess.get('backup_count', '?')} files (mtime {preprocess.get('preprocess_mtime', '?')})"
-    elif download.get("exists") == "yes":
-        s = PENDING
-        d = "download done, fix-si.sh not yet run"
-    else:
-        s = PENDING
-        d = "blocked on Stage 1"
-    stages.append({"name": "Stage 2/6: Preprocessing (fix-si.sh)", "status": s, "detail": d})
-
-    # Stage 3: Conf endpoint
-    expected_path_substring = f"/{date}/"
-    if expected_path_substring in conf:
-        s = DONE
-        d = conf
-    elif conf and "smithsonian" in conf:
-        s = WARN
-        d = f"conf endpoint doesn't reference {date}: {conf}"
-    else:
-        s = PENDING
-        d = "conf endpoint not detected"
-    stages.append({"name": f"Stage 3/6: Conf endpoint references {date}", "status": s, "detail": d})
-
-    # Stage 4: Harvest
-    harvest_ts = parse_dir_timestamp(harvest.get("path", ""))
-    harvest_records = parse_record_count(harvest.get("manifest", ""))
-    if running_harvest:
-        s = RUNNING
-        d = "harvest.sh smithsonian in flight"
-    elif harvest.get("success") == "yes":
-        if harvest_records is not None and harvest_records < SMITHSONIAN_MIN_PLAUSIBLE_RECORDS:
-            s = WARN
-            d = (f"_SUCCESS present but only {harvest_records:,} records — likely a stale or "
-                 f"failed run; expected millions. Path: {harvest.get('path', '?')}")
+def parse_process_lines(proc_text: str):
+    rows = []
+    for ln in proc_text.splitlines():
+        ln = ln.strip()
+        if not ln or ln == "(none)":
+            continue
+        m = re.match(r"^\s*(\d+)\s+(\S+)\s+(.*)$", ln)
+        if not m:
+            continue
+        pid, etime, cmd = m.group(1), m.group(2), m.group(3)
+        script_match = re.search(r"/([^/\s]+\.sh)(\s+.*)?$", cmd)
+        if script_match:
+            name = script_match.group(1)
+            tail = (script_match.group(2) or "").strip()
+            script = f"{name} {tail}".strip()
         else:
-            s = DONE
-            d = f"{harvest.get('path', '?')} (mtime {harvest.get('mtime', '?')})"
-            if "manifest" in harvest:
-                d += f" — {harvest['manifest']}"
-    elif harvest.get("exists") != "no":
-        s = WARN
-        d = f"output dir exists but no _SUCCESS: {harvest.get('path', '?')}"
-    else:
-        s = PENDING
-        d = "no harvest output yet"
-    stages.append({"name": "Stage 4/6: Harvest", "status": s, "detail": d})
-
-    # Stage 5: Pipeline (mapping + enrichment + jsonl)
-    # Cross-reference timestamps with the harvest run — any sub-stage output
-    # whose timestamp predates the current harvest is from a previous ingest
-    # and should NOT be counted as done for this delivery.
-    def stage_belongs_to_current_run(stage_dict):
-        """True if this stage's output is from the current harvest run (or
-        later). False if it's older (a previous run's output)."""
-        if stage_dict.get("success") != "yes":
-            return False
-        if harvest_ts is None:
-            # No harvest yet — there's no "current run" to belong to.
-            return False
-        ts = parse_dir_timestamp(stage_dict.get("path", ""))
-        return ts is not None and ts >= harvest_ts
-
-    sub_done_current = sum(
-        1 for x in (mapping, enrichment, jsonl) if stage_belongs_to_current_run(x)
-    )
-    sub_done_total = sum(1 for x in (mapping, enrichment, jsonl) if x.get("success") == "yes")
-    sub_stale = sub_done_total - sub_done_current
-
-    # Build a per-substage record count string for any completed sub-stages,
-    # e.g. "mapping: 7,845,472 | enrichment: 7,845,201 | jsonl: pending"
-    def substage_counts():
-        parts = []
-        for label, stage_dict in (("mapping", mapping), ("enrichment", enrichment), ("jsonl", jsonl)):
-            if stage_belongs_to_current_run(stage_dict):
-                count = parse_record_count(stage_dict.get("manifest", ""))
-                parts.append(f"{label}: {count:,}" if count else f"{label}: done (no manifest)")
-            elif running_pipeline:
-                parts.append(f"{label}: in progress" if not parts else f"{label}: pending")
-        return " | ".join(parts) if parts else ""
-
-    if running_pipeline:
-        s = RUNNING
-        counts = substage_counts()
-        d = f"in flight ({sub_done_current}/3 substages done)"
-        if counts:
-            d += f" — {counts}"
-    elif sub_done_current == 3:
-        s = DONE
-        counts = substage_counts()
-        d = f"all 3 substages complete"
-        if counts:
-            d += f" — {counts}"
-    elif sub_done_current > 0:
-        s = WARN
-        counts = substage_counts()
-        d = f"only {sub_done_current}/3 substages from current run done"
-        if counts:
-            d += f" — {counts}"
-    elif sub_stale > 0:
-        # All "done" sub-stages are from a previous run — for THIS delivery,
-        # the pipeline hasn't started yet.
-        s = STALE
-        d = (f"{sub_stale} sub-stage(s) have _SUCCESS markers but they're from a "
-             f"previous run (predate the current harvest). Pipeline NOT yet done for {date}.")
-    elif harvest.get("success") == "yes":
-        s = PENDING
-        d = "harvest complete, pipeline not yet run"
-    else:
-        s = PENDING
-        d = "blocked on Stage 4"
-    stages.append({"name": "Stage 5/6: Pipeline (mapping/enrichment/jsonl)", "status": s, "detail": d})
-
-    # Stage 6: S3 sync — must be from current harvest's date or later, not
-    # just any folder dated within the same calendar month.
-    harvest_date_str = str(harvest_ts)[:8] if harvest_ts else None  # e.g. "20260429"
-    s3_folders = s3_jsonl_folders()
-    target_yyyymm = date.replace("-", "")[:6]
-    if harvest_date_str:
-        matching_current = [f for f in s3_folders if f >= harvest_date_str]
-        matching_month = [f for f in s3_folders if f.startswith(target_yyyymm)]
-    else:
-        matching_current = []
-        matching_month = [f for f in s3_folders if f.startswith(target_yyyymm)]
-
-    if matching_current:
-        s = DONE
-        d = f"jsonl folder in S3 dated {sorted(matching_current)[-1]} (>= harvest {harvest_date_str})"
-    elif matching_month and stage_belongs_to_current_run(jsonl):
-        # Local jsonl is current and matches this month — assume the S3 folder
-        # we see is for the current run even if its timestamp is earlier.
-        s = DONE
-        d = f"jsonl folder in S3 for {target_yyyymm} (date {sorted(matching_month)[-1]})"
-    elif matching_month:
-        s = STALE
-        d = (f"jsonl folder in S3 dated {sorted(matching_month)[-1]} is from this month but "
-             f"PRECEDES the current harvest {harvest_date_str}. S3 sync NOT yet done for {date}.")
-    elif sub_done_current == 3:
-        s = WARN
-        d = "local pipeline complete but S3 doesn't show a folder yet"
-    else:
-        s = PENDING
-        d = "blocked on Stage 5"
-    stages.append({"name": "Stage 6/6: S3 sync to dpla-master-dataset", "status": s, "detail": d})
-
-    return stages, {
-        "running_download": running_download,
-        "running_preprocess": running_preprocess,
-        "running_harvest": running_harvest,
-        "running_pipeline": running_pipeline,
-    }
+            script = cmd
+        rows.append({"pid": pid, "etime": etime, "script": script})
+    return rows
 
 
-# ---------- next-action suggester ----------
-def suggest_next_action(stages, running):
-    """Return a one-paragraph suggestion of what to do next."""
-    if any(running.values()):
-        which = next(k for k, v in running.items() if v)
-        if which == "running_download":
-            return "Wait for the S3 download to finish. Re-check in 5–15 min."
-        if which == "running_preprocess":
-            return "Wait for fix-si.sh to finish. NMNHBOTANY alone takes ~6 min, total ~10–15 min."
-        if which == "running_harvest":
-            return ("Wait for harvest.sh to finish. Smithsonian harvest is typically 3–4 hours. "
-                    "Check the harvest log periodically.")
-        if which == "running_pipeline":
-            return ("Wait for ingest.sh to finish. Mapping/enrichment/jsonl + S3 sync is typically "
-                    "1–2 hours. Watch the pipeline log.")
+def parse_si_harvest_progress(progress_lines: str):
+    """Parse 'SiFileHarvester - Harvested 73.2% (409,678 / 559,554)' lines."""
+    best = None
+    for line in progress_lines.splitlines():
+        m = re.search(r"Harvested\s+([\d.]+)%\s+\((\d[\d,]*)\s*/\s*(\d[\d,]*)\)", line)
+        if m:
+            pct = float(m.group(1))
+            current = int(m.group(2).replace(",", ""))
+            total = int(m.group(3).replace(",", ""))
+            best = (pct, current, total)
+    return best  # returns (pct, current, total) or None
 
-    # Nothing running — find the first pending stage.
-    for stage in stages:
-        if stage["status"] == PENDING:
-            num = stage["name"].split(":")[0]
-            if "1/6" in num:
-                return "Stage 1: kick off the download (aws s3 sync from dpla-hub-si)."
-            if "2/6" in num:
-                return "Stage 2: run fix-si.sh on the downloaded folder."
-            if "3/6" in num:
-                return "Stage 3: update smithsonian.harvest.endpoint in i3.conf, push, pull on box."
-            if "4/6" in num:
-                return "Stage 4: kick off the harvest (./scripts/harvest.sh smithsonian)."
-            if "5/6" in num:
-                return "Stage 5: kick off the pipeline (./scripts/ingest.sh smithsonian --skip-harvest)."
-            if "6/6" in num:
-                return ("Stage 6: ingest.sh should have synced to S3. If it didn't, check the "
-                        "pipeline log for S3 errors and consider a manual aws s3 sync.")
 
-    # Look for STALE first — that means we have outputs from a previous run
-    # but the current run's pipeline/S3 hasn't been done yet.
-    for stage in stages:
-        if stage["status"] == STALE:
-            num = stage["name"].split(":")[0]
-            if "5/6" in num:
-                return ("Stage 5: previous run's pipeline outputs are present but predate the "
-                        "current harvest. Run ./scripts/ingest.sh smithsonian --skip-harvest to "
-                        "produce fresh mapping/enrichment/jsonl for this delivery.")
-            if "6/6" in num:
-                return ("Stage 6: S3 has an earlier folder but not one matching the current "
-                        "harvest. After the pipeline finishes, the S3 sync should land a fresh "
-                        "folder dated >= the current harvest.")
-
-    if any(s["status"] == WARN for s in stages):
-        return "There are warnings — review the [WARN] lines above."
-    return "All six stages complete. Smithsonian is done for this delivery."
+# ---------- color ----------
+GREEN = "\033[32m"; YELLOW = "\033[33m"; RED = "\033[31m"
+DIM = "\033[2m"; BOLD = "\033[1m"; RESET = "\033[0m"
+USE_COLOR = sys.stdout.isatty()
+def c(color, text): return f"{color}{text}{RESET}" if USE_COLOR else text
 
 
 # ---------- render ----------
-def render(date, stages, running, sections):
-    out = []
-    out.append("")
-    out.append("=" * 70)
-    out.append(f"  Smithsonian Ingest Status — delivery {date}")
-    out.append("=" * 70)
-    out.append("")
-    for st in stages:
-        out.append(f"  {st['status']:<10} {st['name']}")
-        out.append(f"             {st['detail']}")
-        out.append("")
+def render(sections: dict) -> str:
+    lines = []
+    lines.append("")
+    lines.append(c(DIM, "=" * 70))
+    lines.append(f"  Smithsonian ingest status   (instance {INSTANCE_ID})")
+    lines.append(c(DIM, "=" * 70))
 
-    # Running-stage detail (log tail)
-    if running.get("running_harvest"):
-        out.append("HARVEST LOG (last 15 lines):")
-        out.append(sections.get("HARVEST_LOG", "").rstrip())
-        out.append("")
-    elif running.get("running_pipeline"):
-        out.append("PIPELINE LOG (last 15 lines):")
-        out.append(sections.get("PIPELINE_LOG", "").rstrip())
-        out.append("")
+    # PROCESS
+    proc_text = sections.get("PROCESS", "").strip()
+    proc_rows = parse_process_lines(proc_text)
+    is_harvest_running = any("harvest.sh" in r["script"] for r in proc_rows)
+    is_pipeline_running = any("ingest.sh" in r["script"] for r in proc_rows)
+    is_running = bool(proc_rows)
 
-    out.append("NEXT ACTION:")
-    out.append(f"  {suggest_next_action(stages, running)}")
-    out.append("")
-    return "\n".join(out)
+    lines.append("")
+    lines.append("PROCESS")
+    if not is_running:
+        lines.append("  " + c(YELLOW, "(no smithsonian process running)"))
+    else:
+        primary = proc_rows[0]
+        lines.append(f"  Script:  {c(GREEN, primary['script'])}")
+        lines.append(f"  PID:     {primary['pid']}   (running for {primary['etime']})")
+        if len(proc_rows) > 1:
+            lines.append(c(DIM, f"  + {len(proc_rows) - 1} subprocess(es)"))
+
+    # COMPLETED STAGES
+    lines.append("")
+    lines.append("COMPLETED STAGES (this run)")
+    done_lines = [ln for ln in sections.get("STAGES_DONE", "").splitlines() if ln.strip()]
+    if not done_lines:
+        lines.append(c(DIM, "  (none yet this run)"))
+    else:
+        for ln in done_lines:
+            parts = ln.split("|", 2)
+            if len(parts) == 3:
+                stage, mtime, manifest = parts
+                manifest = re.sub(
+                    r"(\d[\d,]*)",
+                    lambda m: f"{int(m.group(1).replace(',', '')):,}",
+                    manifest.strip(),
+                    count=1,
+                )
+                lines.append(f"  {c(GREEN, stage):<22} done {mtime}   {manifest}")
+            else:
+                lines.append(f"  {ln}")
+
+    # CURRENT STAGE
+    stage_first_ts = parse_first_stage_timestamps(sections.get("STAGE_FIRST", ""))
+    loginfo_lines = sections.get("LOGINFO", "").splitlines()
+    log_mtime = next((ln.split("=", 1)[1] for ln in loginfo_lines if ln.startswith("mtime=")), None)
+    ec2_now   = next((ln.split("=", 1)[1] for ln in loginfo_lines if ln.startswith("ec2_now=")), None)
+    now_ref   = f"2000-01-01 {ec2_now}" if ec2_now else log_mtime
+
+    lines.append("")
+    lines.append("CURRENT STAGE")
+    if not is_running:
+        lines.append(c(DIM, "  (no process running — see SUMMARY)"))
+    else:
+        current_stage = detect_current_stage(sections, is_harvest_running, is_pipeline_running)
+        if not current_stage:
+            lines.append(c(YELLOW, "  Could not infer current stage from log."))
+        else:
+            stage_start = stage_first_ts.get(current_stage)
+            runtime_s = stage_runtime_seconds(stage_start, now_ref)
+            lines.append(f"  Stage:     {c(YELLOW, current_stage)}")
+            if stage_start:
+                lines.append(f"  Started:   {stage_start}   (running for {fmt_duration(runtime_s)})")
+            else:
+                lines.append("  Started:   (no stage-start marker found in log)")
+
+            if current_stage == "harvest":
+                progress = parse_si_harvest_progress(sections.get("PROGRESS_LINES", ""))
+                if progress:
+                    pct, current, total = progress
+                    lines.append(
+                        f"  Progress:  {current:,} / {total:,} files "
+                        f"({c(BOLD, f'{pct:.1f}%')})"
+                    )
+                else:
+                    lines.append("  Progress:  (no progress lines in recent log)")
+            else:
+                lines.append(c(DIM, "  Progress:  (Spark stage — not derivable from log)"))
+
+    # SUMMARY
+    lines.append("")
+    lines.append("SUMMARY: " + derive_summary(is_running, is_harvest_running, is_pipeline_running, sections))
+    lines.append("")
+    return "\n".join(lines)
+
+
+def derive_summary(is_running, is_harvest_running, is_pipeline_running, sections):
+    done_count = len([ln for ln in sections.get("STAGES_DONE", "").splitlines() if ln.strip()])
+    if is_running:
+        if is_harvest_running:
+            progress = parse_si_harvest_progress(sections.get("PROGRESS_LINES", ""))
+            if progress:
+                pct, current, total = progress
+                return c(YELLOW, f"running — harvest at {pct:.1f}% ({current:,} / {total:,})")
+            return c(YELLOW, "running — harvest in progress")
+        if is_pipeline_running:
+            stage_recent = sections.get("STAGE_RECENT", "")
+            for line in reversed(stage_recent.splitlines()):
+                for stage, keywords in STAGE_KEYWORDS.items():
+                    if stage == "harvest":
+                        continue
+                    for kw in keywords:
+                        if kw in line:
+                            return c(YELLOW, f"running — currently in {stage}")
+            return c(YELLOW, "running — pipeline in progress")
+        return c(YELLOW, "running — stage unclear")
+
+    if done_count == len(STAGES):
+        return c(GREEN, "complete — all stages DONE")
+    return c(RED, f"process is gone, only {done_count}/{len(STAGES)} stages complete in last 48h — likely failed or still launching")
 
 
 # ---------- main ----------
 def main():
-    parser = argparse.ArgumentParser(description="Smithsonian ingest status checker")
-    parser.add_argument("--date", help="Delivery date YYYY-MM-DD. Default: latest in s3://dpla-hub-si/.")
+    parser = argparse.ArgumentParser(description="Check on a Smithsonian ingest.")
     parser.add_argument(
-        "--watch", nargs="?", const=60, type=int, default=None,
-        help="Refresh every N seconds (default 60).",
+        "--watch", nargs="?", const=30, type=int, default=None,
+        help="Re-run every N seconds (default 30 if --watch is given without a value).",
     )
     args = parser.parse_args()
 
-    date = args.date
-    if not date:
-        date = find_latest_ia_delivery()
-        if not date:
-            sys.exit(f"Could not find any deliveries in s3://{S3_DELIVERY_BUCKET}/")
-        print(f"(auto-detected latest delivery: {date})")
-    if not re.match(r"^\d{4}-\d{2}-\d{2}$", date):
-        sys.exit(f"Invalid --date {date}. Use YYYY-MM-DD.")
-
-    script = build_status_script(date)
+    script = build_status_script()
 
     def one_pass():
         try:
             out = ssm_run(script)
         except RuntimeError as e:
-            print(f"[ERROR] {e}")
+            print(f"\n[ERROR] {e}\n")
             return
         sections = parse_sections(out)
-        stages, running = analyze(date, sections)
-        print(render(date, stages, running, sections))
+        print(render(sections))
 
     if args.watch is None:
         one_pass()
@@ -597,7 +454,7 @@ def main():
             os.system("clear" if os.name == "posix" else "cls")
             print(time.strftime("Last refresh: %Y-%m-%d %H:%M:%S"))
             one_pass()
-            print(f"(refreshing every {interval}s — Ctrl+C to exit)")
+            print(c(DIM, f"(refreshing every {interval}s — Ctrl+C to exit)"))
             time.sleep(interval)
     except KeyboardInterrupt:
         print("\nStopped.")

--- a/ingest_python_scripts/smithsonian/launch_smithsonian.py
+++ b/ingest_python_scripts/smithsonian/launch_smithsonian.py
@@ -324,11 +324,12 @@ def run_harvest(date):
             f'RUNNING=$(pgrep -af "harvest.sh smithsonian" || true)\n'
             f'if [ -n "$LATEST" ] && [ -f "$LATEST/_SUCCESS" ] && [ "$LATEST" -nt "$ORIG" ]; then echo "done:$LATEST"\n'
             f'elif [ -z "$RUNNING" ] && [ -n "$LATEST" ]; then echo "failed:$LATEST"\n'
-            f'else echo "running"; fi'
+            f'else echo "running"; fi',
+            timeout_seconds=60,
         ).strip()
         return out if out.startswith("done:") or out.startswith("failed:") else None
 
-    result = poll_until_done(check_fn, lambda: ssm_run(f'tail -2 {HARVEST_LOG} 2>/dev/null || true'))
+    result = poll_until_done(check_fn, lambda: ssm_run(f'tail -2 {HARVEST_LOG} 2>/dev/null || true', timeout_seconds=60))
     if result.startswith("failed:"):
         slack_notify(f":x: *Smithsonian harvest FAILED* — `{result[7:]}`\nCheck `{HARVEST_LOG}`")
         err(f"Harvest exited without _SUCCESS at: {result[7:]}")
@@ -448,11 +449,12 @@ def run_pipeline(date):
             f'if [ -n "$HLAT" ] && [ "$HLAT" -nt "$ORIG" ] && [ -n "$MLAT" ] && [ "$MLAT" -nt "$HLAT" ] '
             f'&& [ -f "$LATEST/_SUCCESS" ] && [ "$LATEST" -nt "$MLAT" ]; then echo "done:$LATEST"\n'
             f'elif [ -z "$RUNNING" ]; then echo "failed"\n'
-            f'else echo "running"; fi'
+            f'else echo "running"; fi',
+            timeout_seconds=60,
         ).strip()
         return out if out.startswith("done:") or out == "failed" else None
 
-    result = poll_until_done(check_fn, lambda: ssm_run(f'tail -2 {PIPELINE_LOG} 2>/dev/null || true'))
+    result = poll_until_done(check_fn, lambda: ssm_run(f'tail -2 {PIPELINE_LOG} 2>/dev/null || true', timeout_seconds=60))
     if result == "failed":
         slack_notify(f":x: *Smithsonian pipeline FAILED* — no jsonl `_SUCCESS`\nCheck `{PIPELINE_LOG}`")
         err("Pipeline exited without jsonl/_SUCCESS.")

--- a/ingest_python_scripts/smithsonian/launch_smithsonian.py
+++ b/ingest_python_scripts/smithsonian/launch_smithsonian.py
@@ -138,9 +138,22 @@ def ssm_bg(shell_cmd):
         f"nohup bash -lc 'echo {inner_b64} | base64 -d | bash -l' "
         f"</dev/null >/dev/null 2>&1 & disown; echo launched"
     )
-    result = ssm_run(bg_wrapper, timeout_seconds=20)
+    result = ssm_run(bg_wrapper, timeout_seconds=30)
     if "launched" not in result:
         raise RuntimeError(f"Background launch may have failed. SSM output: {result!r}")
+
+
+def slack_notify(msg):
+    """Post to #tech-alerts via EC2 common.sh — same channel as ingest.sh milestones."""
+    encoded = base64.b64encode(msg.encode()).decode()
+    script = (
+        f"source {INGEST_DIR}/scripts/common.sh\n"
+        f"slack_notify \"$(echo {encoded} | base64 -d)\""
+    )
+    try:
+        ssm_run(script, timeout_seconds=30, poll_seconds=3)
+    except Exception:
+        pass  # Slack failure is never fatal
 
 
 def aws_s3_ls(s3_path):
@@ -250,7 +263,7 @@ def run_preprocess(date):
 
     info("Running fix-si.sh inline (this takes ~10–15 min) …")
     ssm_run(
-        f"bash {INGEST_DIR}/scripts/harvest/fix-si.sh {dest}",
+        f"bash {INGEST_DIR}/scripts/harvest/fix-si.sh {date}",
         timeout_seconds=PREPROCESS_TIMEOUT_S, poll_seconds=15,
     )
     count = ssm_run(
@@ -302,6 +315,7 @@ def run_harvest(date):
     info(f"Polling every {POLL_INTERVAL_S}s. Typically 3–4 hours.\n")
 
     ssm_bg(f"bash {INGEST_DIR}/scripts/harvest.sh smithsonian > {HARVEST_LOG} 2>&1")
+    slack_notify(f":rocket: *Smithsonian harvest launched* — delivery `{date}`\nLog: `{HARVEST_LOG}`")
 
     def check_fn():
         out = ssm_run(
@@ -316,9 +330,11 @@ def run_harvest(date):
 
     result = poll_until_done(check_fn, lambda: ssm_run(f'tail -2 {HARVEST_LOG} 2>/dev/null || true'))
     if result.startswith("failed:"):
+        slack_notify(f":x: *Smithsonian harvest FAILED* — `{result[7:]}`\nCheck `{HARVEST_LOG}`")
         err(f"Harvest exited without _SUCCESS at: {result[7:]}")
         err(f"Check {HARVEST_LOG}. Re-run with --start-at harvest to retry.")
         sys.exit(1)
+    slack_notify(f":white_check_mark: *Smithsonian harvest complete* — `{result[5:]}`")
 
 
 def harvest_checkpoint():
@@ -379,9 +395,11 @@ def run_mapping(date):
 
     check = ssm_run(_mapping_done_check("failed")).strip()
     if not check.startswith("done:"):
+        slack_notify(f":x: *Smithsonian mapping FAILED* — no `_MANIFEST`\nCheck `{PIPELINE_LOG}`")
         err(f"Mapping did not produce _MANIFEST. Check {PIPELINE_LOG}.")
         err("Re-run with --start-at mapping to retry.")
         sys.exit(1)
+    slack_notify(f":white_check_mark: *Smithsonian mapping complete* — `{check[5:]}`")
 
 
 def mapping_checkpoint():
@@ -436,9 +454,11 @@ def run_pipeline(date):
 
     result = poll_until_done(check_fn, lambda: ssm_run(f'tail -2 {PIPELINE_LOG} 2>/dev/null || true'))
     if result == "failed":
+        slack_notify(f":x: *Smithsonian pipeline FAILED* — no jsonl `_SUCCESS`\nCheck `{PIPELINE_LOG}`")
         err("Pipeline exited without jsonl/_SUCCESS.")
         err(f"Check {PIPELINE_LOG}. Re-run with --start-at pipeline to retry.")
         sys.exit(1)
+    slack_notify(f":tada: *Smithsonian pipeline complete* — `{result[5:]}`\nReady for post-indexer.")
 
 
 def pipeline_checkpoint():

--- a/ingest_python_scripts/smithsonian/launch_smithsonian.py
+++ b/ingest_python_scripts/smithsonian/launch_smithsonian.py
@@ -116,7 +116,19 @@ def ssm_run(shell_cmd, timeout_seconds=30, poll_seconds=4):
         "--output", "text",
     ])
     if status != "Success":
-        raise RuntimeError(f"SSM ended with status {status}.\nOutput:\n{output}")
+        try:
+            stderr = _aws([
+                "ssm", "get-command-invocation",
+                "--command-id", cmd_id,
+                "--instance-id", INSTANCE_ID,
+                "--query", "StandardErrorContent",
+                "--output", "text",
+            ])
+        except Exception:
+            stderr = "(could not fetch stderr)"
+        raise RuntimeError(
+            f"SSM ended with status {status}.\nStdout:\n{output}\nStderr:\n{stderr}"
+        )
     return output
 
 
@@ -212,7 +224,7 @@ def run_download(date):
     info(f"Syncing s3://{S3_DELIVERY_BUCKET}/{date}/ → {dest}/")
     info(f"(timeout {DOWNLOAD_TIMEOUT_S // 60} min)")
     ssm_run(
-        f"aws s3 sync s3://{S3_DELIVERY_BUCKET}/{date}/ {dest}/ --profile {AWS_PROFILE}",
+        f"aws s3 sync s3://{S3_DELIVERY_BUCKET}/{date}/ {dest}/",
         timeout_seconds=DOWNLOAD_TIMEOUT_S, poll_seconds=15,
     )
     count_str = ssm_run(

--- a/ingest_python_scripts/smithsonian/launch_smithsonian.py
+++ b/ingest_python_scripts/smithsonian/launch_smithsonian.py
@@ -250,7 +250,7 @@ def run_preprocess(date):
 
     info("Running fix-si.sh inline (this takes ~10–15 min) …")
     ssm_run(
-        f"cd {INGEST_DIR} && ./scripts/harvest/fix-si.sh {dest}",
+        f"bash {INGEST_DIR}/scripts/harvest/fix-si.sh {dest}",
         timeout_seconds=PREPROCESS_TIMEOUT_S, poll_seconds=15,
     )
     count = ssm_run(
@@ -301,7 +301,7 @@ def run_harvest(date):
     info(f"Log: {HARVEST_LOG}")
     info(f"Polling every {POLL_INTERVAL_S}s. Typically 3–4 hours.\n")
 
-    ssm_bg(f"cd {INGEST_DIR} && ./scripts/harvest.sh smithsonian > {HARVEST_LOG} 2>&1")
+    ssm_bg(f"bash {INGEST_DIR}/scripts/harvest.sh smithsonian > {HARVEST_LOG} 2>&1")
 
     def check_fn():
         out = ssm_run(
@@ -373,7 +373,7 @@ def run_mapping(date):
     info("Typically ~35–40 min for 7.8M records.\n")
 
     ssm_run(
-        f"cd {INGEST_DIR} && ./scripts/ingest.sh smithsonian --mapping-only > {PIPELINE_LOG} 2>&1",
+        f"bash {INGEST_DIR}/scripts/ingest.sh smithsonian --mapping-only > {PIPELINE_LOG} 2>&1",
         timeout_seconds=MAPPING_TIMEOUT_S, poll_seconds=30,
     )
 
@@ -415,8 +415,7 @@ def run_pipeline(date):
     info(f"Polling every {POLL_INTERVAL_S}s. Typically 1–2 hours.\n")
 
     ssm_bg(
-        f"cd {INGEST_DIR} && "
-        f"./scripts/ingest.sh smithsonian --resume-from enrichment > {PIPELINE_LOG} 2>&1"
+        f"bash {INGEST_DIR}/scripts/ingest.sh smithsonian --resume-from enrichment > {PIPELINE_LOG} 2>&1"
     )
 
     orig = f"{DATA_ROOT}/originalRecords/{date}"

--- a/ingest_python_scripts/smithsonian/launch_smithsonian.py
+++ b/ingest_python_scripts/smithsonian/launch_smithsonian.py
@@ -124,7 +124,7 @@ def ssm_run(shell_cmd, timeout_seconds=30, poll_seconds=4):
                 "--query", "StandardErrorContent",
                 "--output", "text",
             ])
-        except Exception:
+        except RuntimeError:
             stderr = "(could not fetch stderr)"
         raise RuntimeError(
             f"SSM ended with status {status}.\nStdout:\n{output}\nStderr:\n{stderr}"

--- a/ingest_python_scripts/smithsonian/launch_smithsonian.py
+++ b/ingest_python_scripts/smithsonian/launch_smithsonian.py
@@ -325,11 +325,11 @@ def run_harvest(date):
             f'if [ -n "$LATEST" ] && [ -f "$LATEST/_SUCCESS" ] && [ "$LATEST" -nt "$ORIG" ]; then echo "done:$LATEST"\n'
             f'elif [ -z "$RUNNING" ] && [ -n "$LATEST" ]; then echo "failed:$LATEST"\n'
             f'else echo "running"; fi',
-            timeout_seconds=60,
+            timeout_seconds=90,
         ).strip()
         return out if out.startswith("done:") or out.startswith("failed:") else None
 
-    result = poll_until_done(check_fn, lambda: ssm_run(f'tail -2 {HARVEST_LOG} 2>/dev/null || true', timeout_seconds=60))
+    result = poll_until_done(check_fn, lambda: ssm_run(f'tail -2 {HARVEST_LOG} 2>/dev/null || true', timeout_seconds=90))
     if result.startswith("failed:"):
         slack_notify(f":x: *Smithsonian harvest FAILED* — `{result[7:]}`\nCheck `{HARVEST_LOG}`")
         err(f"Harvest exited without _SUCCESS at: {result[7:]}")
@@ -450,11 +450,11 @@ def run_pipeline(date):
             f'&& [ -f "$LATEST/_SUCCESS" ] && [ "$LATEST" -nt "$MLAT" ]; then echo "done:$LATEST"\n'
             f'elif [ -z "$RUNNING" ]; then echo "failed"\n'
             f'else echo "running"; fi',
-            timeout_seconds=60,
+            timeout_seconds=90,
         ).strip()
         return out if out.startswith("done:") or out == "failed" else None
 
-    result = poll_until_done(check_fn, lambda: ssm_run(f'tail -2 {PIPELINE_LOG} 2>/dev/null || true', timeout_seconds=60))
+    result = poll_until_done(check_fn, lambda: ssm_run(f'tail -2 {PIPELINE_LOG} 2>/dev/null || true', timeout_seconds=90))
     if result == "failed":
         slack_notify(f":x: *Smithsonian pipeline FAILED* — no jsonl `_SUCCESS`\nCheck `{PIPELINE_LOG}`")
         err("Pipeline exited without jsonl/_SUCCESS.")

--- a/ingest_python_scripts/virginias/virginias_download.py
+++ b/ingest_python_scripts/virginias/virginias_download.py
@@ -112,10 +112,21 @@ def clone_repos():
     # (VaFileHarvester expects .zip files in the endpoint directory, not subdirs).
     zip_cmds = (
         f"cd {DEST} && "
+        f"failed=() && "
         f"for repo in {repos_list}; do "
-        f"  [ -d \"$repo\" ] && find \"$repo\" -name '*.xml' | zip \"${{repo}}.zip\" -@ "
-        f"  && echo \"zipped $repo\" && rm -rf \"$repo\" || true; "
-        f"done"
+        f"  if [ -d \"$repo\" ]; then "
+        f"    if find \"$repo\" -name '*.xml' | zip \"${{repo}}.zip\" -@; then "
+        f"      echo \"zipped $repo\" && rm -rf \"$repo\"; "
+        f"    else "
+        f"      echo \"ERROR: failed to zip $repo\" >&2 && failed+=(\"$repo\"); "
+        f"    fi; "
+        f"  else "
+        f"    echo \"ERROR: missing repo dir: $repo\" >&2 && failed+=(\"$repo\"); "
+        f"  fi; "
+        f"done && "
+        f"if [ ${{#failed[@]}} -gt 0 ]; then "
+        f"  echo \"Zipping failed for: ${{failed[*]}}\" >&2 && exit 1; "
+        f"fi"
     )
     shell_cmd = f"rm -rf {DEST} && mkdir -p {DEST} && {clone_cmds} && {zip_cmds} && echo DONE && ls -lh {DEST}/*.zip"
 

--- a/ingest_python_scripts/virginias/virginias_download.py
+++ b/ingest_python_scripts/virginias/virginias_download.py
@@ -107,9 +107,19 @@ def clone_repos():
         f"git clone --depth 1 --branch {branch} https://github.com/dplava/{repo}.git {DEST}/{repo} 2>&1"
         for repo, branch in REPOS
     )
-    shell_cmd = f"mkdir -p {DEST} && {clone_cmds} && echo DONE && ls {DEST}/"
+    repos_list = " ".join(repo for repo, _ in REPOS)
+    # After cloning, zip each repo's XML files into a single zip per institution
+    # (VaFileHarvester expects .zip files in the endpoint directory, not subdirs).
+    zip_cmds = (
+        f"cd {DEST} && "
+        f"for repo in {repos_list}; do "
+        f"  [ -d \"$repo\" ] && find \"$repo\" -name '*.xml' | zip \"${{repo}}.zip\" -@ "
+        f"  && echo \"zipped $repo\" && rm -rf \"$repo\" || true; "
+        f"done"
+    )
+    shell_cmd = f"rm -rf {DEST} && mkdir -p {DEST} && {clone_cmds} && {zip_cmds} && echo DONE && ls -lh {DEST}/*.zip"
 
-    print(f"\nCloning {len(REPOS)} dplava repos to EC2:{DEST} ...")
+    print(f"\nCloning {len(REPOS)} dplava repos to EC2:{DEST} and zipping XML files ...")
     out, err = ssm_run(shell_cmd, poll_seconds=600)
     if out:
         print(out)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR improves ingestion utilities by expanding/fixing Python-based date handling and OAI harvest log/progress parsing, refining ingest preflight labeling, adding richer per-stage timing/runtime reporting for community-webs and NARA, and significantly improving Smithsonian ingest launch/status reliability and notifications.

### ingest_python_scripts/check_ingest.py
- Adds `I3_HOME` and `OAI_LOGS` constants and supports additional OAI log sources by locating/tailing the newest `oai-harvest-{hub}-*.log` under the derived `OAI_LOGS` directory (emitting an `OAI_HARVEST_LOG` section).
- Refactors “first-seen” stage boundary detection in the generated bash/SSM payload from combined keyword/regex logic to four explicit sequential `grep -m1` calls and updates stage separators so Python can split logs into per-stage timestamp chunks.
- Extends `extract_log_timestamp()` to recognize ISO timestamps (`yyyy-mm-ddTHH:MM:SS`) in addition to prior `HH:MM:SS`.
- Expands `parse_oai_progress_from_line()` to also parse `(current, total)` from structured `cursor=...` / `total=...` fields emitted by `OaiHarvestLogger` (in addition to Spark-style progress encodings).
- Adds `get_progress_lines(sections)` to prefer Spark `PROGRESS_LINES` but fall back to `OAI_HARVEST_LOG` when Spark-derived progress lines are empty; used by both `render()` and `derive_summary()`.
- Improves stage “running for” duration computation by using an `ec2_now` timestamp emitted by the bash payload (fallback to log mtime).
- **Lines changed:** +71 / -26  
- **Code review effort:** High

### ingest_python_scripts/launch_ingest.py
- Adds `_sortable_date(entry)` to normalize delivery entry names into sortable `YYYYMMDD`, supporting `YYYY-MM-DD`, `YYYYMMDD`, and `MMDDYYYY` formats (fallbacks when unrecognized).
- Updates `list_deliveries(bucket)` to more precisely filter “dated” entries and sort newest-first via `_sortable_date` instead of reverse lexicographic sorting.
- Updates the file-hub preflight prompt label from “endpoint” to “delivery path” while keeping the logic that suggests the newest delivery path as the proposed `hub.harvest.endpoint`.
- **Lines changed:** +27 / -4  
- **Code review effort:** Medium

### ingest_python_scripts/hub_preflight.py
- Adjusts preflight output wording so file-type harvests show “Delivery path:” / “Delivery path check” instead of “Endpoint:” / “Endpoint reachability”, and updates the section header selection based on `harvest_type == "file"`.
- **Lines changed:** +11 / -10  
- **Code review effort:** Low

### ingest_python_scripts/community-webs/check_cw.py
- Adds end-to-end stage “first started” tracking from ingest logs and computes per-stage runtime using stage-first timestamps, including midnight rollover handling.
- **Adds:** `parse_first_stage_timestamps`, `hms_to_seconds`, `fmt_duration`, `stage_runtime_seconds`
- **Lines changed:** +74 / -3  
- **Code review effort:** Medium

### ingest_python_scripts/nara/check_nara.py
- Captures more detailed stage “first seen” timestamps for runtime computation.
- Replaces prior “latest merged harvest” logic with a `STAGES_DONE` section based on recent `_SUCCESS` markers (and `_MANIFEST`-derived record counts when available).
- Extends rendering to show completed stages (this run) and “running for …” duration for inferred current stage.
- **Lines changed:** +119 / -3  
- **Code review effort:** High

### ingest_python_scripts/smithsonian/launch_smithsonian.py
- Improves SSM failure reporting by attempting to include remote `StandardErrorContent` in raised errors.
- Improves reliability of background launches by validating SSM output contains `"launched"` (timeout-based).
- Adds `slack_notify(msg)` helper (posts via `scripts/common.sh`, suppressing Slack failures) and sends Slack notifications for harvest/pipeline start, failure, and completion.
- Stage execution adjustments:
  - Stage 1 `aws s3 sync` removes explicit `--profile {AWS_PROFILE}`.
  - Updates script invocations to use absolute `bash {INGEST_DIR}/...` paths.
  - Adjusts stage 2 `fix-si.sh` argument from `{dest}` to `{date}`.
  - Updates stage 3/4/5 harvest + mapping + pipeline background launches to redirect logs to `{HARVEST_LOG}` / `{PIPELINE_LOG}` and uses `ssm_run(..., timeout_seconds=90)` for polling/diagnostics (with Slack failure/completion notifications).
- **Adds:** `slack_notify(msg)`  
- **Lines changed:** +45 / -12  
- **Code review effort:** High

### ingest_python_scripts/smithsonian/check_status_smithsonian.py
- Refactors the checker to focus on live process detection + log/timestamp inference instead of the prior delivery-date-driven workflow analysis.
- Adds `--watch` refresh loop (default 30s) and removes `--date` / delivery auto-detection behavior.
- Simplifies output into: PROCESS, COMPLETED STAGES (this run), CURRENT STAGE, and a condensed SUMMARY.
- **Large change:** removes multiple prior analysis/suggestion helpers; updates `build_status_script` / `render` / `derive_summary` signatures and behavior.
- **Lines changed:** +317 / -460  
- **Code review effort:** High

## Infrastructure & Configuration Impact
- Requires a manual pipeline trigger or ECS redeployment: **No** (changes are limited to the updated ingestion/checker/launcher scripts; take effect via normal code deployment).
- Adds, removes, or renames environment variables or AWS Secrets Manager keys: **No**.
- Database migrations: **No**.
- Changes shared infrastructure configuration (CodePipeline, CodeBuild, ECS task definitions, IAM policies): **No**.
- Modifies any public-facing API response shape or adds/removes endpoints: **No**.
- Security implications:
  - **Yes, minor/targeted:** Smithsonian stage 1 removes `--profile {AWS_PROFILE}` from a single `aws s3 sync` command, which may cause that call to use the AWS CLI default credential/provider chain instead of the explicitly selected profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->