### PR TITLE
NARA Fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ resolvers += "SparkPackages" at "https://repos.spark-packages.org/"
 // to change IngestRemap/NaraMergeUtil heap, change -Xmx here, not in the shell script)
 Compile / run / javaOptions ++= Seq(
   "-Xms4g",
-  "-Xmx14g",
+  "-Xmx22g",
   "-XX:+UseG1GC",
   "-XX:MaxGCPauseMillis=200",
   "-Dspark.sql.parquet.enableVectorizedReader=false",

--- a/src/main/scala/dpla/ingestion3/harvesters/file/NaraDeltaHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/file/NaraDeltaHarvester.scala
@@ -13,7 +13,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.logging.log4j.{LogManager, Logger}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
-import java.io.{File, FileFilter}
+import java.io.{ByteArrayInputStream, File, FileFilter}
 import scala.util.{Failure, Success, Try, Using}
 import scala.xml._
 
@@ -82,8 +82,11 @@ class NaraDeltaHarvester(
 
       case Some(data) =>
         Try {
-          val dataString = new String(data).replaceAll("<\\?xml.*\\?>", "").trim
-          val xml = XML.loadString(dataString)
+          // Use ByteArrayInputStream to avoid allocating a full UTF-16 String copy
+          // of the raw bytes before XML parsing (avoids doubling memory usage for
+          // large NARA XML files). The XML parser handles the <?xml?> declaration
+          // natively when reading from a stream.
+          val xml = XML.load(new ByteArrayInputStream(data))
 
           val items = handleXML(xml)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated NARA delta harvesting to parse XML directly from the extracted byte stream instead of converting to a UTF-16 string and stripping the XML declaration first. Also increased the forked `Compile / run` JVM heap limit in `build.sbt` from `-Xmx14g` to `-Xmx22g` to support the updated processing path.

No database migration, API shape change, environment variable/secrets change, or shared infrastructure config change is included. No manual pipeline trigger or ECS redeployment is indicated by this PR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->