### PR TITLE
Fix GA4 query so item_data_providers.json populates; harden hub-stats outputs

### DIFF
--- a/ingest_python_scripts/post_indexer.py
+++ b/ingest_python_scripts/post_indexer.py
@@ -477,25 +477,34 @@ def run_hub_stats():
     except RuntimeError as e:
         warn(f"git fetch/reset failed (proceeding anyway):\n{e}")
 
-    info("Running generate_hub_stats.py on ingest EC2 (up to 3 min)...")
+    # GA4 paging plus per-id ES resolution runs several minutes; a
+    # first-run history backfill takes longer still. Full output goes to a
+    # log file on the EC2; only the tail is echoed because SSM keeps just
+    # the first 24k chars of output, which would hide errors printed last.
+    info("Running generate_hub_stats.py on ingest EC2 (up to 45 min)...")
     try:
         out = ssm_run(
             INGEST_INSTANCE_ID,
             (
                 "sudo -u ec2-user bash -lc '"
                 "cd /home/ec2-user/ingestion3 && "
-                "python3 scripts/generate_hub_stats.py"
-                "' 2>&1"
+                "python3 scripts/generate_hub_stats.py > /tmp/hub-stats.log 2>&1; "
+                "rc=$?; tail -c 20000 /tmp/hub-stats.log; exit $rc"
+                "'"
             ),
-            timeout_seconds=180,
-            poll_seconds=10,
+            timeout_seconds=2700,
+            poll_seconds=15,
         )
         print(out[-2000:] if len(out) > 2000 else out)
         ok("Hub stats complete.")
         slack_notify(":bar_chart: *hub stats generated* :white_check_mark:")
     except RuntimeError as e:
         bad(f"Hub stats failed:\n{e}")
-        slack_notify(":warning: *hub stats FAILED* — check ingest EC2")
+        slack_notify(
+            ":warning: *hub stats step failed* — hub_stats/bws may still have "
+            "uploaded; item_data_providers did not. See /tmp/hub-stats.log on "
+            "the ingest EC2."
+        )
 
 
 # ---------- Step 5: sitemaps ----------
@@ -560,10 +569,12 @@ def verify_outputs():
     if not check_s3_file_today("s3://sitemaps.dp.la/sitemap/_MANIFEST", "Sitemap _MANIFEST"):
         all_good = False
 
-    # Hub stats — check both files are from today
+    # Hub stats — check all three files are from today
     if not check_s3_file_today("s3://dashboard-analytics/hub-stats/hub_stats.json", "hub_stats.json"):
         all_good = False
     if not check_s3_file_today("s3://dashboard-analytics/hub-stats/hub_stats_bws.json", "hub_stats_bws.json"):
+        all_good = False
+    if not check_s3_file_today("s3://dashboard-analytics/hub-stats/item_data_providers.json", "item_data_providers.json"):
         all_good = False
 
     if all_good:

--- a/ingest_python_scripts/postchecks.py
+++ b/ingest_python_scripts/postchecks.py
@@ -316,6 +316,7 @@ def render(hub_results, today, check_dt, month_str, stale_days, check_api):
     for label, s3_path in [
         ("Hub stats",    f"s3://{S3_ANALYTICS}/hub-stats/hub_stats.json"),
         ("Hub stats bw", f"s3://{S3_ANALYTICS}/hub-stats/hub_stats_bws.json"),
+        ("Item mapping", f"s3://{S3_ANALYTICS}/hub-stats/item_data_providers.json"),
         ("Sitemaps",     f"s3://{S3_SITEMAPS}/sitemap/_MANIFEST"),
     ]:
         ls = s3_ls(s3_path)

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -8,7 +8,7 @@ Scripts are grouped by purpose. Run from repo root (e.g. `./scripts/ingest.sh ma
 
 | Folder | Purpose | Scripts |
 |--------|---------|---------|
-| **scripts/** (root) | Core pipeline, batch, S3, monitoring | `ingest.sh`, `harvest.sh`, `remap.sh`, `mapping.sh`, `enrich.sh`, `jsonl.sh`, `auto-ingest.sh`, `batch-ingest.sh`, `s3-sync.sh`, `common.sh`, `ingest-watchdog.sh` |
+| **scripts/** (root) | Core pipeline, batch, S3, monitoring | `ingest.sh`, `harvest.sh`, `remap.sh`, `mapping.sh`, `enrich.sh`, `jsonl.sh`, `auto-ingest.sh`, `batch-ingest.sh`, `s3-sync.sh`, `common.sh`, `ingest-watchdog.sh`, `generate_hub_stats.py`, `export_item_attribution.py` |
 | **scripts/communication/** | Schedule, email, Slack | `schedule.sh`, `send-ingest-email.sh`, `notify-harvest-failure.sh`, `send-harvest-failure-email.py` |
 | **scripts/delete/** | Record removal | `delete-by-id.sh`, `delete-from-jsonl.sh`, `delete-from-jsonl.py` |
 | **scripts/harvest/** | Harvest helpers, NARA, Community Webs, SI, VA | `nara-ingest.sh`, `community-webs-export.sh`, `community-webs-ingest.sh`, `community-webs-validate-jsonl.py`, `fix-si.sh`, `harvest-va.sh` |
@@ -38,6 +38,7 @@ Scripts are grouped by purpose. Run from repo root (e.g. `./scripts/ingest.sh ma
 | `delete/delete-by-id.sh` | Delete records from Elasticsearch | `./scripts/delete/delete-by-id.sh <id>...` |
 | `delete/delete-from-jsonl.sh` | Delete records from S3 JSONL files | `./scripts/delete/delete-from-jsonl.sh --hub <hub> <id>...` |
 | `communication/send-ingest-email.sh` | Send ingest summary email | `./scripts/communication/send-ingest-email.sh [--yes] <hub>` |
+| `generate_hub_stats.py` | Rebuild dashboard hub stats + GA4 item mapping in S3 | `./venv/bin/python scripts/generate_hub_stats.py` |
 | *scheduling_emails* (Python) | Monthly pre-scheduling email to hub contacts | `./venv/bin/python -m scheduler.orchestrator.scheduling_emails [--month=N] --dry-run \| --draft \| --send` |
 | `status/ingest-status.sh` | Check ingest status (orchestrator or manual runs) | `./scripts/status/ingest-status.sh` |
 | `communication/notify-harvest-failure.sh` | Send Slack and email (tech@dp.la) on harvest failure | `./scripts/communication/notify-harvest-failure.sh <hub> "<error>"` |
@@ -296,6 +297,21 @@ DRY_RUN=true ./scripts/delete/delete-from-jsonl.sh --hub cdl -f ids.txt
 ```
 
 > **Note**: For better performance, use `delete-from-jsonl.py` instead.
+
+### generate_hub_stats.py - Dashboard Hub Stats and Item Mapping
+
+Rebuilds the three dashboard-analytics inputs in `s3://dashboard-analytics/hub-stats/` after each monthly index rebuild:
+
+- `hub_stats.json` / `hub_stats_bws.json` — item and contributor counts per hub, from the live ES index
+- `item_data_providers.json` — cumulative GA4 item id → contributor name mapping
+
+```bash
+./venv/bin/python scripts/generate_hub_stats.py
+```
+
+Run on the ingest EC2 on day 5 of the month or later (GA4 settles the prior month for ~72 hours; the script warns on earlier runs). `post_indexer.py` step 4 runs it via SSM with system `python3`, so its dependencies (`boto3`, `google-analytics-data`) must be installed for that interpreter on the EC2. The two hub stats files upload first; if `item_data_providers.json` cannot be updated the script exits non-zero so post_indexer alerts.
+
+**Environment**: `ES_HOST`, `ES_PORT`, `AWS_PROFILE` (omit on EC2), `GA4_PROPERTY_ID` (required for the item mapping), `GA4_SECRET_NAME` (default `dpla/ga4-service-account`), `GA4_HISTORY_START` (default `2025-07-18`, the `event_label` custom dimension's registration date — GA4 returns nothing before it).
 
 ## Testing
 

--- a/scripts/communication/send-ingest-email.sh
+++ b/scripts/communication/send-ingest-email.sh
@@ -25,9 +25,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPTS_ROOT/common.sh"
 
-# Setup Java environment (4g for email)
-setup_java "4g" || die "Failed to setup Java environment"
-
 # Parse options
 SKIP_CONFIRM=false
 EMAIL_OVERRIDE=""
@@ -158,6 +155,8 @@ echo ""
 
 # Send email using the Scala Emailer
 echo "Sending email..."
+
+setup_java "4g" || die "Failed to setup Java environment"
 
 cd "$I3_HOME"
 

--- a/scripts/generate_hub_stats.py
+++ b/scripts/generate_hub_stats.py
@@ -234,6 +234,14 @@ def existing_hub_count() -> Optional[int]:
         return None
     except ValueError:
         return None
+    except Exception as e:
+        # Skip the floor check
+        print(
+            f"  WARNING: could not read existing {HUB_KEY} "
+            f"({e.__class__.__name__}); hub-count floor check skipped.",
+            flush=True,
+        )
+        return None
     if not isinstance(data, dict):
         return None
     return len(data.get("hubs") or {})

--- a/scripts/generate_hub_stats.py
+++ b/scripts/generate_hub_stats.py
@@ -18,9 +18,11 @@ Uses two passes per stats file: first a hub-level totals aggregation,
 then one per-hub query for contributor counts. A single nested aggregation
 across all hubs exceeds ES's search.max_buckets limit.
 
-Both hub stats files upload before the GA4 work starts. If
-item_data_providers.json cannot be updated, the script exits non-zero so
-post_indexer.py alerts, but the hub stats uploads stand.
+The hub stats files upload before the GA4 work starts. A BWS build
+failure skips only the BWS upload; a GA4 failure leaves
+item_data_providers.json untouched. Both exit non-zero so post_indexer.py
+alerts, and any uploads that already happened stand. A failure in the
+unfiltered build aborts everything.
 
 Usage:
     ./venv/bin/python scripts/generate_hub_stats.py
@@ -610,16 +612,27 @@ def main() -> None:
             flush=True,
         )
 
-    # Build both stats files, then upload both: a failure mid-build
-    # publishes nothing, and a GA4 failure later cannot block the stats
-    # uploads, which have already happened.
+    # Build the stats files before uploading anything: a failure in the
+    # unfiltered build publishes nothing, and a GA4 failure later cannot
+    # block the stats uploads, which have already happened.
     print("Generating hub stats from ES...", flush=True)
     hub_stats = build_stats(bws=False, generated_at=generated_at)
     hub_count = len(hub_stats["hubs"])
     print(f"  {hub_count} hubs", flush=True)
 
-    bws_stats = build_stats(bws=True, generated_at=generated_at)
-    print(f"  {len(bws_stats['hubs'])} hubs with BWS items", flush=True)
+    # A BWS-only failure must not block hub_stats.json. Skip the BWS
+    # upload so we never publish an empty file, then exit non-zero below.
+    try:
+        bws_stats = build_stats(bws=True, generated_at=generated_at)
+        print(f"  {len(bws_stats['hubs'])} hubs with BWS items", flush=True)
+    except Exception as e:
+        print(traceback.format_exc(), flush=True)
+        print(
+            f"  ERROR: BWS stats failed ({e.__class__.__name__}: {e}); "
+            "existing hub_stats_bws.json untouched.",
+            flush=True,
+        )
+        bws_stats = None
 
     # A partially loaded index passes per-query guards but would wipe most
     # hubs for 24h. Compare against the live file.
@@ -631,7 +644,8 @@ def main() -> None:
         )
 
     upload(hub_stats, HUB_KEY)
-    upload(bws_stats, BWS_KEY)
+    if bws_stats is not None:
+        upload(bws_stats, BWS_KEY)
 
     print("Generating item_data_providers.json...", flush=True)
     try:
@@ -645,22 +659,30 @@ def main() -> None:
         )
         idp = None
 
-    # Exit non-zero on IDP failure so post_indexer's SSM status check alerts;
-    # the hub stats uploads above have already happened either way.
-    if idp is None:
+    if idp is not None:
+        upload(idp, IDP_KEY, compact=True)
+
+    if bws_stats is not None and idp is not None:
         print(
-            f"Done with errors. {hub_count} hubs uploaded; "
-            f"item_data_providers.json not updated. generated_at={generated_at}",
+            f"Done. {hub_count} hubs, {len(idp['items']):,} item mappings, "
+            f"generated_at={generated_at}",
             flush=True,
         )
-        sys.exit(1)
+        return
 
-    upload(idp, IDP_KEY, compact=True)
+    # Exit non-zero on any partial failure so post_indexer's SSM status
+    # check alerts. The uploads above stand either way.
+    skipped = []
+    if bws_stats is None:
+        skipped.append("hub_stats_bws.json")
+    if idp is None:
+        skipped.append("item_data_providers.json")
     print(
-        f"Done. {hub_count} hubs, {len(idp['items']):,} item mappings, "
-        f"generated_at={generated_at}",
+        f"Done with errors. {hub_count} hubs uploaded; not updated: "
+        f"{', '.join(skipped)}. generated_at={generated_at}",
         flush=True,
     )
+    sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/generate_hub_stats.py
+++ b/scripts/generate_hub_stats.py
@@ -48,7 +48,7 @@ import time
 import traceback
 import urllib.error
 import urllib.request
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import boto3
@@ -75,6 +75,9 @@ EVENT_CATEGORY_PREFIXES = [
     "Click Through : ",
 ]
 
+# Known non-item categories; the drift check skips them.
+IGNORED_CATEGORY_PREFIXES = ("View API Item : ", "Browse")
+
 # DPLA item IDs are 32 hex chars. Filters out GA4's "(other)" bucket rows
 # and malformed labels.
 ITEM_ID_RE = re.compile(r"[0-9a-f]{32}")
@@ -95,7 +98,8 @@ def _es_search(url: str, payload: bytes, timeout: int, query: dict) -> dict:
 
 
 def es_query(query: dict, timeout: int = 30) -> dict:
-    """Search ES, retrying transient failures (network, 5xx, shard errors)."""
+    """Search ES, retrying transient failures (network, 5xx, shard errors,
+    garbled response body)."""
     url = f"http://{ES_HOST}:{ES_PORT}/dpla_alias/_search"
     payload = json.dumps(query).encode()
     for attempt in range(3):
@@ -105,7 +109,7 @@ def es_query(query: dict, timeout: int = 30) -> dict:
             if e.code < 500:
                 raise
             err: Exception = e
-        except (OSError, RuntimeError) as e:
+        except (OSError, RuntimeError, ValueError) as e:
             err = e
         wait = 2 * (2**attempt)
         print(
@@ -208,6 +212,31 @@ def upload(data: dict, key: str, compact: bool = False) -> None:
     print(f"  Uploaded s3://{BUCKET}/{key}", flush=True)
 
 
+def existing_hub_count() -> Optional[int]:
+    """Hub count in the live hub_stats.json, or None if absent or unreadable.
+
+    Never raises: a floor guard that cannot read the floor skips the check
+    rather than abort a run that already built good data.
+    """
+    try:
+        obj = aws_client("s3").get_object(Bucket=BUCKET, Key=HUB_KEY)
+        data = json.loads(obj["Body"].read())
+    except botocore.exceptions.ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code != "NoSuchKey":
+            print(
+                f"  WARNING: could not read existing {HUB_KEY} ({code}); "
+                "hub-count floor check skipped.",
+                flush=True,
+            )
+        return None
+    except ValueError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    return len(data.get("hubs") or {})
+
+
 # ---------------------------------------------------------------------------
 # item_data_providers.json
 # ---------------------------------------------------------------------------
@@ -234,6 +263,25 @@ def recent_months_range() -> tuple[str, str]:
     )
 
 
+def month_windows(start_date: str, end_date: str) -> list:
+    """Split [start_date, end_date] into calendar-month windows.
+
+    One report per month keeps cardinality low: less "(other)" collapse
+    and thresholding.
+    """
+    start = datetime.strptime(start_date, "%Y-%m-%d").date()
+    end = datetime.strptime(end_date, "%Y-%m-%d").date()
+    windows = []
+    cursor = start
+    while cursor <= end:
+        month_end = cursor.replace(
+            day=calendar.monthrange(cursor.year, cursor.month)[1]
+        )
+        windows.append((cursor.isoformat(), min(month_end, end).isoformat()))
+        cursor = month_end + timedelta(days=1)
+    return windows
+
+
 def fetch_ga4_credentials() -> dict:
     """Fetch GA4 service account JSON from AWS Secrets Manager."""
     secret = aws_client("secretsmanager").get_secret_value(SecretId=GA4_SECRET_NAME)
@@ -241,7 +289,9 @@ def fetch_ga4_credentials() -> dict:
     return json.loads(raw)
 
 
-def ga4_item_ids(credentials: dict, start_date: str, end_date: str) -> set:
+def ga4_item_ids(
+    credentials: dict, start_date: str, end_date: str, check_drift: bool = True
+) -> set:
     """Return the set of item IDs from all four event tables in
     [start_date, end_date].
 
@@ -312,6 +362,7 @@ def ga4_item_ids(credentials: dict, start_date: str, end_date: str) -> set:
     item_ids: set = set()
     dropped = 0
     thresholded = False
+    data_loss = False
     offset = 0
     page_size = 10000
 
@@ -337,12 +388,10 @@ def ga4_item_ids(credentials: dict, start_date: str, end_date: str) -> set:
             limit=page_size,
         )
         response = run_report_with_retry(request)
+        # Partial harvest beats none: the merge only adds, and the Rails
+        # side falls back to the DPLA API for any id not collected.
         if response.metadata.data_loss_from_other_row:
-            raise RuntimeError(
-                "GA4 collapsed some event_label values into the '(other)' "
-                "row (data_loss_from_other_row); this window is missing "
-                "item ids that a re-query cannot recover."
-            )
+            data_loss = True
         if response.metadata.subject_to_thresholding:
             thresholded = True
         if not response.rows:
@@ -364,12 +413,22 @@ def ga4_item_ids(credentials: dict, start_date: str, end_date: str) -> set:
             f"  {dropped:,} label rows dropped (no 32-hex id in label)",
             flush=True,
         )
+    if data_loss:
+        print(
+            f"  WARNING: GA4 collapsed some event_label values into "
+            f"'(other)' for {start_date} → {end_date}; ids in that bucket "
+            f"were not collected.",
+            flush=True,
+        )
     if thresholded:
         print(
             "  WARNING: GA4 withheld low-user rows from this report "
             "(subject_to_thresholding); some item ids are missing.",
             flush=True,
         )
+
+    if not check_drift:
+        return item_ids
 
     # Drift check: EVENT_CATEGORY_PREFIXES is hand-copied from the Rails
     # app. Surface any "{event} : {hub}" category we are not harvesting.
@@ -390,6 +449,7 @@ def ga4_item_ids(credentials: dict, start_date: str, end_date: str) -> set:
             for c in categories
             if " : " in c
             and not any(c.startswith(p) for p in EVENT_CATEGORY_PREFIXES)
+            and not c.startswith(IGNORED_CATEGORY_PREFIXES)
         )
         if unknown:
             print(
@@ -484,14 +544,27 @@ def build_item_data_providers(generated_at: str) -> Optional[dict]:
         start_date = GA4_HISTORY_START
 
     print(f"  Querying GA4 {start_date} → {end_date}...", flush=True)
+    windows = month_windows(start_date, end_date)
+    if not windows:
+        print(
+            f"  ERROR: no months to query ({start_date} is after {end_date}); "
+            "check GA4_HISTORY_START. Leaving item_data_providers.json untouched.",
+            flush=True,
+        )
+        return None
+
     credentials = fetch_ga4_credentials()
-    seen_ids = ga4_item_ids(credentials, start_date, end_date)
+    seen_ids: set = set()
+    for i, (win_start, win_end) in enumerate(windows):
+        seen_ids |= ga4_item_ids(
+            credentials, win_start, win_end, check_drift=(i == len(windows) - 1)
+        )
     print(f"  {len(seen_ids):,} item IDs from GA4", flush=True)
 
     if not seen_ids:
         print(
-            "  ERROR: GA4 returned no item IDs — query or tagging is broken; "
-            "leaving item_data_providers.json untouched.",
+            "  ERROR: GA4 returned no item IDs; query or tagging is broken. "
+            "Leaving item_data_providers.json untouched.",
             flush=True,
         )
         return None
@@ -504,13 +577,20 @@ def build_item_data_providers(generated_at: str) -> Optional[dict]:
     resolved = resolve_ids_from_es(list(seen_ids))
     if not resolved:
         print(
-            "  ERROR: none of the GA4 ids resolved in ES — index or field "
-            "mismatch; leaving item_data_providers.json untouched.",
+            "  ERROR: none of the GA4 ids resolved in ES (index or field "
+            "mismatch); leaving item_data_providers.json untouched.",
             flush=True,
         )
         return None
     current_items.update(resolved)
     print(f"  {len(resolved):,} IDs resolved", flush=True)
+
+    if len(current_items) > 150_000:
+        print(
+            f"  WARNING: mapping at {len(current_items):,} ids; shard the S3 "
+            "file before ~200k (see ItemDataProviders in the Rails app).",
+            flush=True,
+        )
 
     return {"generated_at": generated_at, "items": current_items}
 
@@ -540,6 +620,15 @@ def main() -> None:
 
     bws_stats = build_stats(bws=True, generated_at=generated_at)
     print(f"  {len(bws_stats['hubs'])} hubs with BWS items", flush=True)
+
+    # A partially loaded index passes per-query guards but would wipe most
+    # hubs for 24h. Compare against the live file.
+    previous = existing_hub_count()
+    if previous and hub_count < previous * 0.9:
+        raise RuntimeError(
+            f"Hub count dropped from {previous} to {hub_count}; the index "
+            "may be mid-rebuild. Refusing to overwrite the live stats files."
+        )
 
     upload(hub_stats, HUB_KEY)
     upload(bws_stats, BWS_KEY)

--- a/scripts/generate_hub_stats.py
+++ b/scripts/generate_hub_stats.py
@@ -3,13 +3,24 @@
 Generate hub_stats.json, hub_stats_bws.json, and item_data_providers.json
 from the live ES index and GA4, then upload to s3://dashboard-analytics/hub-stats/.
 
-Run on the ingest EC2 after each monthly index rebuild completes,
-before final verification. Requires boto3, google-analytics-data, and
-network access to ES.
+Run on the ingest EC2 after each monthly index rebuild completes, before
+final verification. Run on day 5 of the month or later: GA4 adjusts data
+for the just-ended month for ~72 hours (see GaPersistentCache::SETTLING_DAYS
+in the Rails app). Requires boto3, google-analytics-data, and network access
+to ES.
+
+Run monthly to keep item_data_providers current. A missed month is
+recoverable: GA4's retention setting does not limit Data API reports, so
+old months can be re-queried by widening the window. The only hard floor
+is the event_label dimension's registration date (2025-07-18).
 
 Uses two passes per stats file: first a hub-level totals aggregation,
 then one per-hub query for contributor counts. A single nested aggregation
 across all hubs exceeds ES's search.max_buckets limit.
+
+Both hub stats files upload before the GA4 work starts. If
+item_data_providers.json cannot be updated, the script exits non-zero so
+post_indexer.py alerts, but the hub stats uploads stand.
 
 Usage:
     ./venv/bin/python scripts/generate_hub_stats.py
@@ -21,13 +32,21 @@ Environment:
     GA4_PROPERTY_ID     - GA4 numeric property ID (required for item_data_providers)
     GA4_SECRET_NAME     - Secrets Manager secret name for GA4 service account JSON
                           (default: dpla/ga4-service-account)
-    GA4_CLICK_EVENT     - GA4 event name for item click-throughs (default: click_item)
-    GA4_HISTORY_START   - Earliest date for first-run backfill (default: 2018-01-01)
+    GA4_HISTORY_START   - Earliest date for first-run backfill (default: 2025-07-18,
+                          the registration date of the event_label custom
+                          dimension; the API returns nothing before that date)
 """
+
+from __future__ import annotations
 
 import calendar
 import json
 import os
+import re
+import sys
+import time
+import traceback
+import urllib.error
 import urllib.request
 from datetime import datetime, timezone
 from typing import Optional
@@ -43,15 +62,27 @@ BWS_KEY = "hub-stats/hub_stats_bws.json"
 IDP_KEY = "hub-stats/item_data_providers.json"
 GA4_PROPERTY_ID = os.environ.get("GA4_PROPERTY_ID", "")
 GA4_SECRET_NAME = os.environ.get("GA4_SECRET_NAME", "dpla/ga4-service-account")
-GA4_CLICK_EVENT = os.environ.get("GA4_CLICK_EVENT", "click_item")
-GA4_HISTORY_START = os.environ.get("GA4_HISTORY_START", "2018-01-01")
+GA4_HISTORY_START = os.environ.get("GA4_HISTORY_START", "2025-07-18")
+
+# The event tables whose rows the dashboard resolves contributor names for.
+# In this GA4 property the event *type* lives in customEvent:event_category
+# as "{event name} : {hub name}"; eventName holds the contributor name, so
+# never filter on it. Must match WebsiteEvents::NAMES_BY_ID in the Rails app.
+EVENT_CATEGORY_PREFIXES = [
+    "View Item : ",
+    "View Exhibition Item : ",
+    "View Primary Source : ",
+    "Click Through : ",
+]
+
+# DPLA item IDs are 32 hex chars. Filters out GA4's "(other)" bucket rows
+# and malformed labels.
+ITEM_ID_RE = re.compile(r"[0-9a-f]{32}")
 
 
-def es_query(query: dict, timeout: int = 30) -> dict:
-    url = f"http://{ES_HOST}:{ES_PORT}/dpla_alias/_search"
-    data = json.dumps(query).encode()
+def _es_search(url: str, payload: bytes, timeout: int, query: dict) -> dict:
     req = urllib.request.Request(
-        url, data=data, headers={"Content-Type": "application/json"}
+        url, data=payload, headers={"Content-Type": "application/json"}
     )
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         data = json.loads(resp.read())
@@ -61,6 +92,36 @@ def es_query(query: dict, timeout: int = 30) -> dict:
     if shards.get("failed", 0) > 0:
         raise RuntimeError(f"Elasticsearch shard failures: {shards}")
     return data
+
+
+def es_query(query: dict, timeout: int = 30) -> dict:
+    """Search ES, retrying transient failures (network, 5xx, shard errors)."""
+    url = f"http://{ES_HOST}:{ES_PORT}/dpla_alias/_search"
+    payload = json.dumps(query).encode()
+    for attempt in range(3):
+        try:
+            return _es_search(url, payload, timeout, query)
+        except urllib.error.HTTPError as e:
+            if e.code < 500:
+                raise
+            err: Exception = e
+        except (OSError, RuntimeError) as e:
+            err = e
+        wait = 2 * (2**attempt)
+        print(
+            f"  ES transient error ({err.__class__.__name__}); "
+            f"retrying in {wait}s...",
+            flush=True,
+        )
+        time.sleep(wait)
+    return _es_search(url, payload, timeout, query)
+
+
+def aws_client(service: str):
+    # AWS_PROFILE for local dev; profile_name=None on EC2 falls back to the
+    # instance role.
+    session = boto3.Session(profile_name=os.environ.get("AWS_PROFILE"))
+    return session.client(service, region_name="us-east-1")
 
 
 def hub_totals(bws: bool = False) -> dict:
@@ -75,6 +136,11 @@ def hub_totals(bws: bool = False) -> dict:
         query["query"] = {"term": {"tags": "blackwomensuffrage"}}
     result = es_query(query)
     hubs_agg = result["aggregations"]["hubs"]
+    if not hubs_agg["buckets"]:
+        raise RuntimeError(
+            "Hub aggregation returned no buckets (empty index, wrong alias, "
+            "or renamed field); refusing to overwrite the live stats files."
+        )
     if hubs_agg.get("sum_other_doc_count", 0) > 0:
         raise RuntimeError(
             f"Hub aggregation truncated (sum_other_doc_count="
@@ -128,14 +194,15 @@ def build_stats(bws: bool = False, generated_at: Optional[str] = None) -> dict:
     }
 
 
-def upload(data: dict, key: str) -> None:
-    # Use AWS_PROFILE if set (local dev); on EC2 profile_name=None falls back
-    # to the instance metadata credential chain.
-    session = boto3.Session(profile_name=os.environ.get("AWS_PROFILE"))
-    session.client("s3", region_name="us-east-1").put_object(
+def upload(data: dict, key: str, compact: bool = False) -> None:
+    # compact halves the payload for the large cumulative file.
+    body = (
+        json.dumps(data, separators=(",", ":")) if compact else json.dumps(data, indent=2)
+    )
+    aws_client("s3").put_object(
         Bucket=BUCKET,
         Key=key,
-        Body=json.dumps(data, indent=2).encode(),
+        Body=body.encode(),
         ContentType="application/json",
     )
     print(f"  Uploaded s3://{BUCKET}/{key}", flush=True)
@@ -146,26 +213,39 @@ def upload(data: dict, key: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def prev_month_range() -> tuple[str, str]:
-    """Return (start_date, end_date) ISO strings for the previous calendar month."""
+def recent_months_range() -> tuple[str, str]:
+    """Return (start_date, end_date) ISO strings covering the previous two
+    calendar months.
+
+    Two months, not one: a run early in the month can miss events GA4 was
+    still settling for the month before. The merge only adds IDs, so
+    re-querying the same months is safe, and one missed run heals on the
+    next.
+    """
     now = datetime.now(timezone.utc)
-    year, month = (now.year, now.month - 1) if now.month > 1 else (now.year - 1, 12)
-    last_day = calendar.monthrange(year, month)[1]
-    return f"{year:04d}-{month:02d}-01", f"{year:04d}-{month:02d}-{last_day:02d}"
+    end_year, end_month = (now.year, now.month - 1) if now.month > 1 else (now.year - 1, 12)
+    start_year, start_month = (
+        (end_year, end_month - 1) if end_month > 1 else (end_year - 1, 12)
+    )
+    last_day = calendar.monthrange(end_year, end_month)[1]
+    return (
+        f"{start_year:04d}-{start_month:02d}-01",
+        f"{end_year:04d}-{end_month:02d}-{last_day:02d}",
+    )
 
 
 def fetch_ga4_credentials() -> dict:
     """Fetch GA4 service account JSON from AWS Secrets Manager."""
-    session = boto3.Session(profile_name=os.environ.get("AWS_PROFILE"))
-    sm = session.client("secretsmanager", region_name="us-east-1")
-    secret = sm.get_secret_value(SecretId=GA4_SECRET_NAME)
-    return json.loads(secret["SecretString"])
+    secret = aws_client("secretsmanager").get_secret_value(SecretId=GA4_SECRET_NAME)
+    raw = secret.get("SecretString") or secret["SecretBinary"]
+    return json.loads(raw)
 
 
 def ga4_item_ids(credentials: dict, start_date: str, end_date: str) -> set:
-    """Return set of item IDs from GA4 click-through events in [start_date, end_date].
+    """Return the set of item IDs from all four event tables in
+    [start_date, end_date].
 
-    Item IDs are the first segment of the eventLabel dimension value,
+    Item IDs are the first segment of the customEvent:event_label value,
     which has the format "{item_id} : {item_title}".
     """
     from google.analytics.data_v1beta import BetaAnalyticsDataClient
@@ -174,8 +254,17 @@ def ga4_item_ids(credentials: dict, start_date: str, end_date: str) -> set:
         Dimension,
         Filter,
         FilterExpression,
+        FilterExpressionList,
         Metric,
+        OrderBy,
         RunReportRequest,
+    )
+    from google.api_core.exceptions import (
+        DeadlineExceeded,
+        InternalServerError,
+        ResourceExhausted,
+        ServiceUnavailable,
+        TooManyRequests,
     )
     from google.oauth2.service_account import Credentials
 
@@ -185,55 +274,164 @@ def ga4_item_ids(credentials: dict, start_date: str, end_date: str) -> set:
     )
     client = BetaAnalyticsDataClient(credentials=creds)
 
+    transient = (
+        DeadlineExceeded,
+        InternalServerError,
+        ResourceExhausted,
+        ServiceUnavailable,
+        TooManyRequests,
+    )
+
+    def run_report_with_retry(report_request):
+        for attempt in range(3):
+            try:
+                return client.run_report(report_request)
+            except transient as e:
+                wait = 15 * (2**attempt)
+                print(
+                    f"  GA4 transient error ({e.__class__.__name__}); "
+                    f"retrying in {wait}s...",
+                    flush=True,
+                )
+                time.sleep(wait)
+        return client.run_report(report_request)
+
+    category_filters = [
+        FilterExpression(
+            filter=Filter(
+                field_name="customEvent:event_category",
+                string_filter=Filter.StringFilter(
+                    value=prefix,
+                    match_type=Filter.StringFilter.MatchType.BEGINS_WITH,
+                ),
+            )
+        )
+        for prefix in EVENT_CATEGORY_PREFIXES
+    ]
+
     item_ids: set = set()
+    dropped = 0
+    thresholded = False
     offset = 0
     page_size = 10000
 
     while True:
         request = RunReportRequest(
             property=f"properties/{GA4_PROPERTY_ID}",
-            dimensions=[Dimension(name="eventLabel")],
+            dimensions=[Dimension(name="customEvent:event_label")],
             metrics=[Metric(name="eventCount")],
             date_ranges=[DateRange(start_date=start_date, end_date=end_date)],
             dimension_filter=FilterExpression(
-                filter=Filter(
-                    field_name="eventName",
-                    string_filter=Filter.StringFilter(
-                        value=GA4_CLICK_EVENT,
-                        match_type=Filter.StringFilter.MatchType.EXACT,
-                    ),
-                )
+                or_group=FilterExpressionList(expressions=category_filters)
             ),
+            # Explicit order: GA4 row order is unspecified without it, which
+            # makes offset pagination skip or repeat rows.
+            order_bys=[
+                OrderBy(
+                    dimension=OrderBy.DimensionOrderBy(
+                        dimension_name="customEvent:event_label"
+                    )
+                )
+            ],
             offset=offset,
             limit=page_size,
         )
-        response = client.run_report(request)
+        response = run_report_with_retry(request)
+        if response.metadata.data_loss_from_other_row:
+            raise RuntimeError(
+                "GA4 collapsed some event_label values into the '(other)' "
+                "row (data_loss_from_other_row); this window is missing "
+                "item ids that a re-query cannot recover."
+            )
+        if response.metadata.subject_to_thresholding:
+            thresholded = True
         if not response.rows:
             break
         for row in response.rows:
             label = row.dimension_values[0].value
             item_id = label.split(" : ")[0].strip()
-            if item_id:
+            if ITEM_ID_RE.fullmatch(item_id):
                 item_ids.add(item_id)
-        if len(response.rows) < page_size:
+            else:
+                dropped += 1
+        # row_count is the documented completion signal; a short page is not.
+        offset += len(response.rows)
+        if offset >= response.row_count:
             break
-        offset += page_size
+
+    if dropped:
+        print(
+            f"  {dropped:,} label rows dropped (no 32-hex id in label)",
+            flush=True,
+        )
+    if thresholded:
+        print(
+            "  WARNING: GA4 withheld low-user rows from this report "
+            "(subject_to_thresholding); some item ids are missing.",
+            flush=True,
+        )
+
+    # Drift check: EVENT_CATEGORY_PREFIXES is hand-copied from the Rails
+    # app. Surface any "{event} : {hub}" category we are not harvesting.
+    try:
+        cat_request = RunReportRequest(
+            property=f"properties/{GA4_PROPERTY_ID}",
+            dimensions=[Dimension(name="customEvent:event_category")],
+            metrics=[Metric(name="eventCount")],
+            date_ranges=[DateRange(start_date=start_date, end_date=end_date)],
+            limit=10000,
+        )
+        categories = {
+            row.dimension_values[0].value
+            for row in run_report_with_retry(cat_request).rows
+        }
+        unknown = sorted(
+            c
+            for c in categories
+            if " : " in c
+            and not any(c.startswith(p) for p in EVENT_CATEGORY_PREFIXES)
+        )
+        if unknown:
+            print(
+                f"  WARNING: {len(unknown)} event categories not in "
+                f"EVENT_CATEGORY_PREFIXES; update the list if these are "
+                f"item events: {unknown[:10]}",
+                flush=True,
+            )
+    except Exception as e:
+        print(
+            f"  WARNING: category drift check failed "
+            f"({e.__class__.__name__}: {e})",
+            flush=True,
+        )
 
     return item_ids
 
 
 def fetch_existing_idp() -> dict:
     """Fetch existing item_data_providers.json from S3, or return empty structure."""
-    session = boto3.Session(profile_name=os.environ.get("AWS_PROFILE"))
-    s3 = session.client("s3", region_name="us-east-1")
     try:
-        obj = s3.get_object(Bucket=BUCKET, Key=IDP_KEY)
-        return json.loads(obj["Body"].read())
+        obj = aws_client("s3").get_object(Bucket=BUCKET, Key=IDP_KEY)
     except botocore.exceptions.ClientError as e:
         if e.response["Error"]["Code"] == "NoSuchKey":
             print("  No existing item_data_providers.json; starting fresh.", flush=True)
             return {"items": {}}
         raise
+    try:
+        existing = json.loads(obj["Body"].read())
+    except ValueError as e:
+        raise RuntimeError(
+            f"Existing s3://{BUCKET}/{IDP_KEY} is not valid JSON ({e}). "
+            "Inspect it; delete the object to rebuild from full history."
+        ) from e
+    items = existing.get("items") if isinstance(existing, dict) else None
+    if not isinstance(items, dict):
+        raise RuntimeError(
+            f"Existing s3://{BUCKET}/{IDP_KEY} does not look like "
+            '{"items": {...}}. Inspect it; delete the object to rebuild '
+            "from full history."
+        )
+    return existing
 
 
 def resolve_ids_from_es(ids: list) -> dict:
@@ -258,45 +456,61 @@ def resolve_ids_from_es(ids: list) -> dict:
     return resolved
 
 
-def build_item_data_providers(generated_at: str) -> dict:
-    """Build the cumulative item_data_providers.json.
+def build_item_data_providers(generated_at: str) -> Optional[dict]:
+    """Build the cumulative item_data_providers.json, or None if it must not
+    be uploaded.
 
-    Fetches the existing mapping from S3, queries GA4 for new item IDs
-    (previous calendar month, or full history on first run), resolves
-    them against ES, and returns the merged mapping.
+    Fetches the existing mapping from S3, queries GA4 for item IDs
+    (previous two calendar months, or full history on first run), resolves
+    them against ES, and returns the merged mapping. The merge only adds
+    IDs, so a run can never shrink the mapping; when GA4 is misconfigured
+    or returns nothing, returns None so the existing file stays untouched.
     """
     if not GA4_PROPERTY_ID:
         print(
-            "  WARNING: GA4_PROPERTY_ID not set; skipping item_data_providers.",
+            "  ERROR: GA4_PROPERTY_ID not set; leaving item_data_providers.json untouched.",
             flush=True,
         )
-        return {"generated_at": generated_at, "items": {}}
+        return None
 
     existing = fetch_existing_idp()
-    current_items: dict = existing.get("items", {})
+    current_items: dict = existing["items"]
 
     # First run (empty mapping): backfill all available GA4 history.
-    # Subsequent runs: previous calendar month only.
     if current_items:
-        start_date, end_date = prev_month_range()
+        start_date, end_date = recent_months_range()
     else:
-        _, end_date = prev_month_range()
+        _, end_date = recent_months_range()
         start_date = GA4_HISTORY_START
 
-    print(
-        f"  Querying GA4 ({GA4_CLICK_EVENT}) {start_date} → {end_date}...", flush=True
-    )
+    print(f"  Querying GA4 {start_date} → {end_date}...", flush=True)
     credentials = fetch_ga4_credentials()
     seen_ids = ga4_item_ids(credentials, start_date, end_date)
     print(f"  {len(seen_ids):,} item IDs from GA4", flush=True)
 
-    new_ids = [i for i in seen_ids if i not in current_items]
-    print(f"  {len(new_ids):,} new IDs to resolve from ES", flush=True)
+    if not seen_ids:
+        print(
+            "  ERROR: GA4 returned no item IDs — query or tagging is broken; "
+            "leaving item_data_providers.json untouched.",
+            flush=True,
+        )
+        return None
 
-    if new_ids:
-        resolved = resolve_ids_from_es(new_ids)
-        current_items.update(resolved)
-        print(f"  {len(resolved):,} IDs resolved", flush=True)
+    new_count = sum(1 for i in seen_ids if i not in current_items)
+    print(f"  {new_count:,} of these are new", flush=True)
+
+    # Resolve every id in the window, not just new ones, so contributor
+    # renames in ES reach recently active items.
+    resolved = resolve_ids_from_es(list(seen_ids))
+    if not resolved:
+        print(
+            "  ERROR: none of the GA4 ids resolved in ES — index or field "
+            "mismatch; leaving item_data_providers.json untouched.",
+            flush=True,
+        )
+        return None
+    current_items.update(resolved)
+    print(f"  {len(resolved):,} IDs resolved", flush=True)
 
     return {"generated_at": generated_at, "items": current_items}
 
@@ -309,26 +523,52 @@ def build_item_data_providers(generated_at: str) -> dict:
 def main() -> None:
     generated_at = datetime.now(timezone.utc).isoformat()
 
+    if datetime.now(timezone.utc).day < 5:
+        print(
+            "WARNING: running before day 5; GA4 may still be adjusting the "
+            "just-ended month (see GaPersistentCache::SETTLING_DAYS).",
+            flush=True,
+        )
+
+    # Build both stats files, then upload both: a failure mid-build
+    # publishes nothing, and a GA4 failure later cannot block the stats
+    # uploads, which have already happened.
     print("Generating hub stats from ES...", flush=True)
     hub_stats = build_stats(bws=False, generated_at=generated_at)
     hub_count = len(hub_stats["hubs"])
     print(f"  {hub_count} hubs", flush=True)
 
     bws_stats = build_stats(bws=True, generated_at=generated_at)
-    bws_hub_count = len(bws_stats["hubs"])
-    print(f"  {bws_hub_count} hubs with BWS items", flush=True)
-
-    print("Generating item_data_providers.json...", flush=True)
-    idp = build_item_data_providers(generated_at)
-    idp_count = len(idp.get("items", {}))
-    print(f"  {idp_count:,} items in mapping", flush=True)
+    print(f"  {len(bws_stats['hubs'])} hubs with BWS items", flush=True)
 
     upload(hub_stats, HUB_KEY)
     upload(bws_stats, BWS_KEY)
-    upload(idp, IDP_KEY)
 
+    print("Generating item_data_providers.json...", flush=True)
+    try:
+        idp = build_item_data_providers(generated_at)
+    except Exception as e:
+        print(traceback.format_exc(), flush=True)
+        print(
+            f"  ERROR: item_data_providers failed ({e.__class__.__name__}: {e}); "
+            "existing file untouched.",
+            flush=True,
+        )
+        idp = None
+
+    # Exit non-zero on IDP failure so post_indexer's SSM status check alerts;
+    # the hub stats uploads above have already happened either way.
+    if idp is None:
+        print(
+            f"Done with errors. {hub_count} hubs uploaded; "
+            f"item_data_providers.json not updated. generated_at={generated_at}",
+            flush=True,
+        )
+        sys.exit(1)
+
+    upload(idp, IDP_KEY, compact=True)
     print(
-        f"Done. {hub_count} hubs, {idp_count:,} item mappings, "
+        f"Done. {hub_count} hubs, {len(idp['items']):,} item mappings, "
         f"generated_at={generated_at}",
         flush=True,
     )

--- a/scripts/tests/test-hub-alias-mock.sh
+++ b/scripts/tests/test-hub-alias-mock.sh
@@ -28,10 +28,10 @@ mkdir -p "$FAKE_BIN"
 AWS_CALLS_LOG="$TMPDIR/aws-calls.log"
 : > "$AWS_CALLS_LOG"
 
-# Stub aws so tests are deterministic and side-effect free.
+# Stub aws so tests are deterministic and side-effect free
 cat > "$FAKE_BIN/aws" <<'EOF'
 #!/usr/bin/env bash
-echo "$*" >> "${AWS_CALLS_LOG:?}"
+echo "AWS_PROFILE=${AWS_PROFILE:-<unset>} $*" >> "${AWS_CALLS_LOG:?}"
 if [ "${1:-}" = "s3" ] && [ "${2:-}" = "ls" ]; then
   exit 0
 fi
@@ -50,11 +50,14 @@ mkdir -p \
 
 PYTHON_BIN="$REPO_ROOT/venv/bin/python"
 
+# AWS_PROFILE is cleared so results do not depend on the caller's shell;
+# common.sh unsets an empty profile (the EC2 instance-role path).
 run_with_stubbed_aws() {
     PATH="$FAKE_BIN:$PATH" \
     AWS_CALLS_LOG="$AWS_CALLS_LOG" \
     DPLA_DATA="$DATA_DIR" \
     I3_HOME="$REPO_ROOT" \
+    AWS_PROFILE="" \
     "$@"
 }
 
@@ -76,23 +79,44 @@ run_with_stubbed_aws "$REPO_ROOT/scripts/s3-sync.sh" tn
 assert_log_contains "s3 sync $DATA_DIR/hathi/ s3://dpla-master-dataset/hathitrust/"
 assert_log_contains "s3 sync $DATA_DIR/tn/ s3://dpla-master-dataset/tennessee/"
 
-# 2) strict mode disables aliasing
+# 2) profile handling: sync must not pass --profile
+# and must not invent AWS_PROFILE since EC2 uses an instance role,
+# and a named profile there makes every aws call fail.
+# A caller-set profile must propagate.
+if grep -F " s3 sync " "$AWS_CALLS_LOG" | grep -q -- "--profile"; then
+    echo "s3 sync must not receive --profile (breaks EC2 instance roles, PR #669)"
+    echo "Recorded calls:"
+    sed 's/^/  /' "$AWS_CALLS_LOG"
+    exit 1
+fi
+assert_log_contains "AWS_PROFILE=<unset> s3 sync $DATA_DIR/hathi/ s3://dpla-master-dataset/hathitrust/"
+
 PATH="$FAKE_BIN:$PATH" \
 AWS_CALLS_LOG="$AWS_CALLS_LOG" \
 DPLA_DATA="$DATA_DIR" \
 I3_HOME="$REPO_ROOT" \
+AWS_PROFILE=dpla \
+"$REPO_ROOT/scripts/s3-sync.sh" tn
+assert_log_contains "AWS_PROFILE=dpla s3 sync $DATA_DIR/tn/ s3://dpla-master-dataset/tennessee/"
+
+# 3) strict mode disables aliasing
+PATH="$FAKE_BIN:$PATH" \
+AWS_CALLS_LOG="$AWS_CALLS_LOG" \
+DPLA_DATA="$DATA_DIR" \
+I3_HOME="$REPO_ROOT" \
+AWS_PROFILE="" \
 I3_STRICT_HUB_NAMES=1 \
 "$REPO_ROOT/scripts/s3-sync.sh" hathi
 assert_log_contains "s3 sync $DATA_DIR/hathi/ s3://dpla-master-dataset/hathi/"
 
-# 3) check-jsonl-sync uses alias for tn
+# 4) check-jsonl-sync uses alias for tn
 run_with_stubbed_aws "$REPO_ROOT/scripts/status/check-jsonl-sync.sh" --data-dir "$DATA_DIR" --profile dpla || true
 assert_log_contains "s3 ls s3://dpla-master-dataset/tennessee/jsonl/20260201_000000-tn-MAP3_1.IndexRecord.jsonl/ --profile dpla"
 
-# 4) check-jsonl-sync keeps canonical tennessee unchanged
+# 5) check-jsonl-sync keeps canonical tennessee unchanged
 assert_log_contains "s3 ls s3://dpla-master-dataset/tennessee/jsonl/20260201_000000-tennessee-MAP3_1.IndexRecord.jsonl/ --profile dpla"
 
-# 5) orchestrator dry-run succeeds against canonical-key i3.conf with both
+# 6) orchestrator dry-run succeeds against canonical-key i3.conf with both
 # legacy and canonical hub arguments (no AWS writes in dry-run path)
 if [ -x "$PYTHON_BIN" ]; then
   I3_CANONICAL_CONF="$TMPDIR/i3-canonical.conf"

--- a/scripts/tests/test-hub-alias-mock.sh
+++ b/scripts/tests/test-hub-alias-mock.sh
@@ -31,7 +31,7 @@ AWS_CALLS_LOG="$TMPDIR/aws-calls.log"
 # Stub aws so tests are deterministic and side-effect free
 cat > "$FAKE_BIN/aws" <<'EOF'
 #!/usr/bin/env bash
-echo "AWS_PROFILE=${AWS_PROFILE:-<unset>} $*" >> "${AWS_CALLS_LOG:?}"
+echo "AWS_PROFILE=${AWS_PROFILE-<unset>} $*" >> "${AWS_CALLS_LOG:?}"
 if [ "${1:-}" = "s3" ] && [ "${2:-}" = "ls" ]; then
   exit 0
 fi

--- a/scripts/tests/test-hub-alias-mock.sh
+++ b/scripts/tests/test-hub-alias-mock.sh
@@ -71,6 +71,17 @@ assert_log_contains() {
     fi
 }
 
+# Assert that the log line for one invocation carries no --profile.
+assert_log_line_no_profile() {
+    local needle="$1"
+    if grep -F "$needle" "$AWS_CALLS_LOG" | grep -q -- "--profile"; then
+        echo "s3 sync must not receive --profile (breaks EC2 instance roles, PR #669): $needle"
+        echo "Recorded calls:"
+        sed 's/^/  /' "$AWS_CALLS_LOG"
+        exit 1
+    fi
+}
+
 echo "Running alias smoke tests with stubbed AWS..."
 
 # 1) s3-sync legacy alias behavior
@@ -98,6 +109,7 @@ I3_HOME="$REPO_ROOT" \
 AWS_PROFILE=dpla \
 "$REPO_ROOT/scripts/s3-sync.sh" tn
 assert_log_contains "AWS_PROFILE=dpla s3 sync $DATA_DIR/tn/ s3://dpla-master-dataset/tennessee/"
+assert_log_line_no_profile "AWS_PROFILE=dpla s3 sync $DATA_DIR/tn/ s3://dpla-master-dataset/tennessee/"
 
 # 3) strict mode disables aliasing
 PATH="$FAKE_BIN:$PATH" \
@@ -108,6 +120,7 @@ AWS_PROFILE="" \
 I3_STRICT_HUB_NAMES=1 \
 "$REPO_ROOT/scripts/s3-sync.sh" hathi
 assert_log_contains "s3 sync $DATA_DIR/hathi/ s3://dpla-master-dataset/hathi/"
+assert_log_line_no_profile "s3 sync $DATA_DIR/hathi/ s3://dpla-master-dataset/hathi/"
 
 # 4) check-jsonl-sync uses alias for tn
 run_with_stubbed_aws "$REPO_ROOT/scripts/status/check-jsonl-sync.sh" --data-dir "$DATA_DIR" --profile dpla || true

--- a/scripts/tests/test-hub-alias-mock.sh
+++ b/scripts/tests/test-hub-alias-mock.sh
@@ -73,8 +73,8 @@ echo "Running alias smoke tests with stubbed AWS..."
 # 1) s3-sync legacy alias behavior
 run_with_stubbed_aws "$REPO_ROOT/scripts/s3-sync.sh" hathi
 run_with_stubbed_aws "$REPO_ROOT/scripts/s3-sync.sh" tn
-assert_log_contains "s3 sync $DATA_DIR/hathi/ s3://dpla-master-dataset/hathitrust/ --profile dpla"
-assert_log_contains "s3 sync $DATA_DIR/tn/ s3://dpla-master-dataset/tennessee/ --profile dpla"
+assert_log_contains "s3 sync $DATA_DIR/hathi/ s3://dpla-master-dataset/hathitrust/"
+assert_log_contains "s3 sync $DATA_DIR/tn/ s3://dpla-master-dataset/tennessee/"
 
 # 2) strict mode disables aliasing
 PATH="$FAKE_BIN:$PATH" \
@@ -83,7 +83,7 @@ DPLA_DATA="$DATA_DIR" \
 I3_HOME="$REPO_ROOT" \
 I3_STRICT_HUB_NAMES=1 \
 "$REPO_ROOT/scripts/s3-sync.sh" hathi
-assert_log_contains "s3 sync $DATA_DIR/hathi/ s3://dpla-master-dataset/hathi/ --profile dpla"
+assert_log_contains "s3 sync $DATA_DIR/hathi/ s3://dpla-master-dataset/hathi/"
 
 # 3) check-jsonl-sync uses alias for tn
 run_with_stubbed_aws "$REPO_ROOT/scripts/status/check-jsonl-sync.sh" --data-dir "$DATA_DIR" --profile dpla || true

--- a/scripts/tests/test-hub-alias-mock.sh
+++ b/scripts/tests/test-hub-alias-mock.sh
@@ -50,14 +50,16 @@ mkdir -p \
 
 PYTHON_BIN="$REPO_ROOT/venv/bin/python"
 
-# AWS_PROFILE is cleared so results do not depend on the caller's shell;
-# common.sh unsets an empty profile (the EC2 instance-role path).
+# AWS_PROFILE and I3_STRICT_HUB_NAMES are cleared so results do not depend
+# on the caller's shell; common.sh unsets an empty profile (the EC2
+# instance-role path). The strict-mode test sets I3_STRICT_HUB_NAMES=1 itself.
 run_with_stubbed_aws() {
     PATH="$FAKE_BIN:$PATH" \
     AWS_CALLS_LOG="$AWS_CALLS_LOG" \
     DPLA_DATA="$DATA_DIR" \
     I3_HOME="$REPO_ROOT" \
     AWS_PROFILE="" \
+    I3_STRICT_HUB_NAMES="" \
     "$@"
 }
 
@@ -107,6 +109,7 @@ AWS_CALLS_LOG="$AWS_CALLS_LOG" \
 DPLA_DATA="$DATA_DIR" \
 I3_HOME="$REPO_ROOT" \
 AWS_PROFILE=dpla \
+I3_STRICT_HUB_NAMES="" \
 "$REPO_ROOT/scripts/s3-sync.sh" tn
 assert_log_contains "AWS_PROFILE=dpla s3 sync $DATA_DIR/tn/ s3://dpla-master-dataset/tennessee/"
 assert_log_line_no_profile "AWS_PROFILE=dpla s3 sync $DATA_DIR/tn/ s3://dpla-master-dataset/tennessee/"
@@ -150,10 +153,12 @@ hathitrust.s3_destination = "s3://dpla-master-dataset/hathitrust/"
 EOF
 
   PATH="$FAKE_BIN:$PATH" AWS_CALLS_LOG="$AWS_CALLS_LOG" \
+    I3_STRICT_HUB_NAMES="" \
     "$PYTHON_BIN" -m scheduler.orchestrator.main --dry-run \
     --config "$I3_CANONICAL_CONF" --hub=tn,hathi >/dev/null
 
   PATH="$FAKE_BIN:$PATH" AWS_CALLS_LOG="$AWS_CALLS_LOG" \
+    I3_STRICT_HUB_NAMES="" \
     "$PYTHON_BIN" -m scheduler.orchestrator.main --dry-run \
     --config "$I3_CANONICAL_CONF" --hub=tennessee,hathitrust >/dev/null
 fi

--- a/scripts/tests/test-scripts.sh
+++ b/scripts/tests/test-scripts.sh
@@ -240,6 +240,31 @@ test_syntax() {
 }
 
 # =============================================================================
+# Test: Python script syntax
+# =============================================================================
+
+test_python_syntax() {
+    echo ""
+    echo "=========================================="
+    echo "  Testing Python Script Syntax"
+    echo "=========================================="
+
+    local scripts=(
+        "generate_hub_stats.py"
+        "export_item_attribution.py"
+    )
+
+    for script in "${scripts[@]}"; do
+        local script_path="$SCRIPTS_DIR/$script"
+        if [[ -f "$script_path" ]]; then
+            run_test "Python syntax: $script" "python3 -m py_compile '$script_path'"
+        else
+            log_skip "Python syntax: $script (file not found)"
+        fi
+    done
+}
+
+# =============================================================================
 # Test: Scripts source common.sh
 # =============================================================================
 
@@ -1038,6 +1063,7 @@ main() {
     # Run tests
     test_common_sh
     test_syntax
+    test_python_syntax
     test_referenced_script_paths
     
     if [[ "$QUICK_MODE" != "true" ]]; then

--- a/scripts/tests/test-scripts.sh
+++ b/scripts/tests/test-scripts.sh
@@ -234,7 +234,8 @@ test_syntax() {
         if [[ -f "$script_path" ]]; then
             run_test "Syntax: $script" "bash -n '$script_path'"
         else
-            log_skip "Syntax: $script (file not found)"
+            TESTS_RUN=$((TESTS_RUN + 1))
+            log_fail "Syntax: $script (file not found)"
         fi
     done
 }

--- a/scripts/tests/test-scripts.sh
+++ b/scripts/tests/test-scripts.sh
@@ -259,7 +259,8 @@ test_python_syntax() {
         if [[ -f "$script_path" ]]; then
             run_test "Python syntax: $script" "python3 -m py_compile '$script_path'"
         else
-            log_skip "Python syntax: $script (file not found)"
+            TESTS_RUN=$((TESTS_RUN + 1))
+            log_fail "Python syntax: $script (file not found)"
         fi
     done
 }


### PR DESCRIPTION
## generate_hub_stats.py

- Fix the GA4 query
  - The old dimension (`eventLabel`) and event name (`click_item`) don't exist in this property, so item IDs were never collected or output into `item_data_providers.json` (output before was just `{"generated_at": "2026-07-02T19:01:50.721851+00:00","items": {}}`) Now queries `customEvent:event_label` filtered by the four event categories the dashboard reads.
- Query the previous two months instead of just one, so a missed or early run catches up on the next
- Paginate with an explicit sort and stop on `row_count`
- Retry GA4 and ES calls on transient errors
- Fail if GA4 collapses labels into its "(other)" row (previously would lose IDs silently)
- Warn if GA4 withholds low-user rows or has event categories missing from our list
- Only keep labels that start with a 32-hex item ID
- Re-resolve every ID so contributor renames get picked up
- Never write `item_data_providers.json` on failure
  - Before, an unset `GA4_PROPERTY_ID` replaced it with an empty file
- Fail run if none of the GA4 IDs resolve in ES
  - Previously a broken resolution re-uploaded the file unchanged with a fresh timestamp, which also kept the dashboard's staleness alarm from firing.
- Skip the hub stats uploads if ES returns no hubs (empty index or wrong alias)
- Build both hub stats files before uploading either so a mid-build failure publishes nothing
- Give a clear error if the existing S3 file is corrupt or the wrong shape instead of crashing on it every month
- Start the first-run backfill at `2025-07-18`, when the event_label dimension was registered. GA4 has nothing earlier.
- Removed `GA4_CLICK_EVENT` and the wrong claim that 14-month retention limits the Data API
- One aws_client helper instead of three copies of the boto3 session setup
- Other hardening and error handling improvements

## post_indexer.py

- Allow 45 minutes for the hub stats step. The first run backfills a year of GA4 data.
- Write full output to `/tmp/hub-stats.log` on the EC2 and echo the tail.
  - SSM keeps only the first 24k characters, which hid errors.
- Check `item_data_providers.json` freshness in verify_outputs so a failed GA4 step can't be reported as "all outputs verified".
- Clearer Slack message when the step fails.

## postchecks.py

- Show `item_data_providers.json` in the status output.

## SCRIPTS.md, test-scripts.sh

- Document `generate_hub_stats.py` and add a Python syntax check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# CodeRabbit Review
## Summary

- **Hardened hub stats generation and verification**
  - Added retries, validation, pagination, drift detection, and failure safeguards to GA4/Elasticsearch processing.
  - Prevents invalid or partial `item_data_providers.json` uploads while allowing valid hub-stat files to complete.
  - Post-indexer checks now verify all three hub-stat artifacts and report item-mapping freshness.
  - Increased SSM timeout and improved logging/Slack diagnostics.

- **Fixed GA4 item-to-contributor mappings**
  - Uses `customEvent:event_label` and the dashboard’s four event-category prefixes.
  - Validates 32-character hexadecimal item IDs and re-resolves all observed IDs to capture contributor renames.
  - Backfills the previous two calendar months on later runs, bounded by `GA4_HISTORY_START`.

- **Documentation and tests**
  - Documented scripts, outputs, scheduling, failure behavior, and relevant configuration.
  - Added Python syntax checks and stricter Bash-script presence checks.
  - Improved AWS profile behavior coverage in hub-alias tests.
  - Deferred Java setup until emailer execution.

## Operational considerations

- **Manual pipeline trigger / ECS redeployment:** Not required; changes apply on the next scheduled or SSM-driven ingest run after deployment.
- **Environment variables / secrets:** `GA4_CLICK_EVENT` was removed. `GA4_PROPERTY_ID`, `GA4_SECRET_NAME`, `GA4_HISTORY_START`, `ES_HOST`, and `ES_PORT` remain in use or documented. No new Secrets Manager keys are added.
- **Database migrations:** None.
- **Shared infrastructure configuration:** No CodePipeline, CodeBuild, ECS task definition, or IAM policy changes.
- **Public API changes:** None.
- **Security implications:** No authentication changes. GA4 credentials continue to be sourced from Secrets Manager, with stronger validation and safeguards against publishing invalid analytics data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->