### PR TITLE
Wikidata QID updates for institutions_v2.json

### DIFF
--- a/src/main/resources/wiki/institutions_v2.json
+++ b/src/main/resources/wiki/institutions_v2.json
@@ -6523,7 +6523,7 @@
         "upload": false
       },
       "Columbia County Library (Evans, Ga.)": {
-        "Wikidata": "Q77062489",
+        "Wikidata": "Q78362427",
         "upload": true
       },
       "Columbia County Library System": {
@@ -23509,7 +23509,7 @@
         "upload": true
       },
       "Indiana University Health": {
-        "Wikidata": "",
+        "Wikidata": "Q6023587",
         "upload": false
       },
       "Indiana University Indianapolis (Campus). University Library Special Collections and Archives": {
@@ -23949,7 +23949,7 @@
         "upload": false
       },
       "Parke County Indiana": {
-        "Wikidata": "",
+        "Wikidata": "Q506538",
         "upload": false
       },
       "Parke County Public LIbrary": {
@@ -23969,7 +23969,7 @@
         "upload": false
       },
       "Parke County, Indiana": {
-        "Wikidata": "",
+        "Wikidata": "Q506538",
         "upload": false
       },
       "ParkeCounty Public Library": {
@@ -24217,7 +24217,7 @@
         "upload": false
       },
       "Vigo County Historical Society": {
-        "Wikidata": "",
+        "Wikidata": "Q30289570",
         "upload": false
       },
       "Vigo County Public Library": {
@@ -35603,7 +35603,7 @@
         "upload": false
       },
       "City of Lewisville": {
-        "Wikidata": "",
+        "Wikidata": "Q26495",
         "upload": false
       },
       "City of Quanah": {
@@ -35767,7 +35767,7 @@
         "upload": false
       },
       "Del Mar College": {
-        "Wikidata": "",
+        "Wikidata": "Q5252909",
         "upload": false
       },
       "Delta County Public Library": {
@@ -35863,7 +35863,7 @@
         "upload": false
       },
       "Eula Hunt Beck Florence Public Library": {
-        "Wikidata": "",
+        "Wikidata": "Q69491449",
         "upload": false
       },
       "Euless Public Library": {
@@ -36123,7 +36123,7 @@
         "upload": false
       },
       "Herman Brown Free Library": {
-        "Wikidata": "",
+        "Wikidata": "Q69970543",
         "upload": false
       },
       "Hidalgo County Historical Commission": {
@@ -36227,7 +36227,7 @@
         "upload": false
       },
       "Kaufman County Library": {
-        "Wikidata": "",
+        "Wikidata": "Q69491659",
         "upload": false
       },
       "Kemah Historical Society": {
@@ -36235,7 +36235,7 @@
         "upload": false
       },
       "Kennedale Public Library": {
-        "Wikidata": "",
+        "Wikidata": "Q69492642",
         "upload": false
       },
       "Kerens Public Library": {
@@ -36431,7 +36431,7 @@
         "upload": false
       },
       "Mineola Historical Museum": {
-        "Wikidata": "",
+        "Wikidata": "Q107321464",
         "upload": false
       },
       "Mineola Landmark Commission": {
@@ -36499,7 +36499,7 @@
         "upload": false
       },
       "National Juneteenth Museum": {
-        "Wikidata": "",
+        "Wikidata": "Q113641448",
         "upload": false
       },
       "National Museum of the Pacific War/Admiral Nimitz Foundation": {
@@ -36623,7 +36623,7 @@
         "upload": false
       },
       "Pilot Point Community Library": {
-        "Wikidata": "",
+        "Wikidata": "Q69491925",
         "upload": false
       },
       "Pioneer City County Museum": {
@@ -36955,7 +36955,7 @@
         "upload": false
       },
       "Sam Bell Maxey House State Historic Site": {
-        "Wikidata": "",
+        "Wikidata": "Q7407171",
         "upload": false
       },
       "Sam Houston High School": {
@@ -37011,7 +37011,7 @@
         "upload": false
       },
       "Scottish Rite Hospital for Children": {
-        "Wikidata": "",
+        "Wikidata": "Q7707955",
         "upload": false
       },
       "Shamrock Public Library": {
@@ -37047,7 +37047,7 @@
         "upload": false
       },
       "Smith County Historical Society": {
-        "Wikidata": "",
+        "Wikidata": "Q135239934",
         "upload": false
       },
       "Smith Public Library": {
@@ -37363,7 +37363,7 @@
         "upload": false
       },
       "Tom Lea Institute": {
-        "Wikidata": "",
+        "Wikidata": "Q30258304",
         "upload": false
       },
       "Tomball Museum Center": {
@@ -37555,7 +37555,7 @@
         "upload": false
       },
       "White Settlement Public Library": {
-        "Wikidata": "",
+        "Wikidata": "Q69492204",
         "upload": false
       },
       "Whitewright Public Library": {


### PR DESCRIPTION
Populates missing `Wikidata` QIDs in `institutions_v2.json` and corrects one wrong Georgia QID. Scope is **only** `Wikidata` field values — no `upload` flags, institution names, or structure changed.

### Georgia QID correction
- **Columbia County Library (Evans, Ga.)**: `Q77062489` → **`Q78362427`**.
  - `Q77062489` is *Columbus Public Library (Columbus, Ga.)* — a different institution two entries below that correctly keeps it.
  - `Q78362427` is the Evans, GA library ("public library in Evans, Georgia, USA", located in Columbia County `Q2437337`), confirmed via Wikidata lookup.
  - This bites Wikimedia maintain runs, where a bare QID resolves to an institution: `maintain Q77062489` would otherwise pull in both libraries.

### Other changes
- Fills previously-empty `Wikidata` fields for institutions under Indiana Memory and The Portal to Texas History.

19 `Wikidata` fields changed in total. JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updated `src/main/resources/wiki/institutions_v2.json` with Wikidata QID corrections and additions. A total of 19 `Wikidata` field values were changed across the file.

**Changes:**
- Corrected one QID: Columbia County Library (Evans, Georgia) QID changed from `Q77062489` to `Q78362427` to properly reference the Evans location rather than Columbus Public Library
- Added 19 previously missing Wikidata identifiers for institutions under Indiana Memory and The Portal to Texas History collections
- JSON file validated

**Impact:**
No deployment, redeployment, or infrastructure changes required. The `institutions_v2.json` file is loaded dynamically at runtime via HTTP request from the GitHub main branch by the `InstitutionsLoader` component, which is used by `WikiMapper` to determine Wikimedia upload eligibility. Changes take effect immediately on the next execution without additional build or deployment steps.

No environment variables, secrets, database migrations, API changes, or security implications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->