### PR TITLE
Edits to hathi mapping pt 3

### DIFF
--- a/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
@@ -234,15 +234,23 @@ class HathiMapping extends MarcXmlMapping {
       .map(URI(_))
 
     if (from974.nonEmpty) from974
-    else
+    else {
       // OAI harvest: derive from <setSpec> e.g. "hathitrust:pdus" → "pdus"
-      (data \\ "setSpec")
+      // Prefer "pd" (CC PDM, globally public domain) over "pdus" (NoC-US, US-only)
+      // when both are present, as pd is the stronger statement.
+      val edmRightsPreferenceOrder = Seq("pd", "pdus", "cc-zero", "cc-by", "cc-by-sa",
+        "cc-by-nd", "cc-by-nc", "cc-by-nc-sa", "cc-by-nc-nd", "ic-world", "und-world")
+      val codes = (data \\ "setSpec")
         .map(_.text.trim)
         .filter(s => s.startsWith("hathitrust:") && s != "hathitrust")
         .map(_.split(":").last)
+        .toSet
+      edmRightsPreferenceOrder
+        .filter(codes.contains)
         .flatMap(key => Try { edmRightsMapping(key) }.toOption)
         .map(URI(_))
         .slice(0, 1)
+    }
   }
 
   override def subject(data: Document[NodeSeq]): ZeroToMany[SkosConcept] =
@@ -531,7 +539,7 @@ class HathiMapping extends MarcXmlMapping {
   // Standardized rights URIs for edmRights field
   // pd / pdus are the only codes present in current OAI harvests
   private val edmRightsMapping: Map[String, String] = Map(
-    "pd"           -> "https://creativecommons.org/publicdomain/mark/1.0/",
+    "pd"           -> "http://creativecommons.org/publicdomain/mark/1.0/",
     "pdus"         -> "http://rightsstatements.org/vocab/NoC-US/1.0/",
     "cc-by"        -> "https://creativecommons.org/licenses/by/4.0/",
     "cc-by-nd"     -> "https://creativecommons.org/licenses/by-nd/4.0/",

--- a/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
@@ -239,7 +239,7 @@ class HathiMapping extends MarcXmlMapping {
       // Prefer "pd" (CC PDM, globally public domain) over "pdus" (NoC-US, US-only)
       // when both are present, as pd is the stronger statement.
       val edmRightsPreferenceOrder = Seq("pd", "pdus", "cc-zero", "cc-by", "cc-by-sa",
-        "cc-by-nd", "cc-by-nc", "cc-by-nc-sa", "cc-by-nc-nd", "ic-world", "und-world")
+        "cc-by-nd", "cc-by-nc", "cc-by-nc-sa", "cc-by-nc-nd")
       val codes = (data \\ "setSpec")
         .map(_.text.trim)
         .filter(s => s.startsWith("hathitrust:") && s != "hathitrust")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated Hathi rights fallback mapping to prefer standardized OAI `setSpec` codes by explicit priority instead of first-match behavior, ensuring codes like `pd` win over less specific alternatives such as `pdus`. Also changed the `pd` rights URI from `https://creativecommons.org/...` to `http://creativecommons.org/...`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->