### PR TITLE
Edits to hathi enrichment dataProviderURI

### DIFF
--- a/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
+++ b/src/main/scala/dpla/ingestion3/enrichments/EnrichmentDriver.scala
@@ -26,18 +26,16 @@ class EnrichmentDriver extends Serializable {
     * @return
     */
   private def createDataProviderUri(name: ZeroToOne[String]): ZeroToOne[URI] =
-    name match {
-      case Some(dataProvider) =>
-        val providerLabel = dataProvider.toLowerCase // lowercase
-          .trim // remove leading and trailing whitespace
-          .replaceAll("( )+", "-") // replace 1-n whitespace with single -
-          .replaceAll("[^a-z0-9s-]", "") // remove non-alphanumeric chars
-        Some(URI(s"$dplaContributorUri$providerLabel"))
-      case None =>
-        throw new RuntimeException(
-          "Missing required field Data Provider name when minting URI"
-        )
+    name.map { dataProvider =>
+      val providerLabel = dataProvider.toLowerCase // lowercase
+        .trim // remove leading and trailing whitespace
+        .replaceAll("( )+", "-") // replace 1-n whitespace with single -
+        .replaceAll("[^a-z0-9s-]", "") // remove non-alphanumeric chars
+      URI(s"$dplaContributorUri$providerLabel")
     }
+    // Returns None (instead of throwing) when name is None.
+    // Records with no recognized dataProvider code will have no dataProvider URI
+    // rather than being silently dropped during enrichment.
 
   private def enrichDataProvider(record: OreAggregation): EdmAgent = {
     val enrichedWithWikiEntity: EdmAgent = wikiEntityEnrichment.enrichEntity(
@@ -60,7 +58,7 @@ class EnrichmentDriver extends Serializable {
 
     val enriched = record.deDuplicate.standardStringEnrichments
 
-    enriched.copy(
+    val result = enriched.copy(
       provider = wikiEntityEnrichment.enrichEntity(enriched.provider),
       dataProvider = enrichDataProvider(enriched),
       sourceResource = enriched.sourceResource.copy(
@@ -74,6 +72,16 @@ class EnrichmentDriver extends Serializable {
           enriched.sourceResource.`type`.flatMap(typeEnrichment.enrich).distinct
       )
     )
+
+    // Drop records with no resolved dataProvider URI — unrecognized institution
+    // codes produce no name, which produces no URI. require() throws inside Try,
+    // so EnrichExecutor's flatMap(_.toOption) silently discards these records.
+    require(
+      result.dataProvider.uri.isDefined,
+      s"No dataProvider URI for record: dataProvider.name=${result.dataProvider.name.getOrElse("unknown")}"
+    )
+
+    result
   }
 
 }

--- a/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
@@ -333,9 +333,11 @@ class HathiMapping extends MarcXmlMapping {
               .replaceAll("imp$", "")        // strip Michigan imposter suffix: "nypimp" → "nyp"
               .replaceAll("ocm$", "")        // strip OCM OCLC prefix suffix: "uiucocm" → "uiuc"
               .replaceAll("ocn$", "")        // strip OCN OCLC prefix suffix: "tamocn" → "tam"
-              .replaceAll("b$", "")          // strip trailing 'b' (NRLF-style barcode prefix)
               .stripSuffix("-")
+            // Try base before stripping trailing 'b', so codes like "ucb" match correctly.
+            // Only fall through to b-strip for NRLF-style codes (e.g. "nrlfb..." → "nrlf").
             Try { dataProviderMapping(base) }.toOption
+              .orElse(Try { dataProviderMapping(base.replaceAll("b$", "")) }.toOption)
           }
         }
         .map(nameOnlyAgent)

--- a/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
+++ b/src/main/scala/dpla/ingestion3/mappers/providers/HathiMapping.scala
@@ -318,15 +318,23 @@ class HathiMapping extends MarcXmlMapping {
       // OAI harvest: 035 field contains "sdr-{code}.{barcode}" e.g. "sdr-miu.990000000400106381"
       // Some records omit the dot and embed the barcode directly, e.g. "sdr-miu000000075"
       // or include uppercase barcodes, e.g. "sdr-nrlfGLAD50600249-B".
+      // Some NRLF records use a lowercase 'b' barcode prefix, e.g. "sdr-nrlfb168192287".
       // Strategy: try exact code first; if no match, strip trailing barcode noise
-      // (first digit or uppercase letter onward, then any trailing dash).
+      // (first digit or uppercase letter onward, then any trailing dash, then trailing 'b').
       marcFields(data, Seq("035"), Seq("a"))
         .flatMap(extractStrings)
         .find(_.startsWith("sdr-"))
         .flatMap { sdr =>
           val raw = sdr.stripPrefix("sdr-").split("\\.").head
           Try { dataProviderMapping(raw) }.toOption.orElse {
-            val base = raw.replaceAll("[A-Z0-9].*$", "").stripSuffix("-")
+            val base = raw
+              .replaceAll("[A-Z0-9].*$", "") // strip from first uppercase letter or digit
+              .replaceAll("[(]$", "")        // strip dangling ( from OCoLC-style barcodes: "osu(" → "osu"
+              .replaceAll("imp$", "")        // strip Michigan imposter suffix: "nypimp" → "nyp"
+              .replaceAll("ocm$", "")        // strip OCM OCLC prefix suffix: "uiucocm" → "uiuc"
+              .replaceAll("ocn$", "")        // strip OCN OCLC prefix suffix: "tamocn" → "tam"
+              .replaceAll("b$", "")          // strip trailing 'b' (NRLF-style barcode prefix)
+              .stripSuffix("-")
             Try { dataProviderMapping(base) }.toOption
           }
         }
@@ -466,7 +474,7 @@ class HathiMapping extends MarcXmlMapping {
     "ia-duke" -> "Duke University",
     "ia-loc" -> "Library of Congress",
     "ia-ncsu" -> "North Carolina State University",
-    "ia-tu" -> "Tulane University",
+    "ia-tu" -> "Tufts University",
     "ien" -> "Northwestern University",
     "inu" -> "Indiana University",
     "loc" -> "Library of Congress",
@@ -519,7 +527,47 @@ class HathiMapping extends MarcXmlMapping {
     "usu" -> "Utah State University Press",
     "uva" -> "University of Virginia",
     "wu" -> "University of Wisconsin",
-    "yale" -> "Yale University"
+    "yale" -> "Yale University",
+    // Partners added/corrected using cdlib/hathitrust-contrib-configs as source of truth
+    "cul"      -> "Columbia University Libraries",
+    "dcu"      -> "Catholic University",
+    "emu"      -> "Emory University",
+    "fmu"      -> "University of Miami",
+    "ia-aeu"   -> "University of Alberta",
+    "ia-cmalg" -> "Getty Research Institute",
+    "ia-mwica" -> "Clark Art Institute",
+    "ia-nrlf"  -> "Northern Regional Library Facility",
+    "ia-qmm"   -> "McGill University",
+    "ia-ucw"   -> "University of Connecticut",
+    "ia-uma"   -> "University of Massachusetts",
+    "innd"     -> "University of Notre Dame",
+    "keio"     -> "Keio University",
+    "lebau"    -> "American University of Beirut",
+    "mdu-loc"  -> "University of Maryland, College Park",
+    "mou-loc"  -> "University of Missouri - Columbia",
+    "nbuu"     -> "University at Buffalo",
+    "nnu"      -> "New York University",
+    "oclw"     -> "Case Western Reserve",
+    "ohm"      -> "McMaster University",
+    "oks"      -> "Oklahoma State University",
+    "oktu"     -> "University of Tulsa",
+    "ppt"      -> "Temple University",
+    "pu"       -> "University of Pennsylvania",
+    "scu"      -> "University of South Carolina",
+    "tam"      -> "Texas A&M",
+    "tama"     -> "Texas A&M",
+    "txsu"     -> "Texas State University",
+    "ucb"      -> "University of California",
+    "ucsf"     -> "University of California San Francisco",
+    "udel"     -> "University of Delaware",
+    "ukloku"   -> "Knowledge Unlatched",
+    "nbu"      -> "University of Nebraska-Lincoln",
+    "ncwsw"    -> "Wake Forest University",
+    "nncin"    -> "Columbia University",
+    "nwu-loc"  -> "Northwestern University",
+    "phc"      -> "Haverford College",
+    "uql"      -> "University of Queensland",
+    "wau"      -> "University of Washington"
   )
 
   private val rightsMapping: Map[String, String] = Map(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated Hathi enrichment/provider mapping behavior:

- Refactored `EnrichmentDriver` data-provider URI minting so `createDataProviderUri` no longer throws when the provider name is missing (it returns `None` via `name.map`); `enrich()` now enforces `require(result.dataProvider.uri.isDefined, ...)` inside the existing `Try`, so records without a resolvable data-provider URI fail at the record level during enrichment.
- Expanded `HathiMapping.dataProvider` fallback parsing from MARC `035$a` to handle additional `sdr-*` variants (missing dot, uppercase barcodes, NRLF lowercase `b` prefix) and normalize beyond the prior truncation (strip trailing barcode noise, dangling `(`, and suffixes like `imp`, `ocm`, `ocn`, plus trailing `-`/`b` normalization) before mapping to a partner code.
- Corrected the `ia-tu` provider name mapping from “Tulane University” to “Tufts University”.
- Added a broader set of institution code → name mappings for additional partner codes (including new/extra `ia-*` variants and `wau`).

No pipeline/infrastructure, environment variables/secrets, database migrations, public API changes, or security/credential-handling changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->