### PR TITLE
Add exhibition and primary source set membership to JSONL records

### DIFF
--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -39,6 +39,7 @@ Scripts are grouped by purpose. Run from repo root (e.g. `./scripts/ingest.sh ma
 | `delete/delete-from-jsonl.sh` | Delete records from S3 JSONL files | `./scripts/delete/delete-from-jsonl.sh --hub <hub> <id>...` |
 | `communication/send-ingest-email.sh` | Send ingest summary email | `./scripts/communication/send-ingest-email.sh [--yes] <hub>` |
 | `generate_hub_stats.py` | Rebuild dashboard hub stats + GA4 item mapping in S3 | `./venv/bin/python scripts/generate_hub_stats.py` |
+| `curated_membership.py` | Refresh the exhibition/source-set membership snapshot used by the JSONL export | `python3 scripts/curated_membership.py` |
 | *scheduling_emails* (Python) | Monthly pre-scheduling email to hub contacts | `./venv/bin/python -m scheduler.orchestrator.scheduling_emails [--month=N] --dry-run \| --draft \| --send` |
 | `status/ingest-status.sh` | Check ingest status (orchestrator or manual runs) | `./scripts/status/ingest-status.sh` |
 | `communication/notify-harvest-failure.sh` | Send Slack and email (tech@dp.la) on harvest failure | `./scripts/communication/notify-harvest-failure.sh <hub> "<error>"` |
@@ -312,6 +313,23 @@ Rebuilds the three dashboard-analytics inputs in `s3://dashboard-analytics/hub-s
 Run on the ingest EC2 on day 5 of the month or later (GA4 settles the prior month for ~72 hours; the script warns on earlier runs). `post_indexer.py` step 4 runs it via SSM with system `python3`, so its dependencies (`boto3`, `google-analytics-data`) must be installed for that interpreter on the EC2. The two hub stats files upload first; if `item_data_providers.json` cannot be updated the script exits non-zero so post_indexer alerts.
 
 **Environment**: `ES_HOST`, `ES_PORT`, `AWS_PROFILE` (omit on EC2), `GA4_PROPERTY_ID` (required for the item mapping), `GA4_SECRET_NAME` (default `dpla/ga4-service-account`), `GA4_HISTORY_START` (default `2025-07-18`, the `event_label` custom dimension's registration date — GA4 returns nothing before it).
+
+### curated_membership.py - Exhibition and Primary Source Set Membership
+
+Regenerates `src/main/resources/curated/curated-membership.json`, the snapshot the JSONL export uses to stamp `exhibitions` and `primarySourceSets` fields onto index records. It crawls the two curated-content sources:
+
+- Exhibitions: `dpla/dpla-frontend` `exhibitions-data/` — item IDs come from `element_texts` entries named "Has Version"
+- Primary source sets: `dpla/pss-json` `data/` — item IDs come from each source's citation (`dp.la/item/{id}`), falling back to the 32-hex segment of the media `contentUrl`
+
+```bash
+python3 scripts/curated_membership.py [output-path]
+```
+
+Uses only the Python standard library; needs network access to `raw.githubusercontent.com` and `api.github.com`. Re-run when exhibitions or source sets change, then commit the updated snapshot and rebuild the JAR (`sbt assembly`) so the next index build picks it up. Items whose IDs are absent from the index are harmless: the join happens per record at export time, so unmatched IDs are simply never emitted.
+
+**Propagating a refresh:** stamping happens at JSONL export, so after re-running the script and rebuilding the JAR, a JSONL re-export from each hub's latest enrichment output is enough: `./scripts/jsonl.sh <hub>`, then the regular S3 sync and index rebuild. No harvest or full re-ingest is needed. Hubs that are not re-exported keep the old stamp until their next export. The JSONL step logs the snapshot's `generated` timestamp and writes it to the `_MANIFEST`, so a stale JAR is visible after the fact.
+
+**Failure behavior:** fetches retry transient errors (5xx, 429, dropped connections) with backoff; if any slug still fails, the script reports every failure, writes nothing, and exits non-zero, so a partial snapshot cannot be committed by accident. Five consecutive failures abort the run early. It prints a warning for each recovered or unusable item ID (curator typos upstream), for each source that falls back to the media-filename hash, and for slugs outside the usual `[a-z0-9-]` shape — review the warnings after each run. Set `GITHUB_TOKEN` if the unauthenticated GitHub API rate limit is a problem.
 
 ## Testing
 

--- a/scripts/curated_membership.py
+++ b/scripts/curated_membership.py
@@ -52,6 +52,7 @@ import json
 import os
 import re
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.request
@@ -289,9 +290,21 @@ def main() -> int:
         "generated": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "items": dict(sorted(items.items())),
     }
-    with open(output, "w") as f:
-        json.dump(doc, f, indent=2, sort_keys=False)
-        f.write("\n")
+    # Write to a temp file and rename
+    tmp = None
+    try:
+        fd, tmp = tempfile.mkstemp(
+            dir=os.path.dirname(output) or ".", suffix=".tmp"
+        )
+        with os.fdopen(fd, "w") as f:
+            json.dump(doc, f, indent=2, sort_keys=False)
+            f.write("\n")
+        os.chmod(tmp, 0o644)
+        os.replace(tmp, output)
+        tmp = None
+    finally:
+        if tmp is not None and os.path.exists(tmp):
+            os.unlink(tmp)
 
     n_ex = sum(1 for v in items.values() if v["exhibitions"])
     n_pss = sum(1 for v in items.values() if v["primarySourceSets"])

--- a/scripts/curated_membership.py
+++ b/scripts/curated_membership.py
@@ -127,7 +127,8 @@ def exhibition_item_ids(data, slug):
         for block in page.get("page_blocks") or []:
             for att in block.get("attachments") or []:
                 for et in (att.get("item") or {}).get("element_texts") or []:
-                    if (et.get("element") or {}).get("name") != "Has Version":
+                    name = str((et.get("element") or {}).get("name") or "")
+                    if name.strip().lower() != "has version":
                         continue
                     text = (et.get("text") or "").strip().lower()
                     match = HEX32_TOKEN.search(text)

--- a/scripts/curated_membership.py
+++ b/scripts/curated_membership.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""
+Extract exhibition and primary source set membership for DPLA items.
+
+Crawls dpla/dpla-frontend exhibitions-data/ and dpla/pss-json data/ and
+writes one JSON file mapping each referenced DPLA item ID (32-hex) to the
+slugs it appears under:
+
+    {
+      "generated": "2026-08-18T00:00:00Z",
+      "items": {
+        "eb167f4df329081fcbcf0108cd6d6837": {
+          "exhibitions": ["race-to-the-moon"],
+          "primarySourceSets": []
+        },
+        ...
+      }
+    }
+
+The JSONL export reads this file from the JAR classpath and stamps member
+items with `exhibitions` and `primarySourceSets`. To refresh: re-run this
+script, commit the snapshot, rebuild the JAR, then re-export JSONL per hub
+(`./scripts/jsonl.sh <hub>`). No re-ingest needed.
+
+Extraction:
+  - Exhibitions: element_texts entries named "Has Version". Matching is
+    case-insensitive; IDs with stray junk are recovered, unusable
+    hex-like values are warned about.
+  - Source sets: all dp.la/item links in each source's citation, falling
+    back to the 32-hex token of the media filename. Fallback IDs are file
+    hashes that usually, but not always, equal the item ID, so each one
+    is warned about for auditing.
+  - Slugs are taken verbatim; unusual shapes are warned about but kept.
+
+Fetches retry transient failures with backoff. Per-slug failures are
+collected; if any remain, nothing is written and the exit is non-zero.
+Five consecutive failures abort the run. Set GITHUB_TOKEN if the GitHub
+API rate limit (60/hour per IP) is a problem.
+
+Usage:
+    python3 scripts/curated_membership.py [output-path]
+
+    Default output: src/main/resources/curated/curated-membership.json
+    (relative to the repo root; works from any directory)
+
+Stdlib only. Needs network access to raw.githubusercontent.com and
+api.github.com.
+"""
+
+import http.client
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+FRONTEND_RAW = "https://raw.githubusercontent.com/dpla/dpla-frontend/main/exhibitions-data"
+PSS_RAW = "https://raw.githubusercontent.com/dpla/pss-json/main/data"
+PSS_TREES_API = "https://api.github.com/repos/dpla/pss-json/git/trees"
+
+# 32-hex token not inside a longer hex run (rejects SHA-1 slices).
+# Input is lowercased before matching.
+HEX32_TOKEN = re.compile(r"(?<![0-9a-f])[0-9a-f]{32}(?![0-9a-f])")
+CITATION_ID = re.compile(r"dp\.la/item/([0-9a-f]{32})(?![0-9a-f])")
+NEAR_MISS = re.compile(r"[0-9a-f]{24,}")
+USUAL_SLUG = re.compile(r"^[a-z0-9-]+$")
+
+DEFAULT_OUTPUT = str(
+    Path(__file__).resolve().parent.parent
+    / "src/main/resources/curated/curated-membership.json"
+)
+
+RETRIES = 4
+MAX_CONSECUTIVE_FAILURES = 5
+
+
+def warn(message):
+    print(f"WARNING: {message}", file=sys.stderr)
+
+
+def fetch_json(url):
+    """GET a JSON document, retrying transient failures with backoff."""
+    headers = {"User-Agent": "dpla-ingestion3"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token and url.startswith("https://api.github.com/"):
+        headers["Authorization"] = f"Bearer {token}"
+    delay = 2
+    error = None
+    for attempt in range(RETRIES):
+        try:
+            req = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as e:
+            if e.code == 403 and e.headers.get("x-ratelimit-remaining") == "0":
+                raise RuntimeError(
+                    f"GitHub API rate limit exhausted for {url}; wait for "
+                    "the hourly window or set GITHUB_TOKEN"
+                ) from e
+            if e.code < 500 and e.code != 429:
+                raise
+            error = e
+        except (OSError, http.client.HTTPException, json.JSONDecodeError) as e:
+            # URLError/timeouts/resets, mid-body failures, truncated bodies
+            error = e
+        if attempt < RETRIES - 1:
+            print(f"retrying {url}: {error}", file=sys.stderr)
+            time.sleep(delay)
+            delay *= 2
+    raise RuntimeError(f"failed after {RETRIES} attempts: {url}: {error}")
+
+
+def check_slug(slug, origin):
+    if not USUAL_SLUG.match(slug):
+        warn(f"{origin}: unusual slug {slug!r} (kept)")
+    return slug
+
+
+def exhibition_item_ids(data, slug):
+    """Item IDs of one exhibition, from "Has Version" element texts."""
+    ids = set()
+    for page in data.get("pages") or []:
+        for block in page.get("page_blocks") or []:
+            for att in block.get("attachments") or []:
+                for et in (att.get("item") or {}).get("element_texts") or []:
+                    if (et.get("element") or {}).get("name") != "Has Version":
+                        continue
+                    text = (et.get("text") or "").strip().lower()
+                    match = HEX32_TOKEN.search(text)
+                    if match:
+                        ids.add(match.group(0))
+                        if match.group(0) != text:
+                            warn(
+                                f"exhibition {slug}: recovered item ID "
+                                f"{match.group(0)} from {text!r}"
+                            )
+                    elif NEAR_MISS.search(text):
+                        warn(
+                            f"exhibition {slug}: unusable hex-like "
+                            f"Has Version value {text!r}"
+                        )
+    return ids
+
+
+def as_list(value):
+    return value if isinstance(value, list) else [value]
+
+
+def pss_source_ids(part, slug):
+    """Item IDs of one source: citation links first, contentUrl fallback.
+
+    The citation sits at mainEntity[0].citation[] with a misspelled type
+    key, so we regex for dp.la/item links instead of matching keys.
+    """
+    main = [m for m in as_list(part.get("mainEntity") or []) if isinstance(m, dict)]
+    first = main[0] if main else {}
+    ids = CITATION_ID.findall(json.dumps(first.get("citation", "")).lower())
+    if ids:
+        return ids
+    media = [m for m in as_list(first.get("associatedMedia") or []) if isinstance(m, dict)]
+    content_url = str(media[0].get("contentUrl", "")).lower() if media else ""
+    match = HEX32_TOKEN.search(content_url)
+    if match:
+        warn(
+            f"source set {slug}: no citation link; using contentUrl "
+            f"token {match.group(0)} from {content_url!r}"
+        )
+        return [match.group(0)]
+    return []
+
+
+def pss_slugs():
+    """Set slugs from the pss-json data/ tree (no entry-count cap)."""
+    root = fetch_json(f"{PSS_TREES_API}/main")
+    data_sha = next(
+        e["sha"]
+        for e in root["tree"]
+        if e["path"] == "data" and e["type"] == "tree"
+    )
+    tree = fetch_json(f"{PSS_TREES_API}/{data_sha}")
+    if tree.get("truncated"):
+        raise RuntimeError("pss-json data/ tree listing was truncated")
+    return sorted(e["path"] for e in tree["tree"] if e["type"] == "tree")
+
+
+def crawl(slugs, fetch_url, extract_ids, label):
+    """Fetch and parse each slug, collecting failures; abort early when
+    everything is failing."""
+    members = {}
+    failures = []
+    consecutive = 0
+    for slug in slugs:
+        try:
+            data = fetch_json(fetch_url(slug))
+            ids, note = extract_ids(data, slug)
+        except Exception as e:
+            failures.append(f"{label} {slug}: {e}")
+            consecutive += 1
+            if consecutive >= MAX_CONSECUTIVE_FAILURES:
+                failures.append(
+                    f"aborting after {consecutive} consecutive failures"
+                )
+                break
+            continue
+        consecutive = 0
+        for item_id in ids:
+            members.setdefault(item_id, set()).add(slug)
+        print(f"{label} {slug}: {len(ids)} items{note}", file=sys.stderr)
+    return members, failures
+
+
+def exhibition_items():
+    """Return ({item_id: {exhibition slugs}}, failures)."""
+    index = fetch_json(f"{FRONTEND_RAW}/exhibitions.json")
+    slugs = list(dict.fromkeys(
+        check_slug(e["slug"], "exhibitions.json") for e in index["exhibitions"]
+    ))
+    return crawl(
+        slugs,
+        lambda slug: f"{FRONTEND_RAW}/{slug}.json",
+        lambda data, slug: (exhibition_item_ids(data, slug), ""),
+        "exhibition",
+    )
+
+
+def pss_extract(data, slug):
+    ids = set()
+    missed = 0
+    for part in data.get("hasPart") or []:
+        if part.get("disambiguatingDescription") != "source":
+            continue
+        part_ids = pss_source_ids(part, slug)
+        if part_ids:
+            ids.update(part_ids)
+        else:
+            missed += 1
+    note = f", {missed} sources without an ID" if missed else ""
+    return ids, note
+
+
+def pss_items():
+    """Return ({item_id: {source set slugs}}, failures)."""
+    slugs = [check_slug(s, "pss-json data/") for s in pss_slugs()]
+    return crawl(
+        slugs,
+        lambda slug: f"{PSS_RAW}/{slug}/updated_{slug}.json",
+        pss_extract,
+        "source set",
+    )
+
+
+def main() -> int:
+    output = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_OUTPUT
+
+    try:
+        exhibitions, exhibition_failures = exhibition_items()
+        source_sets, pss_failures = pss_items()
+    except RuntimeError as e:
+        warn(str(e))
+        return 1
+
+    failures = exhibition_failures + pss_failures
+    if failures:
+        for failure in failures:
+            warn(f"fetch failed: {failure}")
+        print(
+            f"{len(failures)} failures; not writing {output}",
+            file=sys.stderr,
+        )
+        return 1
+
+    items = {}
+    for field, members in (
+        ("exhibitions", exhibitions),
+        ("primarySourceSets", source_sets),
+    ):
+        for item_id, slugs in members.items():
+            entry = items.setdefault(
+                item_id, {"exhibitions": [], "primarySourceSets": []}
+            )
+            entry[field] = sorted(slugs)
+
+    doc = {
+        "generated": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "items": dict(sorted(items.items())),
+    }
+    with open(output, "w") as f:
+        json.dump(doc, f, indent=2, sort_keys=False)
+        f.write("\n")
+
+    n_ex = sum(1 for v in items.values() if v["exhibitions"])
+    n_pss = sum(1 for v in items.values() if v["primarySourceSets"])
+    print(
+        f"wrote {output}: {len(items)} item IDs "
+        f"({n_ex} in exhibitions, {n_pss} in source sets)",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test-curated-membership.py
+++ b/scripts/tests/test-curated-membership.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Parser tests for curated_membership.py. Run by test-scripts.sh."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "curated_membership.py"
+spec = importlib.util.spec_from_file_location("curated_membership", SCRIPT)
+cm = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cm)
+
+ID_A = "a" * 32
+ID_B = "b" * 32
+ID_C = "c" * 32
+ID_D = "d" * 32
+
+
+def attachment(element_name, text):
+    return {"item": {"element_texts": [{"element": {"name": element_name}, "text": text}]}}
+
+
+def page_of(*attachments):
+    return {"pages": [{"page_blocks": [{"attachments": list(attachments)}]}]}
+
+
+def test_exhibition_parser():
+    data = page_of(
+        attachment("Has Version", ID_A),         # exact case
+        attachment("HAS VERSION", ID_B),         # upper case
+        attachment(" has version ", ID_C),       # case + whitespace
+        attachment("Title", ID_D),               # other element: ignored
+        attachment("Has Version", ID_A.upper()), # uppercase ID: recovered
+        attachment("Has Version", f"{ID_B}?"),   # stray junk: recovered
+        attachment("Has Version", "e" * 31),     # truncated: dropped
+    )
+    ids = cm.exhibition_item_ids(data, "test")
+    assert ids == {ID_A, ID_B, ID_C}, ids
+
+
+def test_null_tolerance():
+    data = {"pages": [{"page_blocks": None}, {"page_blocks": [{"attachments": None}]}]}
+    assert cm.exhibition_item_ids(data, "test") == set()
+
+
+def main():
+    test_exhibition_parser()
+    test_null_tolerance()
+    print("ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test-scripts.sh
+++ b/scripts/tests/test-scripts.sh
@@ -253,6 +253,7 @@ test_python_syntax() {
     local scripts=(
         "generate_hub_stats.py"
         "export_item_attribution.py"
+        "curated_membership.py"
     )
 
     for script in "${scripts[@]}"; do

--- a/scripts/tests/test-scripts.sh
+++ b/scripts/tests/test-scripts.sh
@@ -914,6 +914,16 @@ SQL
 # Test: send-ingest-email.sh --yes flag
 # =============================================================================
 
+test_curated_membership_parser() {
+    echo ""
+    echo "=========================================="
+    echo "  Testing curated_membership.py parser"
+    echo "=========================================="
+
+    run_test "curated_membership parser" \
+        "python3 '$TEST_DIR/test-curated-membership.py'"
+}
+
 test_send_email_yes_flag() {
     echo ""
     echo "=========================================="
@@ -1081,6 +1091,7 @@ main() {
         test_scripts_use_run_entry
         test_nara_scripts_deleted
         test_community_webs_export
+        test_curated_membership_parser
         test_send_email_yes_flag
         test_tailscale_exit_node
     fi

--- a/src/main/resources/curated/curated-membership.json
+++ b/src/main/resources/curated/curated-membership.json
@@ -1,0 +1,21800 @@
+{
+  "generated": "2026-08-18T22:59:21Z",
+  "items": {
+    "0003baba3c1b4837a24bdf1f0a7b37a3": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "00050e6c830653cf21a5f6a1be325476": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "001325e83bb90d3714679a0edf743b83": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "incidents-in-the-life-of-a-slave-girl-by-harriet-jacobs"
+      ]
+    },
+    "002d63fa333000654fed17ec2a8bc25e": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "002fd13d0420cc5ad8bf58d8f867f13f": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "003637194ba5027569b32956fd721ba2": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "005e8c734b5e98e11feb3714dba215ca": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "005f764162b71e611db3fee3cb4aef54": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "0066d2424d66b00aacdab9d43bb6a1f2": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "008074696c243ffba91bd82b5531bc58": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "00851a98f3a44b0dbaef490acdd9a6a0": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "0093857d199d21ee9d81a041af237d20": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "009a4e9eac0a7dddcc3e92fea6a7d9ee": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "00a73d3f722629c87c52b7bf7d9a9bdf": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-woman"
+      ]
+    },
+    "00acaa0d8675c4a4c29fe5d8929f115c": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "00beef769ef6bf868814d74f74299dc7": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "00c4a618e27affb8c950454330a46829": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frank-lloyd-wright-and-modern-american-architecture"
+      ]
+    },
+    "00e442cdd3ea6e3a6debeaa65c8c5d93": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "john-brown-s-raid-on-harper-s-ferry"
+      ]
+    },
+    "00ff77351c6084528cddb07eef320cb5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "commodore-perry-s-expedition-to-japan"
+      ]
+    },
+    "0107a32bb7073b27273f4009fdf69435": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "011bd4b7bc864fb57ed604dad4a4061f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "patronage-and-populism-the-politics-of-the-gilded-age"
+      ]
+    },
+    "0121a1ad73a8a959d88881deb35abce9": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "012b92bc660c995de0b048ffec6688ca": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fifteenth-amendment"
+      ]
+    },
+    "013456168b99c2ced219c2c8fe12b898": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "negro-league-baseball"
+      ]
+    },
+    "013ca4c972acab321edbf8b78887e895": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "015ccdba9b03cf7de83e7fa8d9f8ed20": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "0160f8743aa23fa6848bde8a5f061e75": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "01622eb4195d2c74398e4d37c4a88bdc": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "0189286ee3ac8bb8bc4df4681605ff39": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "0197990bf21f1d72afb7adfc52c3f460": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "01b092b2873139ec776951f5f2e2b9ec": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "01b268d8fd3298f8428c68892d4022e3": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "01c17fd6958276c407c62f48fd853a0f": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "01ca1dacf0d2a52f1e10760d49437951": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "stonewall-and-its-impact-on-the-gay-liberation-movement"
+      ]
+    },
+    "01d2410982ef83ed3ec9a4f174e59f16": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "01d4c559cc76e78cff9caf0fb4d73519": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-woman-warrior-by-maxine-hong-kingston"
+      ]
+    },
+    "01e0da0893e9f0831e3951dbe2d099ff": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-transatlantic-slave-trade"
+      ]
+    },
+    "01e0e9ecfb2168cfe16c2456f18755ff": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-strike"
+      ]
+    },
+    "01e8772986237fa832ba8cc50c6c0299": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scopes-trial"
+      ]
+    },
+    "01f89c4f689f51afc30dd090d996e49c": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "02089f3e3596adf5c3c5e3ddcaa1a1d0": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "020e7ac2693904ec36c98f10ca38cae4": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "021f235c48f23b5b81a93baa54d5a4e2": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "0234f1a735513aeeccf7675da91aa6a8": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "02550ace816c49558616c7dbd1b7a44a": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "0284148ebc9cd38fb855ca4308046d69": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "029d9ba626fc46dc85221b3875919544": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "02aba809b56abbc3f7c77ed7b27a9db3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-absolutely-true-diary-of-a-part-time-indian-by-sherman-alexie"
+      ]
+    },
+    "02b4fdf47043657d48c42eea63e514a6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "when-miners-strike-west-virginia-coal-mining-and-labor-history"
+      ]
+    },
+    "02d068a088ab0000430b577a4fc5a7af": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "texas-revolution"
+      ]
+    },
+    "02d2407af8a2ced5fb704d471488a878": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-women-on-the-home-front"
+      ]
+    },
+    "02dfb0a2afe299e1d5f1414f8241f084": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-raven-by-edgar-allan-poe"
+      ]
+    },
+    "02f49a9b67f1f02d8294de956970a0c8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "john-brown-s-raid-on-harper-s-ferry"
+      ]
+    },
+    "0322cf47466425fd4bcd21ecd5585a70": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "033f4c4c7e8f71e64276c447d2fd2d05": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panama-canal"
+      ]
+    },
+    "034c6b87688c449be84fe5b64e167076": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "0356cb2bd3f6b7da6889b20ab1a21028": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-yellow-fever-epidemic-of-1878"
+      ]
+    },
+    "035e2068918fbbf34e41af8d60497454": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-united-farm-workers-and-the-delano-grape-strike"
+      ]
+    },
+    "0370109a89d6a53335daa5ab049cdd78": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "electrifying-america"
+      ]
+    },
+    "037deccecd946eb92432d8c12fcd8e15": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-indian-boarding-schools"
+      ]
+    },
+    "03afb1e5731d3387db398c54565e2d25": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "03b886838b333db514d0e87f80054c32": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-indian-boarding-schools"
+      ]
+    },
+    "03b8ddd15f132223784d8244827997a5": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "03d5ccb3fabed367346c57567967c0a0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beginnings-of-the-american-red-cross"
+      ]
+    },
+    "03d79e1db64abad43e54f7bab2786540": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "03efc3af78ef73b51b68d7c269bf0032": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "04063a6c5939a91ca6b8dd75607dbe9e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "road-to-revolution-1763-1776"
+      ]
+    },
+    "040a3750db65a5f5bddae82193dfe7c2": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "043b762ba50b6e14fbc47d610c5522a5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "second-ku-klux-klan-and-the-birth-of-a-nation"
+      ]
+    },
+    "044ca6239e243dcb75d8def9842bec39": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "045b9f9bc6a118e11eb7aea7bbc5e516": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "04685bb2fa54b841a9533b5c41dd3306": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "047b80ad6d9f51d164e8b93585e69525": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-hudson-river-school"
+      ]
+    },
+    "0480f352d91b246aff3336f1cbf0af04": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-united-farm-workers-and-the-delano-grape-strike"
+      ]
+    },
+    "0497d2c41291ee16139c6f305ba7f402": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "when-miners-strike-west-virginia-coal-mining-and-labor-history"
+      ]
+    },
+    "0497e1881884020cf7dc66d77efdfeb5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-crucible-by-arthur-miller"
+      ]
+    },
+    "049eff122d7bdd92b693d74aefb40979": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "04bb8eedd94a3fb335a1c64e4f0fca22": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beloved-by-toni-morrison"
+      ]
+    },
+    "04be2268efb7e5804ef00ed125b6a7ba": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "04c0e45baacb7266d0d859075f95eaee": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rock-and-roll-beginnings-to-woodstock"
+      ]
+    },
+    "04c2e6172de078672d1740cfad684f4e": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "04c84fc39fea8519e11dbcc80a830937": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "california-gold-rush"
+      ]
+    },
+    "04d116384719841856d75036a753bddb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "busing-beyond-school-desegregation-in-boston"
+      ]
+    },
+    "04d7d9809c0726bb4a947bb6cb912bf9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "henry-clay-the-great-compromiser"
+      ]
+    },
+    "04fb1b20aa8271e018a7baf7c5c513c5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "nineteenth-century-schools-for-the-deaf-and-blind"
+      ]
+    },
+    "050233a19b080fc21e1fb217f676f361": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "05271b3a1cd86a43f35c2d7cf740d541": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "john-brown-s-raid-on-harper-s-ferry"
+      ]
+    },
+    "05307e1f17898a845b4d4921f369075f": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "053c62f8455821f9683de85c1559c20a": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "053e2477d310990f0617fcb154c112c5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exploration-of-the-americas"
+      ]
+    },
+    "0554cd70c2f11562c830bdc3c674307a": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "055dcf0dce08fd134bc4640ea6f26a8c": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "0565aa021ebe414627b5ca7fddc9d90a": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "0569f4c0477c93bdabb9fce3d982007d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cotton-gin-and-the-expansion-of-slavery"
+      ]
+    },
+    "05864c31390d3d0c73c5a8d60d677c86": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "058c316f3dcc103668ddf7c4d8ef4047": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cross-cultural-colonial-conflicts"
+      ]
+    },
+    "05a279a2301bcd2592ccfb5536d889d5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "creating-the-us-constitution",
+        "shays-rebellion"
+      ]
+    },
+    "05b1d7d948805110986982bbfed56227": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "05cbefd8ca31d89d4b0a2982e7a0953f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "when-miners-strike-west-virginia-coal-mining-and-labor-history"
+      ]
+    },
+    "05de3f7874bff856946771416f3cb161": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "06213177d09a3940d54dcce46b08f99d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-indian-movement-1968-1978"
+      ]
+    },
+    "06229cb578b7b86a9af884345a6fe4c5": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "062f18c09229848c1002bbe3a0c371ea": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-woman"
+      ]
+    },
+    "0630cd3fbb97930b2b0293e199209a58": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "064c046c6648f93f58c0cddf9f42ccf1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beloved-by-toni-morrison"
+      ]
+    },
+    "06535f2d1e7d2431f8187b19fc5c4141": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "067015ab707b76c39a3e459d0656de35": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "settlement-houses-in-the-progressive-era"
+      ]
+    },
+    "0682b7640084f0c5c1df0c7e1d2db12c": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "06a8ed3a1b64555e01ff48346abab83a": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "06dc7ca0e87d85981661c98644e5b585": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-awakening-by-kate-chopin"
+      ]
+    },
+    "06def350a1fa8fff4a426aca94fd2461": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-impact-of-television-on-news-media"
+      ]
+    },
+    "06e4714afb08369029cc3eae25a374e4": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "06f6037e075da31845dabaa8915f51d3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-women-on-the-home-front"
+      ]
+    },
+    "070d673a6a7d48ad0755eb47d5038114": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "070daddc540840e6a0974880b0fb9e02": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "attacks-on-american-soil-pearl-harbor-and-september-11"
+      ]
+    },
+    "071bc74ca90f37fae986ac2653898843": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "california-gold-rush"
+      ]
+    },
+    "07316de970323b445418c64e60d9dbae": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "073d5c5b70a86f92b0d2783e32541239": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-populist-movement"
+      ]
+    },
+    "0740d95aa6f5bbe8768687ef947c0c6f": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "075b968bf7d97cc69ec1813ada737bf4": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "07628fdf50b41c4675c3fe095045b4a5": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "07629c4108c26ec933919616cf63b90b": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "076c94e4403d301fa4e0a949a34812ff": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "henry-clay-the-great-compromiser"
+      ]
+    },
+    "07abad6b48324cea8b4d650ac1a3a2fb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-temperance-movement"
+      ]
+    },
+    "07b64bf6a8653661805c2a77370fe8a6": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "07cab7dd2831f158b24cd9d843c8299c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-emily-dickinson"
+      ]
+    },
+    "07ed41eee439fbbe15c2f1df035162b0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beloved-by-toni-morrison"
+      ]
+    },
+    "07f64078cbdc07afd7f323d5dd8ce7e8": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "08063b7787e1e8ff5d865795e1367608": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-watsons-go-to-birmingham-1963-by-christopher-paul-curtis"
+      ]
+    },
+    "0828a8e664e5e84fe46183536cf7ecdc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-blues"
+      ]
+    },
+    "083ca808a3dcf47924c553d89ccc3da3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exodusters-african-american-migration-to-the-great-plains"
+      ]
+    },
+    "084c2ea7e393f019ace5e2ac7668c926": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "084d16aa60028870578e9fbfec50db87": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "085d7190211f6f6d61a14280ace1a29f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "0876457a1bfdf583447be95f8d66670c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "commodore-perry-s-expedition-to-japan"
+      ]
+    },
+    "087f045611684c4c6df206eb9168115a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-maya-angelou"
+      ]
+    },
+    "088148f1719319057cc0fc97dd69ae1a": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "088f59b5c960a5583fda5666e3e49d56": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "08a2886b3f912c7c3a9f938e055e98ac": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "08a716639c22aa8403516515fd4658fc": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "08a8a525ef6969129b9fd5c11a081f8d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "ida-b-wells-and-anti-lynching-activism"
+      ]
+    },
+    "08c29848250f7d677912cbf8fc652418": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "08d6d28655a3ebfaedb83a0e168193cf": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "08dd6b6ca632cd55664f5d046278b004": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "08f8e2767ca0dc0b87320b607c9e6fb9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-raven-by-edgar-allan-poe"
+      ]
+    },
+    "092bb67eaf6b5fb324078a15bb4e3984": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "when-miners-strike-west-virginia-coal-mining-and-labor-history"
+      ]
+    },
+    "093e03fbe1a87affa69c03f337874b6c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-golden-age-of-broadway"
+      ]
+    },
+    "0940ac296361e723b807d438d53e4f9a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-temperance-movement"
+      ]
+    },
+    "09451d92e3475cea3cb3c6323f6843aa": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "094e5016358f6e292e4454d0a8f12826": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "theodore-dreiser-s-sister-carrie-and-the-urbanization-of-chicago"
+      ]
+    },
+    "0955f8a62fd306724f64aac8e0b4374e": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "095c79bce93eb76ecfa7f24303618bfb": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "09845d50a643ab16da3bf6aa80e68c21": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "uncle-tom-s-cabin-by-harriet-beecher-stowe"
+      ]
+    },
+    "098fcabf9130bc167822ee5b8f49e9d8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "act-up-and-the-aids-crisis"
+      ]
+    },
+    "099091f33b7488a3e87c7ab9dee70e42": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-in-the-civil-war"
+      ]
+    },
+    "09a768e12d4017ce17a46aa5c25c4ecd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scopes-trial"
+      ]
+    },
+    "09a913db94d4c11e1a23db6b4e4cc1d7": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "09bc6b3002c8b4db289cf3c63771a8ea": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "09bfeb948e14fc88dbea8149888c7053": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beloved-by-toni-morrison"
+      ]
+    },
+    "09df4325c631ff0a9e321e588a074aef": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "09f10097793750a000a1aebc55cd60bb": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "0a2056bccad645df0662f137fe8f0ef4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fake-news-in-the-1890s-yellow-journalism"
+      ]
+    },
+    "0a3041caaac9d5210e8c241326f2c6c0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "lyndon-johnson-s-great-society",
+        "voting-rights-act-of-1965"
+      ]
+    },
+    "0a37329ddbeca4fd41134fb40c49517f": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "0a3744186d201fba42906621a56d9cfd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "settlement-houses-in-the-progressive-era"
+      ]
+    },
+    "0a51594403209153cb3c622059c54794": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "act-up-and-the-aids-crisis"
+      ]
+    },
+    "0a54b0d04c5b6e5a53ae5f87edb30258": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "0a8f20360f2f479868650de31aefec42": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "second-ku-klux-klan-and-the-birth-of-a-nation"
+      ]
+    },
+    "0a912741eecd93220de88565dc3cc3ee": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "0aae882f78b56117aaeb2c542165cceb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cuban-immigration-after-the-revolution-1959-1973"
+      ]
+    },
+    "0abb3e55e0fc49ea59240af9e6e1b9cd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-hudson-river-school"
+      ]
+    },
+    "0ac01e17b75269f472852b89d75a2688": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "of-mice-and-men-by-john-steinbeck"
+      ]
+    },
+    "0adde6cfda98cb53be9aaa2ef14b5ff8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scopes-trial"
+      ]
+    },
+    "0ae406469f1ac62d31d6c5f86b0ab197": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-blues"
+      ]
+    },
+    "0aeb208ef5279965018d1412d3395aa1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-indian-movement-1968-1978"
+      ]
+    },
+    "0af2a6ad08c8e0ffbe1ef42ad0165c17": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "0b0b00eb264391e323e67541570c6370": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-atomic-bomb-and-the-nuclear-age"
+      ]
+    },
+    "0b28ec4d3707ef570ca59705508daed3": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "0b39ad5398155d2594cda640d2ff4787": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "0b4511b1dc394dd72019175ac019b629": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-atomic-bomb-and-the-nuclear-age"
+      ]
+    },
+    "0b4a7ff09d3859b2de7e752436a0a51c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "visual-art-during-the-harlem-renaissance"
+      ]
+    },
+    "0b4d7dc8374dae86aebc2d3b9591961e": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "0b65ea56cc2965ac99a0a113ea9a4cc7": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "0b7ded33e0cc54cd1c2a63bebf0a6ebd": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "0ba5c740bb6c31c93a55d1ecc7064e47": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-deal"
+      ]
+    },
+    "0bbf8174183c2515d095e649e5218222": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-strike"
+      ]
+    },
+    "0bc9bd4e1886294b9559953747f924ec": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "0bcce6da233bf0ff0e783238e39ed6dc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-blues"
+      ]
+    },
+    "0bf3a269eca326bbff3edc7fffcd1ec1": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "0bf66d2501a766c813ac1a81925a4fbc": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "0bfa4408fa481a9a3cd8a40a6c514876": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "0c1655137aa011c88477ad841176a416": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "0c18fe3389e3bb2f245735b58901c2db": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "0c8bbcbcd2cfbfd6a693a5278950fd34": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "henry-clay-the-great-compromiser"
+      ]
+    },
+    "0ca23309dbba9fa8adc53b3f479ad3d9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-war-of-1812"
+      ]
+    },
+    "0d0a5a065d9e661929d941e617b2148d": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "0d3b7dd045ca793f5e37c152a2c3cf7e": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "0d69bf39506862a3fe64ec84d2a515e7": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "0d73e428ea8b36caf2e8c231d67c181b": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "0dbb65f0b1cf9b63779bebce6ab158da": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-indian-boarding-schools"
+      ]
+    },
+    "0dd3aa0318aa894d9ae5b9415d2c8c44": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-raven-by-edgar-allan-poe"
+      ]
+    },
+    "0dd8ca0ede4c8fff2d36a256a082f0ed": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "0de2fb82c1ab1d00aa0bdbb82733392d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fifteenth-amendment"
+      ]
+    },
+    "0df6fb71f42cd14ebd18f63cc818bcae": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "0df8b6cf16db2772329cf20f28e6fdad": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-black-power-movement"
+      ]
+    },
+    "0e154c5148dbdc38d2bac32c51c4314e": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "0e18e6343e102b2b09a1d990d9e90f95": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "0e190fa51aa56017b4139edeb9a151bc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-adventures-of-huckleberry-finn-by-mark-twain"
+      ]
+    },
+    "0e433831aaba070ce9ca87b68b153748": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-united-farm-workers-and-the-delano-grape-strike"
+      ]
+    },
+    "0e4625bbcb3657ec45dcea746142bf34": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "0e577b253ecd1571ed9b4adb2fac426d": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "0e5d179427c087217f72e40de07f9b6b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-through-angel-island"
+      ]
+    },
+    "0e6f22dd44c221faeb0cae3fcabcac97": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "of-mice-and-men-by-john-steinbeck"
+      ]
+    },
+    "0e9d6b210da1fb805d3ec20f1d94ea86": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "0e9e0fe5001d3be9d859d093f63bc8aa": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "0ea2a8e543e949ba9ef3cd048ddac343": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "0ea70c1585c8407357d8c1e24bc252d4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cross-cultural-colonial-conflicts"
+      ]
+    },
+    "0eaf856fddb5357352b72fa8f3c1561f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-maya-angelou"
+      ]
+    },
+    "0eca1ffc7a640d31cc44196069e0f5d9": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "0eea529242d56e0e64c15389d8668e5c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-emily-dickinson"
+      ]
+    },
+    "0f04d8cb3485113e961d5cef0c99ad46": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "0f2801d7b2b3fe6e5a49c2afd4a2c53d": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "0f2f81ee1a4931c1c6daba0fc9f34273": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "0f3e456bb903605792e9e819b5ba3369": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-of-the-antebellum-reform-movement"
+      ]
+    },
+    "0f6533aef7c469d39339ac1eb9db4a94": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "latin-american-revolutionaries"
+      ]
+    },
+    "0f7032c62e1cb4b6939694b0a808124c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "space-race"
+      ]
+    },
+    "0f8151ea79f1da44d7cab4db1f03eaaf": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "0f83668a8093ecdebf42b30514ba1b67": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scopes-trial"
+      ]
+    },
+    "0f99ed3633002f93ba8bee051d9a142a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rise-of-conservatism-in-the-1980s"
+      ]
+    },
+    "0f9d4bae9f44a104e6f92100358a78fa": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "0fd86e235ee567ac7acfdfd2b641b18e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-acts"
+      ]
+    },
+    "0fe9e0be81e37f0b4230418081552cee": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "manifest-destiny"
+      ]
+    },
+    "0ff168d44e38466cc1bc80f0a4f25982": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "10001e9505c2a3c3ed9bc1a5106ecf72": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-and-americanization-1880-1930"
+      ]
+    },
+    "100d03d9c341d086f035781c2e42646c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "boomtimes-again-twentieth-century-mining-in-the-mojave-desert"
+      ]
+    },
+    "1012114591b3276d4c81da766119aebf": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-awakening-by-kate-chopin"
+      ]
+    },
+    "102286bbfe540c092d698ec0b6424e5c": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "1024f36f3cccaa575f8590c8554461b7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-migration"
+      ]
+    },
+    "1026a4129c6d2bbc1b972093e1f6fa03": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jacksonian-democracy"
+      ]
+    },
+    "10435a841bff713da5365e30faa4e098": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "10543a1869cea8044d5c5148d668dd72": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "105ae6d30351bd9dd688a66fc073b923": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-yellow-fever-epidemic-of-1878"
+      ]
+    },
+    "108a90f6e2334674e9191c205bfaf663": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "puerto-rican-migration-to-the-us"
+      ]
+    },
+    "1091bb68d1c2b085b694b99b7d845d50": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "109cca757d17b544dde969c4a8f5333d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "elie-wiesel-s-night-and-the-holocaust"
+      ]
+    },
+    "109fd23719577ed75d2fe6a4761aa938": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "10a25d1c62abfbe1ad47bd625c7b5f7b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-war-of-1812"
+      ]
+    },
+    "10b434a30046e6434afd167fe1e41486": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "road-to-revolution-1763-1776"
+      ]
+    },
+    "10d762ff31e50807b24851a379d0bf94": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "10da71c4566997d0daa93655617cf872": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "10dd619da1d38f32224fb4de6785af6c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frederick-douglass-and-abraham-lincoln"
+      ]
+    },
+    "10e839c9ce41447522b427a14b1e74ff": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "10f99c5a7b19f155bd95b08a815e579d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-boston-tea-party"
+      ]
+    },
+    "110c54725ce465342d3926b758eeab57": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "eugenics-movement-in-the-united-states"
+      ]
+    },
+    "1116f257465c9dc317ff6e4a42089f38": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "111e35d26b225b60c79c8b8b9ca14437": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "113e025519c085a669555406d943b126": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "1158c1298519a503c161a52c8d477f87": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "116d5aaf3d77a5d7c5a6c7a3e10c5afe": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "stonewall-and-its-impact-on-the-gay-liberation-movement"
+      ]
+    },
+    "1173cc8f7c4547410bf76baa94a4d26c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "blackface-minstrelsy-in-modern-america"
+      ]
+    },
+    "117a834820285af60413574acd1adcdc": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "117b78d5556bcd958c88cfca1fa0df87": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "patronage-and-populism-the-politics-of-the-gilded-age"
+      ]
+    },
+    "11969c3342610f7877b6df831cd72a67": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "creating-the-us-constitution"
+      ]
+    },
+    "11a76393953a91ea53ff4d4e03061fdc": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "11ad778528e7a39d14b26c6ee909e78d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "their-eyes-were-watching-god-by-zora-neale-hurston"
+      ]
+    },
+    "11cae59c17177a333fd923a94ad302a4": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "11e35c44bb12d089a9a272ca4ae00b83": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "11eb929802a2e7a2729f4c66b92f54b2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frank-lloyd-wright-and-modern-american-architecture"
+      ]
+    },
+    "11f35a933881202ff7acf8587ec8cf06": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panic-of-1837"
+      ]
+    },
+    "11fbbdfe9d9286aa8d353cc904490f12": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "120f5910e4e2256e9bcd312f99442fda": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-united-farm-workers-and-the-delano-grape-strike"
+      ]
+    },
+    "121350a93e7d40c31debed12bccda397": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "123b4db45c9c2528d70ad2b2280f46dd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-whaling-industry"
+      ]
+    },
+    "124aeeae92a9871560ed03ea0c39a5ae": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "124fcaf1127087f0ba3cc872f8e53b67": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "1255a7c6acf2a5759f3f56e2b91ab455": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "12589e8e0ccb07de62be97111f9b7355": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "126c6f0025158f39e950fa4cc9437f8f": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "1279ed276509e7749307a98d0c373bf2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "northern-draft-riots-during-the-civil-war"
+      ]
+    },
+    "1290be67a508ea0e70d7eb4bef1588d8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "spanish-missions-in-california"
+      ]
+    },
+    "12915c2d53a95da5256919783f05aa16": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-s-eastern-front-operation-barbarossa"
+      ]
+    },
+    "129fbca0da4a5fe3154c925edca1d0a4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-indian-movement-1968-1978"
+      ]
+    },
+    "12aa9c107efcbf95019a56319c8d9505": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "treaty-of-versailles-and-the-end-of-world-war-i"
+      ]
+    },
+    "12db290561ec80c3b7eff214a75d1a2f": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "12de9423a9c9cebabd696ff1062a5ba6": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "12ff54fd30d536724007efebc0d4491a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "japanese-american-internment-during-world-war-ii"
+      ]
+    },
+    "1304d7ffd7ecd2d8b921fdc53d42bca6": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "1317643746ac8d64c80c699b0f0890c5": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "1330b337464f8d4a0dffda635a0c62fe": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "voting-rights-act-of-1965"
+      ]
+    },
+    "1333379d39cd5eac24f8efbdce373f54": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "13570a51effde0b7da63dd39d3c65ded": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-maya-angelou"
+      ]
+    },
+    "136a5f5d00cf0054268711f147b980f7": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "1379b3779e8d9758fc76c3f2fb420860": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "spanish-missions-in-california"
+      ]
+    },
+    "1384c7511f26a426f8ae806e7646c9bc": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "1386e033fb8310f32f60f1d76996bfc7": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "139218bf935364c0505b23436a6e30a7": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "13a54052f438d26fdd501d6df2263c80": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "13aaf1077b568990bfaac4f4e698c400": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "13adb3e088676e3518e30b80ae93f752": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "13c722c7d8250dd4caf38e3f8d79a01a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-colonies-motivations-and-realities"
+      ]
+    },
+    "13e8ce743271b42b3a891b2051a5c328": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "14004392c522ea2f777859c3df495c43": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "140a75b9037b11ee3872e478c0c8cee9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "blackface-minstrelsy-in-modern-america"
+      ]
+    },
+    "141ce0f7ead5ed36454d9d3ae5bf1285": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "commodore-perry-s-expedition-to-japan"
+      ]
+    },
+    "143585ca025d51612fef1a22ca7952a7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-yellow-fever-epidemic-of-1878"
+      ]
+    },
+    "146aa6870723c0c1da93c86f779e824a": {
+      "exhibitions": [
+        "industries-settled-montana",
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "147346c99abcafa23682b2cda1506ada": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "148b7038a14007c8fcee006a9593f85a": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "14993f4a5f4167dbc1071e7b90e1cd44": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "when-miners-strike-west-virginia-coal-mining-and-labor-history"
+      ]
+    },
+    "14e1f06f68b9f954a1936424d29673ea": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "perspectives-on-the-french-and-indian-war"
+      ]
+    },
+    "14fd07f680bc574eed5d8fef500ace3d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "busing-beyond-school-desegregation-in-boston"
+      ]
+    },
+    "1516392ddd26bad08aaa1ba2128a93d9": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "151ac1ffae0d2abc17eb808592b7b81f": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "15250ef1ea1ff360166d3549f83786c1": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "1556fbc047740b6fa5e3a2aa61c0fc38": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "156b1f05396af0e7c2466c2e053d4664": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-wounded-knee-massacre"
+      ]
+    },
+    "156d980ed96fdb067bed67aaa716ec1c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "elie-wiesel-s-night-and-the-holocaust"
+      ]
+    },
+    "157ab7a8570db44540356e5a50e5cdc3": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "15a1516adda9f7f1bec4cd108d4ed678": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "15a7c482fb4d7e18699b85ae4019eeec": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "15a9476370ea70d9e111ad5643894a52": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "15ac4fc148c902f32e2ac9e20b11fc6c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "revolutionary-war-turning-points-saratoga-and-valley-forge"
+      ]
+    },
+    "15bcbd9d27f2087d9bb875207b13b305": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "15ec9c8eb0b926edc522a588a48445ab": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "15f9c22fcbf84f40b80eedfd4c7a1c57": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-black-power-movement"
+      ]
+    },
+    "160ba100d97d2f892dfa35f035cd8c16": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "second-ku-klux-klan-and-the-birth-of-a-nation"
+      ]
+    },
+    "16360c59654a4184b6c5a29d6cfb0a15": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "164cf9f8f09435184034210feb4532b5": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "16738a83007e89ef46fbc91f801c18c3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-indian-movement-1968-1978"
+      ]
+    },
+    "167ff2ec7451125518c30b225b919344": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-war-of-1812"
+      ]
+    },
+    "168b2c42ccc46701f8bf7b7811a80f23": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-gatsby-by-f-scott-fitzgerald"
+      ]
+    },
+    "16b2ae2c1b7697ce86bd4c6c5a5bb97a": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "16b45a32de0910d96e5c2ebabf7b4c20": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pablo-picasso-s-guernica-and-modern-war"
+      ]
+    },
+    "16b7f403e09cc8a395b47c2323056dfa": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "16d798dd492f10191665677070fe423a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-yellow-fever-epidemic-of-1878"
+      ]
+    },
+    "16e4e024198247a123a52d5640120d91": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "elie-wiesel-s-night-and-the-holocaust"
+      ]
+    },
+    "16e66ed896e93f911a1adabf6c2fcb1b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "secession-of-the-southern-states"
+      ]
+    },
+    "16ecba93e80ef5a9abb5110abca5ea11": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "16eef617f37d1b765b4b5ec21e07e0b1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "lyndon-johnson-s-great-society"
+      ]
+    },
+    "16f6478dfe3de75461f4fbcff63d5223": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-freedmen-s-bureau"
+      ]
+    },
+    "16fcf98a5a896d45c0c97c44bb7bda79": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "16ff2ebbe5fa1415965b56afdddd4f59": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-s-eastern-front-operation-barbarossa"
+      ]
+    },
+    "1709fc9c16595cdeb3c98bf8dbb86827": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "revolutionary-war-turning-points-saratoga-and-valley-forge"
+      ]
+    },
+    "1710ae8ad4ae0f4d7b732fac8c0f2d6e": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "1752c32add4bd19d020d7909916b0923": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "henry-clay-the-great-compromiser"
+      ]
+    },
+    "175567e2f87b9f4326b2132b4f60a634": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-of-the-antebellum-reform-movement"
+      ]
+    },
+    "1759bf2b858a2e4f60dd3a04c5435be6": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "1767f25493050c2e15293f4bf6d4e087": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "176e11e3b0c4fc816efd50d2959a9098": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "177a265a21eda8f644de7faeed18bc01": {
+      "exhibitions": [
+        "activism",
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "1786baedebfbfd918a7bcd783e36fdf6": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "17916e2d869d9f8a703aadff06faa041": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fake-news-in-the-1890s-yellow-journalism"
+      ]
+    },
+    "1794b1352a08455e79337ef324f692e5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "invisible-man-by-ralph-ellison"
+      ]
+    },
+    "17966231a882eb4bf38cc07b5ea42e5d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "henry-clay-the-great-compromiser"
+      ]
+    },
+    "17994c73bb50d6a86cf5b849a74aa230": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-adventures-of-huckleberry-finn-by-mark-twain"
+      ]
+    },
+    "179de1967e16f135fc8659688e523cca": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "17a5c9c04470311a7d5142c16ee734cd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pop-art-in-the-us"
+      ]
+    },
+    "17d2778e0d9b19ed76b9139bd60cad90": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pablo-picasso-s-guernica-and-modern-war"
+      ]
+    },
+    "17d7dcd4dc98642304fc4f4ed09db9ad": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fannie-lou-hamer-and-the-civil-rights-movement-in-rural-mississippi"
+      ]
+    },
+    "17e2a1f9a95b38213f3163e19c4e00d3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-crucible-by-arthur-miller"
+      ]
+    },
+    "17e38790456017f598a962723187e551": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "180b60472767debbc8c6e08f346d74d6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "colonial-religion"
+      ]
+    },
+    "1834f8bad8535c10c56477b5b077a00a": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "183e0789fb77245e8ac6d7797d950766": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "john-brown-s-raid-on-harper-s-ferry"
+      ]
+    },
+    "18448c4ec781baec912e91cc7d369d91": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "1846d580af362fd91fa5eab0110c1ba1": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "1847d71e7f95e296350b3a503e150c80": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-s-suffrage-the-campaign-for-the-nineteenth-amendment"
+      ]
+    },
+    "1861de7022bb8ffed699d93017742519": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "187f5fb04152b628054296f11ae156fc": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "18829b09f3bdb23c689e8a7f3c6dd072": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "188471c52f642bdcd4595c7b363b654f": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "18a2cdfb12a3e8b2522aef5a4366d9e7": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "18a580829309b1ae372b7274e8268b40": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "18a76762537c3b10403be3bd7e2825c0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "18c383c19e26ced25fede417d448f5c0": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "18c87031097fe672dfeee915e388e74b": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "18c9f0cc478c8f6d349453f990100df8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-transatlantic-slave-trade"
+      ]
+    },
+    "18d261d9026ee8f47e681f4525df0c49": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "18d5fdc8103daa3f0579ef09c104b501": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-atomic-bomb-and-the-nuclear-age"
+      ]
+    },
+    "18e97d0320f25e877aca92e04080f5f9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-atomic-bomb-and-the-nuclear-age"
+      ]
+    },
+    "18ef4d09e5de6d1f24d7ffbe6ebc792a": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "190df356485b21a3a7dd70a44d23e459": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "early-chinese-immigration-to-the-us"
+      ]
+    },
+    "1915bfbaad4a2412ad0efca580f98983": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jitterbugs-swing-kids-and-lindy-hoppers"
+      ]
+    },
+    "192a81366e978745d76ae2b4b42eece2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scopes-trial"
+      ]
+    },
+    "19447869355a890774f7d61abd6560f2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "act-up-and-the-aids-crisis"
+      ]
+    },
+    "1968445e5b5ea1e04aed331cab1d7c80": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fake-news-in-the-1890s-yellow-journalism"
+      ]
+    },
+    "1974c8585ed85f349eebd3516241e84f": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "199ff24e56cb081273571f19c836dd2b": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "19bb96d7634e90dd530727a2bd33a215": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-black-power-movement"
+      ]
+    },
+    "19bc1563d90d8534f0fb1241669433e8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exodusters-african-american-migration-to-the-great-plains"
+      ]
+    },
+    "19c0dd913badcf416f074d53f6657bc6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "latin-american-revolutionaries"
+      ]
+    },
+    "19d3c8f19a87c22a7ac547df2f7b98c1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-abolitionist-movement"
+      ]
+    },
+    "19e72023aded7b41ae4226af7126baa4": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "19fa4d96b851d1ce45b4d6744dffd021": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-lewis-and-clark-expedition"
+      ]
+    },
+    "1a0e1127c5a5447998c77bd04cf3bbba": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "puerto-rican-migration-to-the-us"
+      ]
+    },
+    "1a171bfde0509ce4d32fd415b179b9d4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-women-on-the-home-front"
+      ]
+    },
+    "1a1936c99163e1c212fa797d48b21c15": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "1a2210fb560d7960d8aafdc014d1f9c3": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "1a28740d790124f629f0cc4c656dd031": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "1a5607ac1079ff61afcd6871ac3322ff": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "treaty-of-versailles-and-the-end-of-world-war-i"
+      ]
+    },
+    "1a5fd47af058dd6f6c032d6c71baf61e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-temperance-movement"
+      ]
+    },
+    "1a6f0be51e85e42884bcdb632c20f0f3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "electrifying-america"
+      ]
+    },
+    "1a7102b3eea481f5496a2268aa6957e8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-atomic-bomb-and-the-nuclear-age"
+      ]
+    },
+    "1a80a934a828fa94826e4d9fa4436694": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "1a90bdef89c879357c787c967f0295f4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mormon-migration"
+      ]
+    },
+    "1a90cdd292ec812086fd55dd38e3ae65": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "1a9a26ad10250dd46b1ac84d66670ec9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-invention-of-the-telephone"
+      ]
+    },
+    "1ac81c13345bf7b232351c0db9a5a224": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-populist-movement"
+      ]
+    },
+    "1ae27a3f06eb671070702ae2a04cb3bb": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "1aeefb970f8150fceeebefbf8de7bcfc": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "1af1d37709784b4a51c39430720b6f67": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "blackface-minstrelsy-in-modern-america"
+      ]
+    },
+    "1b04043d979c0d5de7b5a6e6079afe22": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "1b418a2f03529e580daaa158e4bf1e95": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "1b51ac6f3a40b1ac98ea7857e95a326d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pop-art-in-the-us"
+      ]
+    },
+    "1b7e2fbb7aa4ac4910e86c12572f9c7e": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "1b7ea66200ccd4d6db13f970dbda21ed": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "commodore-perry-s-expedition-to-japan"
+      ]
+    },
+    "1bc849d445761e6f45d55a8c8d263919": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "1be36f4f756076b1b880760483a9b836": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "1be8431734c5ddde6792bac75215797d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-and-americanization-1880-1930"
+      ]
+    },
+    "1c0faf9ee9b891f056b7878b1eefc55e": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "1c2141d0bcf7e9583395b78782c12f23": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-black-power-movement"
+      ]
+    },
+    "1c2802b1814464dc8a599ccc950f5a86": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "reservations-resistance-and-the-indian-reorganization-act-1900-1940"
+      ]
+    },
+    "1c2bc0f38804899c6e3b6866edde4adc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "john-brown-s-raid-on-harper-s-ferry"
+      ]
+    },
+    "1c31de7a8b90ec3600fe65c5dd7e825a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-abolitionist-movement"
+      ]
+    },
+    "1c5483d33dcc701f3f4f093d92e058fa": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fifteenth-amendment"
+      ]
+    },
+    "1c549571e42e1f4202a950a3abea8d22": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "1c6bf03e9ead503e52d9cebafd32b752": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": [
+        "early-chinese-immigration-to-the-us"
+      ]
+    },
+    "1c842cc695831369bb24b6ad07a6db49": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "their-eyes-were-watching-god-by-zora-neale-hurston"
+      ]
+    },
+    "1ca0b0adbaf461193a87d93ee7f984c6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "invisible-man-by-ralph-ellison"
+      ]
+    },
+    "1ca86fc8c80f378ffd703603369523aa": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frederick-douglass-and-abraham-lincoln",
+        "secession-of-the-southern-states"
+      ]
+    },
+    "1ca8fde2b2672898a633d290d4118789": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "treaty-of-versailles-and-the-end-of-world-war-i"
+      ]
+    },
+    "1cb137f040bbaf0491b48097e26e2182": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "stonewall-and-its-impact-on-the-gay-liberation-movement"
+      ]
+    },
+    "1ce16546fa6ae2d7583b24503bf35ce0": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "1cf2e42238babce186441a449362f67d": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "1cf6b2ee1d26cf0f5f84247c9e8ad718": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "1cfa77365f32d894b7dc578e7f07eb35": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "act-up-and-the-aids-crisis"
+      ]
+    },
+    "1cfb806be3ed93bafd91b7b312259297": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cross-cultural-colonial-conflicts"
+      ]
+    },
+    "1cff476e1d7379ba2541b736a4626c3e": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "1d00dbeb65eeaf7592a68ba05793606c": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "1d024af8ffd87a3be978d150c3c78a83": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "1d114b6ae9a5bdaf343d8d55524ecaf7": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "1d178923d61d4ec0bae5926368556953": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mormon-migration"
+      ]
+    },
+    "1d42dabc4485bb7e473a9a99d8b35e46": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-through-angel-island"
+      ]
+    },
+    "1d555dd18dd88161ef29ea0e6de1b825": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "1d60818fea1519037a9393088b141287": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "1d6234d5968f2dedb6fc5d625f1a2acc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "spanish-missions-in-california"
+      ]
+    },
+    "1d75bb56917b1cafa8e242454aaa7c97": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "1d842f340a9df1cb5a693955c91db864": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "1dc0703170e170c95723b78924047f39": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "1dc4600dbfc2dd74675762916d2631e5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mexican-labor-and-world-war-ii-the-bracero-program"
+      ]
+    },
+    "1dc8276925e626e926d5e2a7b1d1fe17": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "1dda798003cb702be8c37f8990c91279": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "treaty-of-versailles-and-the-end-of-world-war-i"
+      ]
+    },
+    "1df448dc5e4c288337b6bdcc78c500d8": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "1df8985e78428b0ae7cb8c1e95607317": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "1dfb0841acf410646709f4ffe7e937e7": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "1e2e0891cf8441be3a28539e5c254c4f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "to-kill-a-mockingbird-by-harper-lee"
+      ]
+    },
+    "1e5488468c15e540284438b33458c3a1": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "1e570190219c8385f62f52d8c2d0f703": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "nineteenth-century-schools-for-the-deaf-and-blind"
+      ]
+    },
+    "1e804e436814311628a489a4c1e01a00": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "1ea849fa00ab1dd02ff6426c76ee337f": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "1ebcd2374fbd7f800448956f47fe34be": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "feeding-the-hungry-with-food-stamp-programs"
+      ]
+    },
+    "1ef4a5d10ee94f4c43617cdd0ac6627c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-s-suffrage-the-campaign-for-the-nineteenth-amendment"
+      ]
+    },
+    "1f1683c448c6461e336b03778e1ef1e5": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "1f34be3a6ae3f70996c1c063b31b4396": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panama-canal"
+      ]
+    },
+    "1f421100c2f8c8856fae4bda8e3b4b34": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cuban-immigration-after-the-revolution-1959-1973"
+      ]
+    },
+    "1f5ff5801b8f5d4bdeecb861c8c3d364": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-watsons-go-to-birmingham-1963-by-christopher-paul-curtis"
+      ]
+    },
+    "1f8c36442408800567881b38e963daa0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-adventures-of-huckleberry-finn-by-mark-twain"
+      ]
+    },
+    "1f97d41f69b238d1280580ba359a30ba": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "1fa3a7d86df6c76ccbd35c26934d982f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frank-lloyd-wright-and-modern-american-architecture"
+      ]
+    },
+    "1fa87522d1825caa12552758749b4fc5": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "1fb0961faa7cec6fcb12c30fce53550f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "blackface-minstrelsy-in-modern-america"
+      ]
+    },
+    "1fb79e1798212486069e69fe79edbc74": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-in-the-civil-war"
+      ]
+    },
+    "1fbcf790561e09ed52aa4611430959be": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mexican-labor-and-world-war-ii-the-bracero-program"
+      ]
+    },
+    "1fcd9e47cd2c159802c62c1aa812b299": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "1fe213ffaf54427401a9a51f04253619": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "1fe37ca47d3280db644e9a3cbb9021d4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "environmental-preservation-in-the-progressive-era"
+      ]
+    },
+    "201c1c2a3c84455a202b7f6933b9aafb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "blackface-minstrelsy-in-modern-america"
+      ]
+    },
+    "202cd2eec8a07f914da3df05d75481b7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-migration"
+      ]
+    },
+    "2038b909c3aa4eaf06de84fc59b09d1a": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "203f226205c91e28ac8a3a72b040b42c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "stonewall-and-its-impact-on-the-gay-liberation-movement"
+      ]
+    },
+    "20411e0bf06da70b4803c920ac8fb962": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "2049cc29462014ebd2d47f2c7af8b834": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-transatlantic-slave-trade"
+      ]
+    },
+    "204fb958fd8c3d277595fe604f7b92ed": {
+      "exhibitions": [
+        "children-progressive-era",
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "205c6b0d7e2e9c8e0850e30e6b92a09d": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "20621b83de6b60d41a08045db62207f1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-war-of-1812"
+      ]
+    },
+    "206f0a5b2587f5e003daf5173e712da9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-woman-warrior-by-maxine-hong-kingston"
+      ]
+    },
+    "2076d90e8b831d09be1f8a15aacc13b5": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "2087902360615055dc2de74e593f2879": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fifteenth-amendment"
+      ]
+    },
+    "209f3a00b0e964bd1626270cc59aeaad": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "20a3bfd12be18ab2a0006fa4d3a49ac2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "battle-of-gettysburg"
+      ]
+    },
+    "20cbc5875c409420abc018f147e46c56": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "20d280a956fe6830a7b5fc09a2d364cf": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pablo-picasso-s-guernica-and-modern-war"
+      ]
+    },
+    "21366c1fdc142e9527fde117dd27cf61": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-wounded-knee-massacre"
+      ]
+    },
+    "214215889711d4c1ffa0f54ec047a4ba": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "21442994b981aab0bd6b6fcd1b50330d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "truth-justice-and-the-birth-of-the-superhero-comic-book"
+      ]
+    },
+    "21695220c96d8fd0d08179c4085cd741": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "217681b06beb3c8dfec4fa0fb670bedf": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "invisible-man-by-ralph-ellison"
+      ]
+    },
+    "2186ae505e3ecb9c5958fb034380ab89": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "219139335594683705e4b660332cb3d8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "john-brown-s-raid-on-harper-s-ferry"
+      ]
+    },
+    "219c6b12b27e24d333b5f9becb7c44fc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "theodore-dreiser-s-sister-carrie-and-the-urbanization-of-chicago"
+      ]
+    },
+    "21a1d93c6c1aa8f639efc55d54c8076d": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "21a59a9c40e3c9350d2b4895faf064f2": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "21b28a7a1dff36da98d2f0fd4e4505b1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "there-is-no-cure-for-polio"
+      ]
+    },
+    "21b7687b98d82b893bdec1aeb94491eb": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "21c1dfbf1a65abc4f097fb344efca177": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "21c3c0b577af1c10805c8d0eb07cd49a": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "21c85acd6c0bce801951829c8e61a90d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-golden-age-of-broadway"
+      ]
+    },
+    "21c95fb9fb8f1291a3fd0a4afbcecb5f": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "21e0d2e5ae240e53773eca542901adfe": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-wounded-knee-massacre"
+      ]
+    },
+    "21e27507dfdfe20c2d0d2600ea4abc35": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "21f47216d2ce3b799c7b82b997913283": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "21f484ca9baa33d6aff89488eb45229b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "battle-of-gettysburg"
+      ]
+    },
+    "22028bc9437670fd5d01a454a8f50b9f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-gatsby-by-f-scott-fitzgerald"
+      ]
+    },
+    "2205c724567504c353ac9fd9f8fb3bcf": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "220de8728adb8449ef41e28024a9d97c": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "22211163d966762678f1d592fb597b47": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-strike"
+      ]
+    },
+    "22358ef7a214af616f8a3e6bca055c91": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-strike"
+      ]
+    },
+    "223a4244a63167a03b96f1ca4affbc1c": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "223b0b9143846f9d0fd85bca367f7371": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "their-eyes-were-watching-god-by-zora-neale-hurston"
+      ]
+    },
+    "223df5ae2af0cf7dd7766ec3af4fd2e2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "declaration-of-the-rights-of-man-and-of-the-citizen"
+      ]
+    },
+    "224fe5c9fbe28faa495420fd528a1d2f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "attacks-on-american-soil-pearl-harbor-and-september-11",
+        "japanese-american-internment-during-world-war-ii"
+      ]
+    },
+    "2255483ac4750cbe0ff73c831ed9d96e": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "2262330dca961cd74e8be0613a54a5ed": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "227b3ef5fd3cdb7ae58c9bd4203832b7": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "228180e4b1606ecbd4f10c09d6e13d32": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-lewis-and-clark-expedition"
+      ]
+    },
+    "22a615453157706b901ba07a57517aba": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "22ac696206689574d7545418b5eb41a0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "space-race"
+      ]
+    },
+    "22d74a981c0017941ccc68bb1f8369d2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-yellow-fever-epidemic-of-1878"
+      ]
+    },
+    "22ddc16afea6f975e6e3767184454418": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-golden-age-of-broadway"
+      ]
+    },
+    "22df5bf031df7d0ecc70d3b6e8e79c44": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-woman"
+      ]
+    },
+    "22ebb350e6b1021bbcd911979f6a02e4": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "22edc18381dd45d1f1c301fac232d3cb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-equal-rights-amendment"
+      ]
+    },
+    "22f1ff1b4a0f659a3f34ab7cc36166e2": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "22f988c1c1af74e950adefd392f6cce1": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "22ff9409916d0331b12f4ca3b4166bfd": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "23020894b6cb03840718044e4c94f7e3": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "230d3b822e5d7ae3bdab58ba8df3b7e4": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "231882448a45c6df15da16ec76040602": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "231bcdc5fae501afba6b77e41c0e1f98": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-of-the-antebellum-reform-movement"
+      ]
+    },
+    "2321461a0334888f66a5f9231dc8cd68": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "nineteenth-century-schools-for-the-deaf-and-blind"
+      ]
+    },
+    "233f622623a01a3f975487ae2e239262": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-and-americanization-1880-1930"
+      ]
+    },
+    "23419a844e5c48fb5efb56064020bb0e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fifteenth-amendment"
+      ]
+    },
+    "23575583802faace0974edb8a9afeeab": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "2367253a442e11daa0d4bbdb563e1390": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "theodore-dreiser-s-sister-carrie-and-the-urbanization-of-chicago"
+      ]
+    },
+    "23687ed3133d95505da022ed8b8e9060": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-adventures-of-huckleberry-finn-by-mark-twain"
+      ]
+    },
+    "23aa8f0ca881265c295e798aee13e114": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-adventures-of-huckleberry-finn-by-mark-twain"
+      ]
+    },
+    "23c34a1cb4842e16b0089272f0095348": {
+      "exhibitions": [
+        "civilian-conservation-corps",
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "23d4894972a7638b8a618862cb34aa06": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frederick-douglass-and-abraham-lincoln"
+      ]
+    },
+    "23eafa3e36aadd1f9e9c8f7fbd64e159": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "241fc201377a5ecef6feb25e54c6bd8b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-colonies-motivations-and-realities"
+      ]
+    },
+    "245b80d78e55915f8211fbcc782b6dc4": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "248d1b22fb0e0b1d960be4e66ec37f33": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "24bc1f93952c530dc2c5d0c08ef12427": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "24ccb04ec36b7f8a50f9c2f3e2725e9b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "theodore-dreiser-s-sister-carrie-and-the-urbanization-of-chicago"
+      ]
+    },
+    "24d8f977817ec43b5b6e3f25473f7a57": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "24e3b569cc593957f4394cc78119feb3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-blues"
+      ]
+    },
+    "24ef45c4e81141680fa6098d4b80ac01": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "puerto-rican-migration-to-the-us"
+      ]
+    },
+    "24f3a513398b3431d8beb72932959268": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "24f3c464b9d5ea35800f128ffd1cbdb7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "25001673ad75357401649bc0f17ea391": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jacksonian-democracy"
+      ]
+    },
+    "250467892a3686b51b3d178eb3c6cd08": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "250b7de8727c717d70274df1395c54d0": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "251c662952469252fa7fc7647c763c4e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-war-of-1812"
+      ]
+    },
+    "252e1e2a87d20735eb0354e73d269976": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scopes-trial"
+      ]
+    },
+    "253aa873396cb5a1b9a7602383992189": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "elie-wiesel-s-night-and-the-holocaust"
+      ]
+    },
+    "253c766fdc2fd12f53049bdcceedb8d0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-in-the-civil-war"
+      ]
+    },
+    "2545c9cbe5467d83bd2a0a67f9bc6f38": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fifteenth-amendment"
+      ]
+    },
+    "2567f24102aec410fef9f3cdf17a8c30": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "258d9951496dcad54f1797f4fa3901a7": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "25928248f35434ca3f4b7dc10b682e16": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "25977746f3b1a91b3dfd438346772fc3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-crucible-by-arthur-miller"
+      ]
+    },
+    "25aecd030b7b685e73e3abda732e58fb": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "25bb85b7c1ae55b173a8403157294898": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-strike"
+      ]
+    },
+    "25c72e5cc3511e56e6d6debcc281ad5a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "theodore-dreiser-s-sister-carrie-and-the-urbanization-of-chicago"
+      ]
+    },
+    "25d22a6fbafe0d8dd2675ba69686f63d": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "25e80bf58c80e0fb7a1bc21b98aeb3d1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-absolutely-true-diary-of-a-part-time-indian-by-sherman-alexie"
+      ]
+    },
+    "25ee8fd2567674c4709a7e8d223f6d3b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fire-next-time-by-james-baldwin"
+      ]
+    },
+    "25f4f94122541e882ebfe796f6ce2339": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fake-news-in-the-1890s-yellow-journalism"
+      ]
+    },
+    "262e579ffa724d06225acc67a998ad93": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "2635d7f462b2df9739d404aaca0372d6": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "2638c6ebd7901dd8aab8f24c408918b0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-lewis-and-clark-expedition"
+      ]
+    },
+    "2666c96ea954aa9b3fad4197390643ca": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-absolutely-true-diary-of-a-part-time-indian-by-sherman-alexie"
+      ]
+    },
+    "267485630506a2f64e24049372f76cb7": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "267a1da4582a282c31d27d4c4211986e": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "268250c8be492c98c9b5c80c8ed23e1a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-maya-angelou"
+      ]
+    },
+    "268b161e894a063089d8109006ab88c5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "a-raisin-in-the-sun-by-lorraine-hansberry"
+      ]
+    },
+    "2691452733619460c1e4b2c62f4dae93": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "26a1a4e0715d1e2421fcfaa23ea24e1c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-acts"
+      ]
+    },
+    "26b0678c9984456838354cd2d752fe2c": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "26b228ce01ff48ea0592f7eec4c5fc8b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "manifest-destiny"
+      ]
+    },
+    "26cd41b2140b500e73ca4cecb78c08b8": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "26dc1f2e7d4d404a6e83ea55b57158ec": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "26e7113559b000bc5dc9a79eb9fcb0ad": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "26efbfc69f90674fa0f59b4aea1b40d5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "texas-revolution"
+      ]
+    },
+    "26f6e1a330c83c4fcfa12d77f16a706e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-i-america-heads-to-war"
+      ]
+    },
+    "271cdebf5531f8452a2d207539538231": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "272a5dc69a8e97ea8259a2312e6c9abd": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "274d0176c91db78659ea2b434129c405": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-things-they-carried-by-tim-o-brien"
+      ]
+    },
+    "275b339ff8b469e06f2f143c5258b9dc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-strike"
+      ]
+    },
+    "277c228cc31c918b36aa30812887a5b4": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "277c7b50f6be34451b21262e3468571a": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "277e1483f83ff20f2f21489758daa8d4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "negro-league-baseball"
+      ]
+    },
+    "278dba0fc139b3683a884bf1a5fc2662": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "stonewall-and-its-impact-on-the-gay-liberation-movement"
+      ]
+    },
+    "27a70c44076e4100f9b2e6c90e22bd6f": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "27bf7642485921aee2afa01458bd1e14": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "27dc9d8e25d8e2f7e922dc885510b143": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "27ee9dc494d1a00f4b4c33db6cbc2ec7": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "281aa9fd05a19c11c17beb15985b93a3": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "282264a9afd1541e973624cda3364866": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "282e781dd6b9f9c0d3bca1d3088eb9f2": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "2867d04262429baff54f4bb05eb53b6b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-transatlantic-slave-trade"
+      ]
+    },
+    "286f7cb805a2671e46acb07eb2f49757": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "289ca43a38712690a2a72e283be8bd8f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "environmental-preservation-in-the-progressive-era"
+      ]
+    },
+    "28c5d6d560d88d388761b3a27df1a5ff": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "28d13c93c8b0488b3bab7e2051a407a7": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "28d2e1e10118b258ef9d9f0c7388b8f2": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "29167ea2ba328637bc4aeeda2f115bd3": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "291d5741d7e06fd8adeebc569aece696": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "293c9cd15fa0957146faa138568fbe79": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "2952da97df0b5a5e93c7e2d8c024ae85": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "296c52dda989d05b47106af8e0dae329": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pablo-picasso-s-guernica-and-modern-war"
+      ]
+    },
+    "29a0c030db26ee83dc44255980bfbfb6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "visual-art-during-the-harlem-renaissance"
+      ]
+    },
+    "29f94f05a27aa2c1c3b06d8cc103437a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "puerto-rican-migration-to-the-us"
+      ]
+    },
+    "2a2e9d5b061948baae1db9208e23a87b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mexican-labor-and-world-war-ii-the-bracero-program"
+      ]
+    },
+    "2a4ae363741f59b242effdec58a70faa": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "2a793257a38f62fe08c59da932ce7cf8": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "2a8c4dcae9bc48e9da5bcd5e8269105a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-underground-railroad-and-the-fugitive-slave-act-of-1850"
+      ]
+    },
+    "2a8ca5abfb3e314aaeff15f35e2756c5": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "2a8f813b1b463d4f6fc11a8da2ae444c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-yellow-fever-epidemic-of-1878"
+      ]
+    },
+    "2aadca904efb8cb8f669ad34389a3271": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beginnings-of-the-american-red-cross"
+      ]
+    },
+    "2ab51c2864a33e29447139dc74ff9c26": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "2ae9895546dccc4500dbe84b86e8c3bb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "uncle-tom-s-cabin-by-harriet-beecher-stowe"
+      ]
+    },
+    "2ae98ad15d7fb6ae68740ece545834a5": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "2afdb75ba611457cb4d76cbf991534ea": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "lyndon-johnson-s-great-society"
+      ]
+    },
+    "2b6297fdcb6dc3e50964d772379f8f40": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-columbian-exchange"
+      ]
+    },
+    "2b6c73519b20b6b421fb4f82929c7ed9": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "2b94dd4c1d4d4d779b109d998e60f453": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "attacks-on-american-soil-pearl-harbor-and-september-11"
+      ]
+    },
+    "2bb191f14a5b2b170139141adeef12e1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-s-suffrage-the-campaign-for-the-nineteenth-amendment"
+      ]
+    },
+    "2bf8a17b3871ba70df3304f977f72d70": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-and-americanization-1880-1930"
+      ]
+    },
+    "2c0347daf713f72b45523510612f103c": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "2c2e9e9b46a6aaadaf7e859f1ff65e59": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "2c54e4b3c0f23fa425be5361e3d620de": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "there-is-no-cure-for-polio"
+      ]
+    },
+    "2c656498e4402bcc2b1e2b08c2f7d1c2": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "2c7dd495d3f3cef0358b64c55d34571e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "spanish-missions-in-california"
+      ]
+    },
+    "2c8f6acbf82c0df3b8abff536eeeac7e": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "2ca615deabf76538386fd11386586649": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "2cb85485461ab86890b880f51be7b915": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "stonewall-and-its-impact-on-the-gay-liberation-movement"
+      ]
+    },
+    "2cc8d4eb5e568601d5940c7959561202": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "2cd98351ed1c0a457e03a9ef7d3a6da5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beloved-by-toni-morrison",
+        "the-underground-railroad-and-the-fugitive-slave-act-of-1850"
+      ]
+    },
+    "2cfa2c982cd7913c4114838e045d0f94": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "early-chinese-immigration-to-the-us"
+      ]
+    },
+    "2d2279aef57c934f675ce6bf4fbf88df": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-adventures-of-huckleberry-finn-by-mark-twain"
+      ]
+    },
+    "2d427af35f54afbb97f24bde9ae98e96": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mexican-labor-and-world-war-ii-the-bracero-program"
+      ]
+    },
+    "2d4e8d70bae2562bc0234543855eaad1": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "2d66f2730a6d429727d301a39179758e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "blackface-minstrelsy-in-modern-america"
+      ]
+    },
+    "2da637457d827b93d6d7fa35d2b05741": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-through-angel-island"
+      ]
+    },
+    "2de091351aaf030e48c85136329d84cd": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "2df7486cc347e379865d257f03cc8041": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "2e00d117ba8ac04a3fe8b18c7126b9d9": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "2e179cdd6fca4dcb881e3ef0f9d95ef2": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "2e24679c8731904d5387f1dd66d0617f": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "2e4863880f172f44044dddc09fd233b3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "battle-of-gettysburg"
+      ]
+    },
+    "2e49662fd673cfa94ba16ba51651aeb6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scopes-trial"
+      ]
+    },
+    "2e5945ac8f45d97b9f0de2c7bb6b4886": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "uncle-tom-s-cabin-by-harriet-beecher-stowe"
+      ]
+    },
+    "2e5e6a82ee1133ce415374920efc33b8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "full-steam-ahead-the-steam-engine-and-transportation-in-the-nineteenth-century"
+      ]
+    },
+    "2e7d28b67c8596f494da5b4fe91c67e4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "their-eyes-were-watching-god-by-zora-neale-hurston"
+      ]
+    },
+    "2e7d3643f4f0170b38ba0ff49c60e46a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "environmental-preservation-in-the-progressive-era"
+      ]
+    },
+    "2e82f25b000c818b3d2513324afe7020": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "2e89eac5db87c49e6090af46bd600c00": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-wounded-knee-massacre"
+      ]
+    },
+    "2eae182fda58b6e0f07380d7e505c21b": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "2ed8a9c11740884f99511dbe810869a5": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "2ee2642b36e1015fc0346d1cd1ca26b5": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "2ee3719f4e9ea77f36885f121895e398": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "second-ku-klux-klan-and-the-birth-of-a-nation"
+      ]
+    },
+    "2f154e227771fdcdff3a72d59fa02a5b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "northern-draft-riots-during-the-civil-war"
+      ]
+    },
+    "2f27abaeb79b6d51a21df25a3600523b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-united-farm-workers-and-the-delano-grape-strike"
+      ]
+    },
+    "2f4210a3a7725c81717759b8b05123cb": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "2f66a8b7e96426ccf3ccfde8e56910cd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "john-brown-s-raid-on-harper-s-ferry"
+      ]
+    },
+    "2fa73c3b35d37c1a487e5b916773cc4b": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "2fcfd53baa16b06767ed74a582c46c50": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-raven-by-edgar-allan-poe"
+      ]
+    },
+    "2fd098e499f2bbff48bb634ea020a86f": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "2fd4f861228ecf4998cd2910e0cc772d": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "2febf73a33da17cec2a6a097792ee1df": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "3002eba1f8f8359dbaadf9d163ccb361": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-invention-of-the-telephone"
+      ]
+    },
+    "30071d8f8ed1b2a66f4bbb615f15eaf5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-whaling-industry"
+      ]
+    },
+    "301a3b1ef3135e75f77478cccb7da403": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-migration"
+      ]
+    },
+    "301a6978a42566572279bb5397b5bb30": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rock-and-roll-beginnings-to-woodstock"
+      ]
+    },
+    "304736a2a2f9f655d4bb56f89b00e139": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "electrifying-america"
+      ]
+    },
+    "30596cd3dc88cfe2aafbc47d0618a322": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "3060dff409d9cda62547dc2974826f53": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "30612f8a7fda039108657333ce3a46e1": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "308eb5ab7c4214a0ccb28fb6bfb424b7": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "3098fcf0617466f5ed4de957b0229c8d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-golden-age-of-broadway"
+      ]
+    },
+    "309fefb018344c8921a650939d4c2a3d": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "30a487a62968cd98d7b08cd68368b2b3": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "30bea9d372364a99c97c403419b09275": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "road-to-revolution-1763-1776"
+      ]
+    },
+    "3128366b5bfcdb56a4e122e0a9573615": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scarlet-letter-by-nathaniel-hawthorne"
+      ]
+    },
+    "3136dd54605967d7523a2078231c92ab": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "315073ae27841b1bfce45f6efb970484": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "317c228eb36a09b390f994ed04978f2c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "eugenics-movement-in-the-united-states"
+      ]
+    },
+    "318dfdb4c12448304693d02384447b07": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "perspectives-on-the-french-and-indian-war"
+      ]
+    },
+    "318f0df66f9697faa4f5ef495e9c5018": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-invention-of-the-telephone"
+      ]
+    },
+    "319ef3062457ad0277dff4d78976a92b": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "31a3bd6b15d91910246571320510970a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "secession-of-the-southern-states"
+      ]
+    },
+    "31feddfcd9d80806bf98928bb8d6ff87": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-war-of-1812"
+      ]
+    },
+    "320a00e46599d6d593b999f57fc12000": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "social-realism"
+      ]
+    },
+    "321628078d1ef1264d2981eb740130ca": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "321e721e899b2601b4ed84c7eca583f4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-transatlantic-slave-trade"
+      ]
+    },
+    "3239507048ccf85353a2c7f5c2055871": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-through-angel-island"
+      ]
+    },
+    "324914c997fb853061f9f5c105fe8f1e": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "324fdf1759330928d4a40061d29c1ac2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "incidents-in-the-life-of-a-slave-girl-by-harriet-jacobs"
+      ]
+    },
+    "3260992248924991e48655afdebe0b33": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "326ce0ff91b198cc6c8069ce3c0b9749": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-women-on-the-home-front"
+      ]
+    },
+    "326d34bbd40b7b7b02c520a703eab125": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "space-race"
+      ]
+    },
+    "326d830875bfd381b6206a3891785a7f": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "32837e8b8b3e98cade4dd72add7e2f15": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "their-eyes-were-watching-god-by-zora-neale-hurston"
+      ]
+    },
+    "3286ac6bf2aee85d795e8acc8d686677": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "act-up-and-the-aids-crisis"
+      ]
+    },
+    "329221835a9f94fdcebaee8c27cb435e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "little-women-by-louisa-may-alcott"
+      ]
+    },
+    "32925992c488d83ad6c128ad5a07bb9f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "theodore-dreiser-s-sister-carrie-and-the-urbanization-of-chicago"
+      ]
+    },
+    "3298a91fcad2541dcbe154b9885a8277": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "32e16b83d82a58e335ee6374695b04fd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-atomic-bomb-and-the-nuclear-age"
+      ]
+    },
+    "32f18c47a0740c780d462919f669ed97": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rise-of-conservatism-in-the-1980s"
+      ]
+    },
+    "330d5ccd7f85a84322717dae52651a0b": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "3350eec1fcd162dcf9565919503e3c05": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "3355973de0cc507960c143e20e1866f7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-watsons-go-to-birmingham-1963-by-christopher-paul-curtis"
+      ]
+    },
+    "3357c9e7d1641c68cebe1a645cc3446a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "electrifying-america"
+      ]
+    },
+    "335cc8d7cc08ac9b917d672ae51575d7": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "3369c01c881300a4445a3ef0c4d6b55c": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "337105b2ad3793429563c2dde60db764": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "338368009b36f14433bd567b50037f9a": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "33876f650f88a34035d83f043db39d6f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beginnings-of-the-american-red-cross"
+      ]
+    },
+    "33ab524e4e394072f85346071baff544": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "33c623fd4594ab8cc0852e0b5904679a": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "33d642ae717f106c0375aa24f7d61295": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-women-on-the-home-front"
+      ]
+    },
+    "33d801c8255124dbca0633723537c89e": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "33eecc9a96ea0a126a9d81eb7baca2a8": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "341d5c431d3407c55000327e2e7f8465": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "3420c6a58eb17c992594e2e0f110980e": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "3420f07c27d02333e3297c193ce664db": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mexican-labor-and-world-war-ii-the-bracero-program"
+      ]
+    },
+    "34272beee0dcdcf7582ef74fe65b6c66": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-i-america-heads-to-war"
+      ]
+    },
+    "342edc134a610ef9ffc3a088f7636509": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "declaration-of-the-rights-of-man-and-of-the-citizen"
+      ]
+    },
+    "3433ddaab9676743626b8f7130e67da6": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "343aa7d1a22f2435206bcc935c608f5e": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "34414c5a6b7d8567f5db32d3a0053922": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-temperance-movement"
+      ]
+    },
+    "346a146a59761d6b16e2d6e3fad0b22a": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "348e76ea6a440de43ed2175a01c2612d": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": [
+        "early-chinese-immigration-to-the-us"
+      ]
+    },
+    "34b78d4dec981af563e04add5b880ed5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-acts"
+      ]
+    },
+    "34bc9a9a613d4d08175dbb9511b15363": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "second-ku-klux-klan-and-the-birth-of-a-nation"
+      ]
+    },
+    "34bfda5fc87fa942da3d2d0795bad709": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scopes-trial"
+      ]
+    },
+    "34c2416cee4173fd2d7fa57ad88aa2aa": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "34c2d6fbd090f41e842b847d0e9ca751": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "blackface-minstrelsy-in-modern-america"
+      ]
+    },
+    "34cad62f54a3f1d8d6bbf533ae6a519e": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "34f0124dbc897c2f132b692cf8ad0baf": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jacksonian-democracy"
+      ]
+    },
+    "34f13ac3d2993f1dc84177a6f358f852": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "34f340f27814f55833c885a8258fea88": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fannie-lou-hamer-and-the-civil-rights-movement-in-rural-mississippi"
+      ]
+    },
+    "350283f9c1b065e3030901942700eacf": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "350445b6eb8b15f1189a778576f29b34": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "3506b28f1d8959b62bb83fa7f38949ac": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "road-to-revolution-1763-1776"
+      ]
+    },
+    "3521290ccda0810063ad530600d87f61": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "stonewall-and-its-impact-on-the-gay-liberation-movement"
+      ]
+    },
+    "352b22c62314cc50a42f1a42e40d9920": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panic-of-1837"
+      ]
+    },
+    "353ab02ebff716f11970fdbc34846ce2": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "354082800b05767018c36e831a0ffc09": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "35629183857b6cb8b1af2ff1b5c65ef5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "california-gold-rush"
+      ]
+    },
+    "356dd2b2c318812779d673d5ae6b3836": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "356f3e56d09c5a8aa3da628e6844822b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fire-next-time-by-james-baldwin",
+        "the-watsons-go-to-birmingham-1963-by-christopher-paul-curtis"
+      ]
+    },
+    "3588600987f13d1e3cf5fe693dd87940": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-things-they-carried-by-tim-o-brien"
+      ]
+    },
+    "35903f5bdc3b02db79d80c638f30e8d0": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "35af724aaa33febf59de97b639eea351": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scarlet-letter-by-nathaniel-hawthorne"
+      ]
+    },
+    "35b35b794c8f639d385d80e2033ee9a3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cherokee-removal-and-the-trail-of-tears"
+      ]
+    },
+    "35ba8ad3ad1d03bd967270d5fa70e9a0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-colonies-motivations-and-realities"
+      ]
+    },
+    "35d7a3cd6c9c04b5ca8c0b324d343248": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "35ece19593244b3f3e772ec4414e0058": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": [
+        "early-chinese-immigration-to-the-us"
+      ]
+    },
+    "3611748d27ece22bd6c6c3dc3a72bda0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-deal"
+      ]
+    },
+    "3621c4a22794f1bb4d3addc21238ccd0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "african-american-soldiers-in-world-war-i"
+      ]
+    },
+    "362795d05c0dfbaebb8b9a62b82eefe4": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "36385df7705061c5f32a340243f00451": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-underground-railroad-and-the-fugitive-slave-act-of-1850"
+      ]
+    },
+    "36455d4123e690fc899f05a180ce27e4": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "365de4424b930f122ad41e5918e737ab": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "lyndon-johnson-s-great-society"
+      ]
+    },
+    "3684f31022f36d1e8fd92823af223141": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "secession-of-the-southern-states"
+      ]
+    },
+    "369e53bcbbd08bb928f7e9afcef0eb32": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "36af0c2974e907243d82f41efaf62d5c": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "36afd75f814fb54825308931724f4d50": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cross-cultural-colonial-conflicts"
+      ]
+    },
+    "36c287dedd4b81c842806f728f27f667": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "36d294e0dd2345946f2efaeff65d9565": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "36d36c106b5304cd162f5d3db910f2a3": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "36dcf7d739d7f3eb0f6c7e8dbab6171a": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "36e061dbad35b4706866879041c6e07f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "commodore-perry-s-expedition-to-japan"
+      ]
+    },
+    "36e0c9d77e6dac5be2f1a1316fc156bd": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "36ebb134a219d66006177434a833344e": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "3712d620c5692ec51b4ad4e36d59b3f5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-freedmen-s-bureau"
+      ]
+    },
+    "372b54df3dc6460f39432921ed823cc6": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "372eb800752f2c74307ba9d51a9b2a8e": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "3762ef963cb02760fbba9e54f44e6569": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "electrifying-america"
+      ]
+    },
+    "37799c8593bdf9c5bb387608f29ac535": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-equal-rights-amendment"
+      ]
+    },
+    "3783fc39fd7ee449e1816748a1b8f754": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "379ae7a077efa6ef5841b2c4c6141c5b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-s-suffrage-the-campaign-for-the-nineteenth-amendment"
+      ]
+    },
+    "37aafbaa7460eee190752c27f7fb4b9f": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "37fb80fa472406a619b09c244a4c6f33": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "3813293a8cb6e940012720ea0b0b7aaa": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "382276bc086956b5a4721086faaa644a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-gatsby-by-f-scott-fitzgerald"
+      ]
+    },
+    "3831d1fb9f6b2b26755bc25de27438b8": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "3831d3d4038acb1a1db2f48ec1e138c8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "negro-league-baseball"
+      ]
+    },
+    "3838b56bc93ed7ec4369da95c36116b4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-crucible-by-arthur-miller"
+      ]
+    },
+    "38394eb040bf067899f73d1067ca141c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "truth-justice-and-the-birth-of-the-superhero-comic-book"
+      ]
+    },
+    "386e0afddc3bfc3640f60d5c98a9ac96": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "38863f4b666e63534ee1cc724fbdf14a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scopes-trial"
+      ]
+    },
+    "3890c39994573a710760f664edd17319": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "revolutionary-war-turning-points-saratoga-and-valley-forge"
+      ]
+    },
+    "38995d92879a30bf034fcd4ce19aeea6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "electrifying-america"
+      ]
+    },
+    "389a7b8927f63c73b284d6aafbd857d4": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "38a9d43efffefdeffe173b4c63fbbbfe": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "38ac8450e1529ec01d2d01b3a65605ea": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "38af90d3a1a85936681a7d8bd156f6a3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "perspectives-on-the-french-and-indian-war"
+      ]
+    },
+    "38bb1c7ccb3dcb8fbe1fde54faa27df9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "shays-rebellion"
+      ]
+    },
+    "38bcaec371dfd44c53007e0ea1731ce3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "a-raisin-in-the-sun-by-lorraine-hansberry"
+      ]
+    },
+    "38ce80e2e29144df310931b59c80cce5": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "391d6fe89977ed02590028776493b6f3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-indian-boarding-schools"
+      ]
+    },
+    "39226cc1337cd41c173f3c5697764821": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mexican-labor-and-world-war-ii-the-bracero-program"
+      ]
+    },
+    "3924845a657709a891a02637fb2dc4c8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-wounded-knee-massacre"
+      ]
+    },
+    "3938777c495b26a71783d79768c5e403": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "northern-draft-riots-during-the-civil-war"
+      ]
+    },
+    "393997de0829bfbcf8b16f98a62f583c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "negro-league-baseball"
+      ]
+    },
+    "398682dd1341f741b28b494662a319d9": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "3986f996243a4766faa9d6703a090a2d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "revolutionary-war-turning-points-saratoga-and-valley-forge"
+      ]
+    },
+    "399a03e9ddefdd85d36816c4312422ae": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "39a345dfc3ee4a04b7a63dd79b7cf282": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "full-steam-ahead-the-steam-engine-and-transportation-in-the-nineteenth-century"
+      ]
+    },
+    "39a6ece6d93df9547fd46851b7862543": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "california-gold-rush"
+      ]
+    },
+    "39a8f85089742e0ab5a70c875887221a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-colonies-motivations-and-realities"
+      ]
+    },
+    "39b158abb05c69f80896c6525173e1ad": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "39b7b7c155adb4c201ee165abd6d2057": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "39b933da962f5872fe7981fe8858a5ef": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "39e0460fea6615962171e2e38461cb6c": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "39e08bda4e62ef2b3c14743369a555ba": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "3a18200fe19aed2f57f6d94b11b704f2": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "3a274274a2dcc61742de2e199e77e1bd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "california-gold-rush"
+      ]
+    },
+    "3a3d9e7f99ef3221f190c1329a3e1fdb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "japanese-american-internment-during-world-war-ii"
+      ]
+    },
+    "3a7916ef82a8a8c2248b7846a56417a3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "their-eyes-were-watching-god-by-zora-neale-hurston"
+      ]
+    },
+    "3aaf63161438c7dee2494680125fd45e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "stonewall-and-its-impact-on-the-gay-liberation-movement"
+      ]
+    },
+    "3ad3bbd46b0669139ec795be63f6d916": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "3ad71ae27b99f44288cafec14a1971aa": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-women-on-the-home-front"
+      ]
+    },
+    "3afde2f1821179fe30c3b6ffe16a8356": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "3b0dd5fad770c43c8674165846884599": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "colonial-religion"
+      ]
+    },
+    "3b1586f3cd682bb0d66d6d62f7a745d2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-woman"
+      ]
+    },
+    "3b3d13f9c94d8b3bb281915ba9258304": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "road-to-revolution-1763-1776"
+      ]
+    },
+    "3b40d9eed07a397d09ce8119fa730a84": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-raven-by-edgar-allan-poe"
+      ]
+    },
+    "3b5c575778310ada597c936e43746f99": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": [
+        "dutch-new-netherland"
+      ]
+    },
+    "3b848191b9cf73cee571f86c8c878d41": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "3b87383d36ac55406ccd0c1751baeded": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": [
+        "the-lewis-and-clark-expedition"
+      ]
+    },
+    "3b9465b3541c1739daf98d6cfb44b58c": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "3ba8884ba4d76932c8ca799b587ef0ac": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "3bc473f2b9e8a3323711479cb9743dbf": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-and-americanization-1880-1930"
+      ]
+    },
+    "3bec2402885da0bdb93d707edbb2e866": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "3bee3454e351bc4ebfacfac22e0b6119": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "3bf36f61f87351fc633590d87af2c792": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-crucible-by-arthur-miller"
+      ]
+    },
+    "3bffc1f65a90a6b39062f18de46a5001": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "feeding-the-hungry-with-food-stamp-programs"
+      ]
+    },
+    "3c08623654ccde2420d01709b977f5cd": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "3c10259006d6fe26109761d10636ae22": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "3c222dfa2a9e34cdb4cc189d6ba244b4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "visual-art-during-the-harlem-renaissance"
+      ]
+    },
+    "3c41c7265f7ae47edbcf8245b219f542": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-s-suffrage-the-campaign-for-the-nineteenth-amendment"
+      ]
+    },
+    "3c55bade11db1a2d81197a0c4ae04cf4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "electrifying-america"
+      ]
+    },
+    "3c7906a5a529d8b0b1b1300b47f68ab1": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "3c8494c02fd0cec7df1a0396e9dc95ca": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "to-kill-a-mockingbird-by-harper-lee"
+      ]
+    },
+    "3c8968758c39c8e1dbd602a4354ab336": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "african-american-soldiers-in-world-war-i"
+      ]
+    },
+    "3c9e4baab087642be1e9ffa655221d8f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-absolutely-true-diary-of-a-part-time-indian-by-sherman-alexie"
+      ]
+    },
+    "3ca1588a9e90a3a9511818aaa976a037": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-underground-railroad-and-the-fugitive-slave-act-of-1850"
+      ]
+    },
+    "3ca96697d9eed5b2c8f32e755ffc43ef": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "puerto-rican-migration-to-the-us"
+      ]
+    },
+    "3cb0f6d06712467d38bad9a10766ea92": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "3cc19ca5368553bd0f40930caf47cf21": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "3cca1b8cc11e2a88e1013301675cb6ad": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "3cd2cbb1ab0780dcd53036ead7ea8fa0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-whaling-industry"
+      ]
+    },
+    "3ce7fe6f7d005d0fd7d3a4768152aa1c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "ida-b-wells-and-anti-lynching-activism"
+      ]
+    },
+    "3cee922acee1b5d3da5211a26fe9ad05": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-black-power-movement"
+      ]
+    },
+    "3cf8cc9478fd80c32edfff943e850860": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "3cf9b9053917758ed72d169d279a1070": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "3d21b5cd0b85ea04ff9bf422e7f58825": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "3d48627ccd5e0603bfed7fd801002e8e": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "3d6d50a15ba673a319ff473cc275e765": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "boomtimes-again-twentieth-century-mining-in-the-mojave-desert"
+      ]
+    },
+    "3d796041fb6e72897426c30421be1f6c": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "3d90a7c2044a60a8c57d678da3414458": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "3dabb1dde622d9723247e1fa2df3c0bf": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cuban-immigration-after-the-revolution-1959-1973"
+      ]
+    },
+    "3dc2a137df695502e957801296262740": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "elie-wiesel-s-night-and-the-holocaust"
+      ]
+    },
+    "3dc83918776455b07fda4ecc0579f95a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rock-and-roll-beginnings-to-woodstock"
+      ]
+    },
+    "3df59bdae51249d54d06ff362a27a17a": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "3e1f2069c204e58abdeda981c57f4aa6": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "3e21cdb9a03b06904409b27f765fc9b1": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "3e2daca69e9633b9b56938d303ad9f7b": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "3e335f54c2c9f5509da3df129f471fd8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-blues"
+      ]
+    },
+    "3e4e1ab69e26e7a5c1afa298dcdbb306": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-rise-of-italian-fascism-and-its-influence-on-europe"
+      ]
+    },
+    "3e4f991e93db4673247a0c4d4bea2115": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exodusters-african-american-migration-to-the-great-plains"
+      ]
+    },
+    "3e57954f12b64e6e8d52460f7eb3505b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "african-american-soldiers-in-world-war-i"
+      ]
+    },
+    "3e5a3f548b03657284f7dafc8cb06a95": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "3e5e8644235097e38fc03c529510e199": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fannie-lou-hamer-and-the-civil-rights-movement-in-rural-mississippi"
+      ]
+    },
+    "3e7613be8587745f03f3433799fbf13b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jacksonian-democracy"
+      ]
+    },
+    "3e7d2ed78002a923b52fc3a4ac9d554d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "powhatan-people-and-the-english-at-jamestown"
+      ]
+    },
+    "3e82d09db3d97a4a5b722310d0a5eb3a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-whaling-industry"
+      ]
+    },
+    "3eb84eb6bf24ef314f4a947c90b9bba1": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "3ecc9fa82385238770a81071e23f4c33": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "3ee047c49dca67b96ad4faa2e2e74f6f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "texas-revolution"
+      ]
+    },
+    "3effd9e0013078b8321ff1595dcd3a93": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "3f00bb5b33a018eb8c2a38c8cbdfce39": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "latin-american-revolutionaries"
+      ]
+    },
+    "3f02881a24a44b8c0151c6e32ec9a839": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beginnings-of-the-american-red-cross"
+      ]
+    },
+    "3f10d60366f9fc2cde64d0ab10bb033f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-woman"
+      ]
+    },
+    "3f144856d6cc71e6a7df2e3969142beb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "powhatan-people-and-the-english-at-jamestown"
+      ]
+    },
+    "3f4d5d3a67f8ce16f1b00b3cb01dc143": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "ida-b-wells-and-anti-lynching-activism"
+      ]
+    },
+    "3f5f124b65ddb14808d124190e774dd3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "texas-revolution"
+      ]
+    },
+    "3f62c9c544e8b0450311cfbac5451790": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "3fd0980829ee5797a40c9190e1791708": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "3fd67386f8586e86409de1e4b81d6dd7": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "3fe33200d053213447985636af62a0af": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rock-and-roll-beginnings-to-woodstock"
+      ]
+    },
+    "3ff00f75a69470d1dcc849a84f0a7701": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cuban-immigration-after-the-revolution-1959-1973"
+      ]
+    },
+    "3ff0dd8b69d0418d156f974914471c0c": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "3ff5ef81f2c500ef08d660fc834c639c": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "3ffda732d3255c6bde171211b5e55b39": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "japanese-american-internment-during-world-war-ii"
+      ]
+    },
+    "40205cd0814b5bc3588998c3e64816be": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "40523f5a3602bc282c6ac3ba5875c868": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "nineteenth-century-schools-for-the-deaf-and-blind"
+      ]
+    },
+    "405714d95f606141d383ccc3ef22908b": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "4098f1bd9edec05235f8268f55fe05e5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frank-lloyd-wright-and-modern-american-architecture"
+      ]
+    },
+    "409a86384aa96ce59ca061cdabfdc1f0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "john-brown-s-raid-on-harper-s-ferry"
+      ]
+    },
+    "409d9fb417e19e6ba1bde258a97615fe": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "40a6414143c05f4050c90f26198958fa": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "40a78d9607b5e00a270dffa9ff76a45a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-yellow-fever-epidemic-of-1878"
+      ]
+    },
+    "40d04297b7848580a286acd111c6ad49": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panama-canal"
+      ]
+    },
+    "40d3c9d24fab27673716e8e248b9ea3d": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "40dc9b5bbf264a5171a8282d00b86a5a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cross-cultural-colonial-conflicts"
+      ]
+    },
+    "40e3fa9859b19c91897c67578076b2ba": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "40e57fad4ba46243442a7beee9079b6d": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "40e8cf58ca4afb1864a4cf6ccc39eaea": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "treaty-of-versailles-and-the-end-of-world-war-i"
+      ]
+    },
+    "40fa0369c9e16dcdc77ca0b5f2a7ff92": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "attacks-on-american-soil-pearl-harbor-and-september-11"
+      ]
+    },
+    "41033d13a61df7a3b49d000272be1854": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": [
+        "second-ku-klux-klan-and-the-birth-of-a-nation"
+      ]
+    },
+    "41075881f70ea42af4555946ee1f7ff6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panama-canal"
+      ]
+    },
+    "411bf45e1b715b7ed13852eca59bf509": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-deal"
+      ]
+    },
+    "414c019cb476c51e42a5a1cf6b3c1bbb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exodusters-african-american-migration-to-the-great-plains"
+      ]
+    },
+    "4159942f169e05ec6adddfc8d1cf23fd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "puerto-rican-migration-to-the-us"
+      ]
+    },
+    "41a79f155f851b87d442082d84b171cd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-golden-age-of-broadway"
+      ]
+    },
+    "41acf623aa6ce188822f30e01d40f1c0": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "41b52e5630b4839dc5e1e6a8fbcc53bb": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "41eb45e147711bf35cfae9ec289b3a56": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exploration-of-the-americas"
+      ]
+    },
+    "41ed027ec33c9acea49055297d6e2df7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "northern-draft-riots-during-the-civil-war"
+      ]
+    },
+    "41f1a07f9dd7ebcac73f0bf0b71ad7ce": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "41f7892e7fb48afb06332dc2b92245b2": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "41fa9078b2eb774d4f6c4caecd2171cb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-emily-dickinson"
+      ]
+    },
+    "42176092d46b11fb9b8fd7aad74c78f7": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "42238d219a7a6b827e732b0c24f3c22f": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "42390111ff34a2276976662db15764a4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "4241d72c30e3e08b74fc5ca2b5e31692": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "to-kill-a-mockingbird-by-harper-lee"
+      ]
+    },
+    "42556e961a85fa419dc5e330bff57815": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-awakening-by-kate-chopin"
+      ]
+    },
+    "42711a39347b7136e25d3a868f5a81fe": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "428234dc4c2ea69bcdc016f9544f3bc4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "dutch-new-netherland"
+      ]
+    },
+    "4296fb5a3331e9dc73338d3a63994383": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "429da0b92911c6afe5cd20edf9e39c47": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-things-they-carried-by-tim-o-brien"
+      ]
+    },
+    "42a2437f78b1ca43999f84c0fd1e1dac": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-woman"
+      ]
+    },
+    "42a75b49dd1b96b9a7e68c9dac349c5a": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "42b9a89ba4e76579c0d8786c407cd5a8": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "42bdf020196e1cfb3f25e9a1cb3bcc8d": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "42eb97b62b1ca6d984c0cc814c019cca": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exodusters-african-american-migration-to-the-great-plains"
+      ]
+    },
+    "42ff1aeae1c868dbefd51af901ed1748": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "43038b7e46781ef2a77dee8cccb800e8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pop-art-in-the-us"
+      ]
+    },
+    "431204605ab0e34e540efa63f0d01201": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-war-of-1812"
+      ]
+    },
+    "432fed94b02e2489f218056485d76110": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "visual-art-during-the-harlem-renaissance"
+      ]
+    },
+    "433a69a9d2611d40ca77b924cff99d84": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "433b93922a33e4bbfc2c33746a24568a": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "4344f37c2002b2fa74b48bb8c0d29ce9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-temperance-movement"
+      ]
+    },
+    "435a31f3df5913828b201341aef4bc73": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "postwar-rise-of-the-suburbs"
+      ]
+    },
+    "435b6fad8649852dff0ec1024ca1f345": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "435fb67011d689b960d2a6af88fb1e65": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "436d3d05315f79f9981ca40bee66d3e6": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "437f6df16c6cceece513b3c4f45bcd99": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "uncle-tom-s-cabin-by-harriet-beecher-stowe"
+      ]
+    },
+    "4382562cadbeb76d321a24f848c919cf": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "4399bf0bc1a0c92338e1837e8a9e8792": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "43abd207874e1483beb7ac08d0fa3efe": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-s-eastern-front-operation-barbarossa"
+      ]
+    },
+    "43b12adae3aff44a69c00f2702fbf294": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "43b6d1b04584882b6830beea45a37e7e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-s-suffrage-the-campaign-for-the-nineteenth-amendment"
+      ]
+    },
+    "43e6e34472eebb265915aee259e28233": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "43f91dc3fa76d0fcaaeef41f8a60d9d2": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "44247c7ed3759c836a4481bc8d17c27b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "incidents-in-the-life-of-a-slave-girl-by-harriet-jacobs"
+      ]
+    },
+    "4425d27b4ecaa432ab6a44cbf9338660": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-underground-railroad-and-the-fugitive-slave-act-of-1850"
+      ]
+    },
+    "4428bb63d34b70e367b1eae8b3a8b19a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "little-women-by-louisa-may-alcott"
+      ]
+    },
+    "443629569c1f46a54048e1a4afcb2d7a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pop-art-in-the-us"
+      ]
+    },
+    "443c4683dcbdf0d244c46e63d13312a1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "their-eyes-were-watching-god-by-zora-neale-hurston"
+      ]
+    },
+    "44449c61ab8dcfb2fd1aeab6e61be33c": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "444a344ecc4637ef8e5e2822f88fa8fb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "settlement-houses-in-the-progressive-era"
+      ]
+    },
+    "444dcfc8ae4637bd2a76aa82e85fff98": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "445adace00bd0aa30a1284aa00a72bb4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frederick-douglass-and-abraham-lincoln"
+      ]
+    },
+    "447a8d01e4271f5903fc23097638c5ab": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "electrifying-america"
+      ]
+    },
+    "447abc1ea9287b36e1473ca36f35a64b": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "447fc550246ea9731b39edfebbe596be": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "448621cb7f3a0974ad907cf0cd90912b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mormon-migration"
+      ]
+    },
+    "44888ef79a4043f8e02f4f92d35a9ca5": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "448b87bdfec94bfb2a285a259381f830": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "44a5e2057ad83bd7d946cf672f82ac86": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "44d8693ce176b0a7b01f32cd5965ea48": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "44e5958dd130086c9ce3bb967dcc97dd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-populist-movement"
+      ]
+    },
+    "44e97c13e71f6236d04e259e95724e2f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-through-angel-island"
+      ]
+    },
+    "44f9c0085c6cdb04886877b89ed63edf": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pablo-picasso-s-guernica-and-modern-war"
+      ]
+    },
+    "452eaab716d4160d1bb7f0298d79449e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fannie-lou-hamer-and-the-civil-rights-movement-in-rural-mississippi"
+      ]
+    },
+    "456128b20b202a2759f17a4fa27073ba": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-migration"
+      ]
+    },
+    "4573304fbab01ebd6f4b90de845c20ba": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "busing-beyond-school-desegregation-in-boston"
+      ]
+    },
+    "4580df66daf5f8a39ec25d1940b51060": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-absolutely-true-diary-of-a-part-time-indian-by-sherman-alexie"
+      ]
+    },
+    "45839d0c9f2c0465f0c85259b25feab3": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "4583efc79963e455116926ba5c8b7584": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "45d0cddaa6b0f1339c4f8f5631166612": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "patronage-and-populism-the-politics-of-the-gilded-age"
+      ]
+    },
+    "45dff43e7f516a7e45a8b4ee5898222f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "voting-rights-act-of-1965"
+      ]
+    },
+    "45f14e38b52f0ca8b98568f7bc1a41b5": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "46117db1ebe932b36d2c0823ff62e6ba": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "4613a63629e37622f34dc54511c7d1ca": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "a-raisin-in-the-sun-by-lorraine-hansberry"
+      ]
+    },
+    "461f5bdb077ed9aeb23efb29a6b1c131": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "4628e72ad5208d04bee53d48f29ad80f": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "463097fd57e13a1fd160b8a9d379f3c6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "little-women-by-louisa-may-alcott"
+      ]
+    },
+    "4631f602cc6d89fde62deb6d7d2b507a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "incidents-in-the-life-of-a-slave-girl-by-harriet-jacobs"
+      ]
+    },
+    "46389f80435feed6d6da4cfda727261d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mexican-labor-and-world-war-ii-the-bracero-program"
+      ]
+    },
+    "464d276f5ff5caeda993ada869dd0cb6": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "466b6cf987dba10f58ff4a5325f0c25b": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "467e25463e3d2f7a4a4acc04b777b6e1": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "46adcef6baab13967e2f3af09106d3c7": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "46b3aba071b81cf58bc77876b20fd436": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "46cbc0d1b58c44615087bf80be0710c2": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "46e93f7ab6f8265c8234233178af8474": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rock-and-roll-beginnings-to-woodstock"
+      ]
+    },
+    "46f584197d55ebdd025bf808eb74f96a": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "470baaf29acf640dc2a77eb724cc368e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fire-next-time-by-james-baldwin"
+      ]
+    },
+    "471b595af5dd9ee891e6d7787bbfccf5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-united-farm-workers-and-the-delano-grape-strike"
+      ]
+    },
+    "472f572fd047f9c47f3bf70b6a292d3b": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "4745e1bcc1d8a1b4b8b0ec4eb9496829": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "texas-revolution"
+      ]
+    },
+    "4777f0c5807a8c7bcd49868df94ca90d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-black-power-movement"
+      ]
+    },
+    "47819d1ff057659a0e62896519f81a33": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "47827bf94e73d3b56f836d59bb11291c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-invention-of-the-telephone"
+      ]
+    },
+    "479bcf21c7a7c4959fd04341fdc74cb7": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "47a71ffcc68651cd24cad1bb5d977c40": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "puerto-rican-migration-to-the-us"
+      ]
+    },
+    "47b3b3814b54f5959b24e8c9ca449f0e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "elie-wiesel-s-night-and-the-holocaust"
+      ]
+    },
+    "47b42f836fc52806f3c1d7acfe6a9df9": {
+      "exhibitions": [
+        "children-progressive-era",
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "47f7a095cd7c1842a28213382ca07545": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "48104603f6e0bf492b79014aa0526e0a": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "482c9d4eccd851d25e593e10199d04e2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "act-up-and-the-aids-crisis"
+      ]
+    },
+    "4832dfd14246e7f97dc816edae7d7c6b": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "483e9dc56cc7121124f83b08b79d1c1c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-deal"
+      ]
+    },
+    "4841cee5469a71770c9a2343525fe92a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "environmental-preservation-in-the-progressive-era"
+      ]
+    },
+    "484b56331b72eacec8b40f735e4447e7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "act-up-and-the-aids-crisis"
+      ]
+    },
+    "485ede64f61268ebc5febe30be9900a6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cherokee-removal-and-the-trail-of-tears"
+      ]
+    },
+    "486af4f251ec6fee6645041926ce400a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "powhatan-people-and-the-english-at-jamestown"
+      ]
+    },
+    "487dbcf8fa88c488929d89d5817937b0": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "4893c5271612594fb34e93e3dfe82187": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "48b2e25f337be4e92c44d6941b442f7d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exodusters-african-american-migration-to-the-great-plains"
+      ]
+    },
+    "48b4d49dbde37f6360f366f655484944": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-s-suffrage-the-campaign-for-the-nineteenth-amendment"
+      ]
+    },
+    "48bd817fce2eda4b8e8d62b22eae2f32": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-grapes-of-wrath-by-john-steinbeck"
+      ]
+    },
+    "48e769a445e35e2760f3904062bc996c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panama-canal"
+      ]
+    },
+    "4906cef5d769dbfc5604a9e4bfe28ac2": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "49153977a7331047422cfd151e5d36d0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rock-and-roll-beginnings-to-woodstock"
+      ]
+    },
+    "49378dd69457a6eabd65f195fd86a630": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "4938a97e7a3e7e2fc54e1887f81f0a1a": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "4940cd95b694b94f1eb82bfce0eb9e72": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "49481d24ea261d8776eb30453563fb20": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-transatlantic-slave-trade"
+      ]
+    },
+    "496860895e6d5579569e444d8e5ee09d": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "49af8b7dc4f0a3a42b6c56a4695b74eb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-populist-movement"
+      ]
+    },
+    "49bea2fe16d893390df5c9e0e5523fb9": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "49cb05fed7c25be194f7e6e32390e4e2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jitterbugs-swing-kids-and-lindy-hoppers"
+      ]
+    },
+    "49ce8673b792a7cb3dfbff008920660f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-freedmen-s-bureau"
+      ]
+    },
+    "49d3e1d116710f4fecc61efc0d25aafc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-in-the-civil-war"
+      ]
+    },
+    "49d77aef2167a57fa4ea4013d44df8d6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "road-to-revolution-1763-1776"
+      ]
+    },
+    "49ffa7ae2e7d31124a5382e0953bd049": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-grapes-of-wrath-by-john-steinbeck"
+      ]
+    },
+    "4a0780b7900e289751174899b12e0479": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "4a0921a2bd0bd6e7ca456bd456fc12dd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-through-angel-island"
+      ]
+    },
+    "4a1cc8ba76ac832ddcf68a50c56c3cd5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "4a2dd09829fd18491a14a85db99e93ff": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "4a2f05f0a6183cacafaca902833174f8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cherokee-removal-and-the-trail-of-tears"
+      ]
+    },
+    "4a2f9b56939fddb1c3343afca6ed4e2a": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "4a3338ed18556b8c8948d6a86d095a4a": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "4a474d073381fda6b50a29108336ebce": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "4a59ebc9c4ba376f505f45f469b7b8a1": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "4a5a12b453093bfee414ffc5d70e6b7a": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "4a5c865206fef5c6bde038116c811f38": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-invention-of-the-telephone"
+      ]
+    },
+    "4a621eec2b7268592686bc7caf8e4cb9": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "4a6c1887473c542e4c9d5871b8bd8b35": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "4a70a05f1e1f66371e2330ea343b9d02": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fire-next-time-by-james-baldwin"
+      ]
+    },
+    "4a7c10eb25abc6361424141406e3e603": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "4a9edf1de23f3053a3c8a5ebbe9cd431": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mormon-migration"
+      ]
+    },
+    "4add2b8e655619a1a786bcbf09df68c8": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": [
+        "the-watsons-go-to-birmingham-1963-by-christopher-paul-curtis"
+      ]
+    },
+    "4b00a406255fac3ebbbe40536de9e202": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "4b01f58d3b7c48d07165a1598f8585b5": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "4b09588985f7de18870063ae721ee70c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-impact-of-television-on-news-media"
+      ]
+    },
+    "4b2b9d11390e9a5047200ea54c8ad4b3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-impact-of-television-on-news-media"
+      ]
+    },
+    "4b3b85782617e60ad843319c80afc49c": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "4b4d5a3df48531dabd839cccaa7fd095": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "4b56ed4838afdc9e830561573e28cd47": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "eugenics-movement-in-the-united-states"
+      ]
+    },
+    "4b5b40a2b3ca6a64d2bd43354d324ae9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "to-kill-a-mockingbird-by-harper-lee"
+      ]
+    },
+    "4b6ff52b528ec5e8c309146dee0da8ba": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "4b7221d80ec0504065bdbd8b685dca9c": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "4b8de3f2e007a3b14591dccd7d48a7fd": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "4ba1f8c11c9c14314ea253015e6c15d8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-atomic-bomb-and-the-nuclear-age"
+      ]
+    },
+    "4bab241ae8ebd637ec2a1ff072582d76": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-temperance-movement"
+      ]
+    },
+    "4bd7ca5449be7ca53f97a62e47deaaae": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "4befdf21d83803d3760848036a7b05a2": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "4bf53ed6e62c49970f981023893a51b8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-in-the-civil-war"
+      ]
+    },
+    "4bf97df6b83e7c52de44d36e81e6d07e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frank-lloyd-wright-and-modern-american-architecture"
+      ]
+    },
+    "4bfa2555906d65e472d862ba7caec770": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "victorian-era"
+      ]
+    },
+    "4c01e4184b541c12e73798f8667ea1c5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rise-of-conservatism-in-the-1980s"
+      ]
+    },
+    "4c25c603332b002e71a2ace54f6e4d59": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "japanese-american-internment-during-world-war-ii"
+      ]
+    },
+    "4c2989b861a2268fd4e50500550e16ef": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-s-eastern-front-operation-barbarossa"
+      ]
+    },
+    "4c40c2e74b103c69a158279d63d473a7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "henry-clay-the-great-compromiser"
+      ]
+    },
+    "4c4c47dba9391d098b4f404a4533ea81": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "4c606861c0f960cca66cedb92a57f4d5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cuban-immigration-after-the-revolution-1959-1973"
+      ]
+    },
+    "4c6265fabeebe950577ab3e6c910d2bf": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "4c6d5015bdc446edcb94a388dfb26e84": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "4c7e92ad902233f6740d89459d2c4005": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-strike"
+      ]
+    },
+    "4c9eca7885f20ff886217a504530f5ca": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "elie-wiesel-s-night-and-the-holocaust"
+      ]
+    },
+    "4ca70cf4fd0c7649ca30e3d0cd493898": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "4cb44e64e9832d52f0cb17332d9f6862": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-migration"
+      ]
+    },
+    "4ccf25025ee87f483839543acbbf8612": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "dutch-new-netherland"
+      ]
+    },
+    "4cdd50ac4cb54c59fe188cc744cc6e16": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "4cfa30f2b01036dc4f6d370de1bc6383": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "4d39c6a24d668023b3d60f53f9f21b16": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "incidents-in-the-life-of-a-slave-girl-by-harriet-jacobs"
+      ]
+    },
+    "4d3a1725c16fcf4a5c180843dabaa4a1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "a-raisin-in-the-sun-by-lorraine-hansberry"
+      ]
+    },
+    "4d3abdec348f28a821a6c8efc767427d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "secession-of-the-southern-states"
+      ]
+    },
+    "4d4912e42707d167df457984b69fee08": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "treaty-of-versailles-and-the-end-of-world-war-i"
+      ]
+    },
+    "4d539a3a0192576478579409d5154e1a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-lewis-and-clark-expedition"
+      ]
+    },
+    "4d53ed3e297b790074bb79a28ce09d36": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cotton-gin-and-the-expansion-of-slavery"
+      ]
+    },
+    "4d5a2a0674b302f851945cedb411aa10": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "theodore-dreiser-s-sister-carrie-and-the-urbanization-of-chicago"
+      ]
+    },
+    "4d60ee167f62b8f28e2e710879c6e615": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panama-canal"
+      ]
+    },
+    "4d68f649f5c0ae5dde3669283c5c27ee": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "4d6a4f138c2cb7a4be8d559f923fe254": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-transatlantic-slave-trade"
+      ]
+    },
+    "4d6f821823d82b3b978cb18163774ac1": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "4d7eb02c635e9ea700dd056f7ddfadc9": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "4d86b995d4894bc7d73945eca5745d72": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "4d9afe76acfe8313b5199f9b2ce134ad": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-acts"
+      ]
+    },
+    "4db90294c490b255ccc6ef921170b29d": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "4dbbb7c59e393c99a293661ab22ab4ce": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "4dbdcfbd9e96fde3076d09c2bf2866ff": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "4de7f095f905c673e1650d9e5d8aeda8": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "4e1c117646d34e36a4527fd4d18fd6f9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-war-of-1812"
+      ]
+    },
+    "4e372252d23f8079dde20c7c4578cf46": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-adventures-of-huckleberry-finn-by-mark-twain"
+      ]
+    },
+    "4e3fa9b37457abb7712c91208f891430": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "battle-of-gettysburg"
+      ]
+    },
+    "4e52a27ab3181dc6aab4c42597fd8f1f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jacksonian-democracy"
+      ]
+    },
+    "4e590ffc34257cfc4086953e0918a244": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "4e5aa3495f6322bc36a243d9dc89adb9": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "4e717e46c6499758643e289e9a15103f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "road-to-revolution-1763-1776"
+      ]
+    },
+    "4e75184b881986066a38f950498bfcf1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fifteenth-amendment"
+      ]
+    },
+    "4e817d17309f6dab756bb74d9c6b13d4": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "4ea428c2564d779561ff1b78c0f92d57": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "4ea988a20db445ef6738b238c489c456": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "lyndon-johnson-s-great-society"
+      ]
+    },
+    "4ef7704039a1eb56ed8b0f892bd07c4e": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "4f1067710bed122cc7dc379bf9bb3a08": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-black-power-movement"
+      ]
+    },
+    "4f13867104b443b92ee1535d06bda0a3": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "4f191c27aedf91a8d53afeacb57f962e": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "4f253fdbca74ff0c1ae1404116d4692d": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "4f287cc025385761a1eaa92e46c75ae6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-hudson-river-school"
+      ]
+    },
+    "4f51da1403100677417b89826d125411": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-rise-of-italian-fascism-and-its-influence-on-europe"
+      ]
+    },
+    "4f595f82e26504a393a7aeb773fc3472": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mexican-labor-and-world-war-ii-the-bracero-program"
+      ]
+    },
+    "4f71bbb27ee329809e507d679e201847": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "4f7bc8bd6cc55a16446f961ccae4cd03": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "revolutionary-war-turning-points-saratoga-and-valley-forge"
+      ]
+    },
+    "4f892ac94b1c93c49cf5c05167d3f14d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "colonial-religion"
+      ]
+    },
+    "4fc73de0c2c6364d03c029fcbecbab69": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "4ffb9147e2dbbdbf38a6edf174c59404": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "5004310049792e72bb7a26d718363171": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "5005422453831a6269d05368e1931511": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "victorian-era"
+      ]
+    },
+    "50281339b66a116d5d87efcd266c2fc7": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "5030d7016956a012aa59248e9dbf45b4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "settlement-houses-in-the-progressive-era"
+      ]
+    },
+    "5040f1419568602eab835b4f905e5a96": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "electrifying-america"
+      ]
+    },
+    "504b95e2aed77922861182d942609c92": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "road-to-revolution-1763-1776"
+      ]
+    },
+    "505ea13494bbaf3aab945b4a6903f7b7": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "50646a4c3ef0ae808b993483d4bdd8be": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "506ab5ad23d62fa8dedfff2324f26227": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "508d4b9d2ef1ac8ad4e42683dbbdea2d": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "50952aa70f1acab04fb1ddf4803b981b": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "509b6b629d210b47c632cd9cf1b97eca": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "50ae67d4f78c7f60af5c9efe0972bc83": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "50af849e9298e33d05d127018237b371": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fifteenth-amendment"
+      ]
+    },
+    "50cea30b71cdac2cadaa5537b9de0e72": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "powhatan-people-and-the-english-at-jamestown"
+      ]
+    },
+    "50d411ad92c332295e3a40e38d95983c": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "50e3ee94d5cee9ee087d8d38a560935c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "stonewall-and-its-impact-on-the-gay-liberation-movement"
+      ]
+    },
+    "50eff0b04edf28019c77e47390e17618": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "5117ab2c8acce719994a8aafd68197fe": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "511bdc20bdf071559104ef8e3a4447d4": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "5124960d41a250db05196a2326899050": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "5125d0b5fb4718b942fb1d0604522889": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-rise-of-italian-fascism-and-its-influence-on-europe"
+      ]
+    },
+    "513d58f4b7cf59c73dbac4a6645b9f58": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "51514ead30727527e4068e096eec32fc": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "518bc2559641e98f42607853cc2acefb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cotton-gin-and-the-expansion-of-slavery"
+      ]
+    },
+    "519d46c9ed383b23c11ad03bfbc4036c": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "519f6be753d3e538a1cfcc1d8e8820c4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-women-on-the-home-front"
+      ]
+    },
+    "51a6aeb6ddd18994e749114dcba146c9": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "51c0332d319c02594c72375fc02bbd7c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-united-farm-workers-and-the-delano-grape-strike"
+      ]
+    },
+    "51d3720b27bf24315420794befee1bc9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "incidents-in-the-life-of-a-slave-girl-by-harriet-jacobs"
+      ]
+    },
+    "51e45c1f26bf503df6d0dc512b4ea64e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cherokee-removal-and-the-trail-of-tears"
+      ]
+    },
+    "51edbb73946d58431ded91a6570dc662": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "invisible-man-by-ralph-ellison"
+      ]
+    },
+    "51f27ec054689c89dfe7b04e5ca47d67": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "colonial-religion"
+      ]
+    },
+    "51ff0e19d92c3c0163c01968483b2ea1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-awakening-by-kate-chopin"
+      ]
+    },
+    "520162df1f44b5d766f709770ff11589": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-rise-of-italian-fascism-and-its-influence-on-europe"
+      ]
+    },
+    "52019b6dc4e90a6a20ffd40ad7920bef": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panama-canal"
+      ]
+    },
+    "52084bd9104ae66841cbbcd0a7f2f087": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "spanish-missions-in-california"
+      ]
+    },
+    "5259abcc0713452044bca7888d714501": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-in-the-civil-war"
+      ]
+    },
+    "525b770eb683de910ec00a427978f635": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cherokee-removal-and-the-trail-of-tears"
+      ]
+    },
+    "525da571492f728c5e570f1f7897e497": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-lewis-and-clark-expedition"
+      ]
+    },
+    "5283c48d2b500456cf0e7770655b9d24": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "528f57fd5d150414df040de421417844": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "shays-rebellion"
+      ]
+    },
+    "52946914e93b20f75de6abb0b5e0df6a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-woman"
+      ]
+    },
+    "529f51e7ae782956e47f5ce8288bff17": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "uncle-tom-s-cabin-by-harriet-beecher-stowe"
+      ]
+    },
+    "52ab7c8c6d5956192aa5a5e55b490a95": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "52ba61d41ab9a8ba6aa9065cd0c187d6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "there-is-no-cure-for-polio"
+      ]
+    },
+    "52cec47cfdab670a76260d90a393e4bd": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "52de8a6ac0586cf3e246d22a2e34a343": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "52e43e971fc50b7156093b3ecbda347d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fifteenth-amendment"
+      ]
+    },
+    "52eae8f9479010692fc7664e5b2e4189": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "there-is-no-cure-for-polio"
+      ]
+    },
+    "52f4d6171eef8eaa20208c7e894cd9ef": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-hudson-river-school"
+      ]
+    },
+    "531d23c9216c3d52423950d4623f9afd": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "53328f16efb19a056fcfbbb580cc9a5c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "colonial-religion"
+      ]
+    },
+    "534479e1f1d10baf64d99b265605157d": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "5358a282592781e4a37fcadd90464252": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-wounded-knee-massacre"
+      ]
+    },
+    "5361d9c837a19f8318cbdae046203348": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-indian-movement-1968-1978"
+      ]
+    },
+    "5384f1c1c87ade1f5ec1ea7e1bb0b397": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "early-chinese-immigration-to-the-us"
+      ]
+    },
+    "538bf872a19f6b91f61cd7cd2084c537": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-woman-warrior-by-maxine-hong-kingston"
+      ]
+    },
+    "538e606153e44d2215c1a8036eea4976": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "53b01d4d297ff645bafa2bf99c069f89": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "space-race"
+      ]
+    },
+    "53d2164847f4c7ced5dea780c8033d24": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "53e26f4dd1803da81da4fb7a6603bbbe": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-strike"
+      ]
+    },
+    "53e30b98309f83918830aca37ab8568f": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "53f15802980c977833c3b30a41a9a398": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "california-gold-rush"
+      ]
+    },
+    "540c8793591b114956a776c93a641d5f": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "54197ebb4692e1cf9e1dd4e10a109440": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "blackface-minstrelsy-in-modern-america"
+      ]
+    },
+    "542469472078efae4c0b7ed4df34f35d": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "542bdd500c8a11131130c1d4dedbe3ec": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "powhatan-people-and-the-english-at-jamestown"
+      ]
+    },
+    "545825d1cd485b69fc17e8f4be3c070c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-gatsby-by-f-scott-fitzgerald"
+      ]
+    },
+    "545f55ee79b01e1301982ee2ee24c80f": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": [
+        "incidents-in-the-life-of-a-slave-girl-by-harriet-jacobs"
+      ]
+    },
+    "5464a158eaabc7240ac47229134b38e9": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "546a9013e5692f2a74f90efec33b1e38": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "5470c474a4f4c6baec9e95b5824e3dce": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-gatsby-by-f-scott-fitzgerald"
+      ]
+    },
+    "547b066c889fdd84341e2c0c1ba7a101": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-through-angel-island"
+      ]
+    },
+    "54951359079a8d6d6ae5eac57821743c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "to-kill-a-mockingbird-by-harper-lee"
+      ]
+    },
+    "54c02378ef0526ba8a149ae8c95e88ee": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "social-realism"
+      ]
+    },
+    "54d4bb2c2364cd32096e713d83696d8f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "perspectives-on-the-french-and-indian-war"
+      ]
+    },
+    "54d9efd08bd99369439f5cd6515dec92": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "second-ku-klux-klan-and-the-birth-of-a-nation"
+      ]
+    },
+    "54e7689f985f1ca6584c695976086c35": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "to-kill-a-mockingbird-by-harper-lee"
+      ]
+    },
+    "551239e1c346b011df195e310adaa660": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-blues"
+      ]
+    },
+    "551abe6c1370b38ac7d54a6c21d1b351": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-emily-dickinson"
+      ]
+    },
+    "551ed3ab307ed0e957326378604dd9b6": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "5527e66510ed259f90e68690fd4cc572": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-hudson-river-school"
+      ]
+    },
+    "552befd92aaa5245baed5ff0580c06a1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-transatlantic-slave-trade"
+      ]
+    },
+    "5531a9a1dbf64c100369a5a360f60371": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "5534a3e916a666ba031a7ec95475858c": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "554457df09ac6ed9bff07a3f4d7ae183": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "5561686c760926d74459d8c8dc66ca5d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rock-and-roll-beginnings-to-woodstock"
+      ]
+    },
+    "557fbde2e6715f2a915c1b73508ecee1": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "5589fed8366ea4e45338cdebb8232f1c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-crucible-by-arthur-miller"
+      ]
+    },
+    "558f22d7950b5048be26369331f5edb0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frederick-douglass-and-abraham-lincoln"
+      ]
+    },
+    "559aad9951a274c3ba9ff0d6a82474ca": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "55f351663b03aaf202e852975f079791": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "560917471eac83e4a6b98fd67ebc0354": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fire-next-time-by-james-baldwin"
+      ]
+    },
+    "5626deb2e32d3ec4eb01bf5b5576732c": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "5628204b36b94aa26e92151c957afc35": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "5659d2638042681dc73e0cf6e737b225": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "5675522948d28d59feaf36478040dfa5": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "56844a2497fc6a14d70a25d117da7449": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-s-suffrage-the-campaign-for-the-nineteenth-amendment"
+      ]
+    },
+    "5689b6a3782ec4c07fe54a01ef245988": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-united-farm-workers-and-the-delano-grape-strike"
+      ]
+    },
+    "568bdf46dd8a39c3b2b4a5e22fc979e1": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "5699b35dd255da771c2756adea8a8184": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "latin-american-revolutionaries"
+      ]
+    },
+    "56ae20ecda7b56fdf5fd732121ca8701": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "battle-of-gettysburg"
+      ]
+    },
+    "56b6e48e1ed393faeff2eff7f255a872": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "56b8937ec739fad2c4870d0b4d212ac7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mexican-labor-and-world-war-ii-the-bracero-program"
+      ]
+    },
+    "56c9c7917710ae791f8fd0480fc9566e": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "56ce9d7901058aacc3d23535ca1e99fe": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-black-power-movement"
+      ]
+    },
+    "56e1d46449f84065a8fdd5253a5e1684": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "56eae83d65d551b36c7a85a61fb84d60": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "56ffc47908aff96bc8ce37e483f60179": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "57087a692fa5e29eb94b7e383a378a7f": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "5710554565eefa37a591f90806300b4a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cross-cultural-colonial-conflicts"
+      ]
+    },
+    "571cbc6f45772d8ab6a890ae52bc6ed3": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "572ca3233ae4b0eba3ac5a003d5bfa16": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-deal"
+      ]
+    },
+    "574ebcf99c3c0dccdf6e8cfddf15ec98": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "electrifying-america"
+      ]
+    },
+    "5757cf92b1c821003f9aef524c7de64c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-united-farm-workers-and-the-delano-grape-strike"
+      ]
+    },
+    "57909d19919ecba28e0dc02349ed47ab": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "57a0c43ca791cd83dd4f83dd7930925b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "texas-revolution"
+      ]
+    },
+    "57b34f29fc12259f89a62f1ee298b657": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-yellow-fever-epidemic-of-1878"
+      ]
+    },
+    "57c5bc5b74f8782d40468fb08c9d39f9": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "57cb01d35f73f3f2522ed959df112c80": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-migration"
+      ]
+    },
+    "57e14ad33dc88161a9b89c2b6c5bbc9a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "secession-of-the-southern-states"
+      ]
+    },
+    "57fde1c934d3bd4d1d0a54c2d5214598": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "580789a5f619773f255e2459b5ae70a8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frank-lloyd-wright-and-modern-american-architecture"
+      ]
+    },
+    "580f607a69adee2d50adfeb6f3a4380f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-maya-angelou"
+      ]
+    },
+    "582165f7aae1ca32572450d833bc9096": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exploration-of-the-americas"
+      ]
+    },
+    "58299b1f0d6c3baed7a2d96c9d9bad31": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-watsons-go-to-birmingham-1963-by-christopher-paul-curtis"
+      ]
+    },
+    "583c0b101b9d669db262b7f9cdef8f8d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-war-of-1812"
+      ]
+    },
+    "589008023171866d5f434fa034f35e3f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "texas-revolution"
+      ]
+    },
+    "58b86399eec343fa324e724ff97dafe6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-atomic-bomb-and-the-nuclear-age"
+      ]
+    },
+    "58c2f0ab59b299b213c0ca8a05f3a65e": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "58c42308ffdd48cdd375b7e11a321146": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "58fcee2d4b18ef0b60f989c0076c9842": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "5900ec2af45fabf8fc011c989e4e46a6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "busing-beyond-school-desegregation-in-boston"
+      ]
+    },
+    "592fa512bbd2c8c56e5fd6317d75eec6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-absolutely-true-diary-of-a-part-time-indian-by-sherman-alexie"
+      ]
+    },
+    "59322fd193cdc9e413b31e577c119839": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-acts"
+      ]
+    },
+    "59412c85c8180febb8bed502c9e834d1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-freedmen-s-bureau"
+      ]
+    },
+    "594255d57a3b29cabac9f4ff9a14a64a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-woman-warrior-by-maxine-hong-kingston"
+      ]
+    },
+    "594e8b72cf1b52a6b37aff7e2c5334d4": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "5978041c0874da03e185c68b32a9b4b8": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "5984744430035c9331f860842d70f3a2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "victorian-era"
+      ]
+    },
+    "599fb0e69bcea7e6ef0cf64b643b9d2f": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "59a1326ccb6aa3f32ffca16aa8b707de": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rise-of-conservatism-in-the-1980s"
+      ]
+    },
+    "59b3a8a5f651db6b2c7af5a9eab82677": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "59b675385cc3fff6a2420d0243dc1f73": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-woman-warrior-by-maxine-hong-kingston"
+      ]
+    },
+    "59d476012ed7f65da276b2572a62c996": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "59d4a93458149215ba76b51f95de7619": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-invention-of-the-telephone"
+      ]
+    },
+    "59d70b1269ffa7579f78abde7a4348bc": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "59e5581cdb49e3fa42cd49ae1372849f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-through-angel-island"
+      ]
+    },
+    "59ebc95aef68957c9d2e886e57b81855": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cotton-gin-and-the-expansion-of-slavery"
+      ]
+    },
+    "59f00966a34868546642695e55b1e231": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "spanish-missions-in-california"
+      ]
+    },
+    "5a22352be16a1eed20efb22e1898bc77": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "5a3b3c9dc2fa941ce5a8ab186caacfab": {
+      "exhibitions": [
+        "america-world-war-i",
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "5a46cc7439d737d3057a2b9a5673dd35": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fannie-lou-hamer-and-the-civil-rights-movement-in-rural-mississippi"
+      ]
+    },
+    "5a5f4b08ee1d75c0de17e395838ef2fa": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-impact-of-television-on-news-media"
+      ]
+    },
+    "5a66eae48a5b8f957ca553c32dd0f800": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "ida-b-wells-and-anti-lynching-activism"
+      ]
+    },
+    "5a6e903c08ab7db299c0c9b200f8d8b5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fake-news-in-the-1890s-yellow-journalism"
+      ]
+    },
+    "5a70f06ed207990ff30e3be170a3a59d": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "5a7354d040481d3cd2a1e724bd859f79": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "5a7cf3c13b3b7116de87eb25464632d0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "declaration-of-the-rights-of-man-and-of-the-citizen"
+      ]
+    },
+    "5a86b77c17598cdb7fdb12f202c5a365": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "5aa6be5149f64270153f3946b2b4f7b1": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "5ab347acfa3461484538db1bbde4db69": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "5ab6b62d324c39e72b51b0be5ff9c8c0": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "5abb73a19c66a2cffe7e50a9832263a8": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "5ac0b5642d02e98f61f7dfb2609fe0d6": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "5ad51fe7bf87a4dea9cea01358b25acc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "invisible-man-by-ralph-ellison"
+      ]
+    },
+    "5ad5970784a48d7b51d4058d6e772463": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cotton-gin-and-the-expansion-of-slavery"
+      ]
+    },
+    "5ae80f2bd63284fd90818d9414523984": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-columbian-exchange"
+      ]
+    },
+    "5aee4f458349cc38bc1cc636cf28bb86": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mormon-migration"
+      ]
+    },
+    "5b06e3b3c9280f889a77251b9596cb02": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scopes-trial"
+      ]
+    },
+    "5b12acc3f80ef78c0ebb36f5e84ceba4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-and-americanization-1880-1930"
+      ]
+    },
+    "5b21ea289d60f31ebaaae59b79474d7a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "a-raisin-in-the-sun-by-lorraine-hansberry"
+      ]
+    },
+    "5b26f6787f04b426217b25b8e107147d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-adventures-of-huckleberry-finn-by-mark-twain"
+      ]
+    },
+    "5b416604d9277753e02237031ec6ac80": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rise-of-conservatism-in-the-1980s"
+      ]
+    },
+    "5b5c47413f97baf3e033ae9aecdc7011": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "truth-justice-and-the-birth-of-the-superhero-comic-book"
+      ]
+    },
+    "5b8b4ea1f259597c39ddf9223f73c9cb": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "5ba2191d209521f635c8ca8a1814ef2b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "john-brown-s-raid-on-harper-s-ferry"
+      ]
+    },
+    "5bdac24b17cf073ee8d1c7a2f3574c2e": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "5be16b478f7c62d8c8a2a6fb0b02b4b3": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "5be6b9427c1e63c7aa3c089cb899ced6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cuban-immigration-after-the-revolution-1959-1973"
+      ]
+    },
+    "5bef460c850de5ed17a2b38d8f5729a6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "texas-revolution"
+      ]
+    },
+    "5c06c06849b39c25c6f12c6aca7d11f9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panama-canal"
+      ]
+    },
+    "5c0b33df1cd7da9eccfc69319c162fe2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "incidents-in-the-life-of-a-slave-girl-by-harriet-jacobs"
+      ]
+    },
+    "5c224cc3a705bae6cd0d0bcd0b02ffee": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "5c23093bf69c1aac8a0ecc6d84a08c76": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "5c39427367972fafa5176618f782262f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-atomic-bomb-and-the-nuclear-age"
+      ]
+    },
+    "5c3ab2ac7ae8098d2662233ab5e22d7e": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "5c3c12233c42c1b1675282b51569ca45": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "5c491ff9269c835097ea324ba3801493": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "5c4ae41508c0cdbde2d08ee9cba5114e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "space-race"
+      ]
+    },
+    "5c519f5e0e760cf2d3278774ed4a5239": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "5c5fa5a3abcaf59ddc4f7cf4c4d67f44": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "5c68bfadae295240e42f383b8d2a7e5f": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "5c832dd0a40b7672bdbd8a6e941e226e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exodusters-african-american-migration-to-the-great-plains"
+      ]
+    },
+    "5c95a64ae569a2071d1bdf5a308f9ac7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "california-gold-rush"
+      ]
+    },
+    "5ca0e9b733fb1cb4748c6a3b7f05b01d": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "5cb5a1e4c062e614bf0f6ebd9f77d0f1": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "5cb8342bdd0a1ecd808f4f5c5dc3641d": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "5cc3251993c6f8f266d508f699e4f04b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "spanish-missions-in-california"
+      ]
+    },
+    "5cc428781a1863024b62f35620b94ef6": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "5ccfa003638140f8057fb630d99e00e3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-columbian-exchange"
+      ]
+    },
+    "5d1dcbca1b47877f481c0f4209d6b2a1": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "5d26f2db342870306398628eea06b418": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "5d5877ce2d183ce5031942ecb3d45a7c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "california-gold-rush"
+      ]
+    },
+    "5d5ca6ee70196ed8a3b2c959f5dda5a0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "truth-justice-and-the-birth-of-the-superhero-comic-book"
+      ]
+    },
+    "5d5f8914d0dab361d2728f82854e55d2": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "5d672b01310e0f6daebf6836fec77fd6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-through-angel-island"
+      ]
+    },
+    "5d706f7160cbbda05060c40326f122f4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jacksonian-democracy"
+      ]
+    },
+    "5d8287475a4d3ab8f41aa4a3d2f4255e": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "5db147e2ae970ab7fb9b75c231cc40fe": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "5dc3293ea79a52600a69da97b1b80719": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "5dc8acbe40138181cee4fac43b7ccb77": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "powhatan-people-and-the-english-at-jamestown"
+      ]
+    },
+    "5dcd08bb66f691c30fb77e5fae83156a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-deal"
+      ]
+    },
+    "5dd083701859c534274fa8a01918c947": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "full-steam-ahead-the-steam-engine-and-transportation-in-the-nineteenth-century"
+      ]
+    },
+    "5ddde164906d8eb172e4f3e8e1acef81": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "perspectives-on-the-french-and-indian-war"
+      ]
+    },
+    "5de7f61657024d8e1d345f4ccb8b10f9": {
+      "exhibitions": [
+        "children-progressive-era",
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "5e286ecaefc93007394b91ff4b1bc275": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scarlet-letter-by-nathaniel-hawthorne"
+      ]
+    },
+    "5e348bddb7180bd530acaf6886991ff6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-strike"
+      ]
+    },
+    "5e3be7f11198e58818fda89c6602e7f9": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "5e43229ea7fbd766be94f30d0ac6e844": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "full-steam-ahead-the-steam-engine-and-transportation-in-the-nineteenth-century"
+      ]
+    },
+    "5e69c6ad2587cb34e263cbffada01396": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "japanese-american-internment-during-world-war-ii"
+      ]
+    },
+    "5e6e4b6d6ae941db9aa6a96ab6d93546": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "5e97c2509f7f7dedc40c3c4be2d5a5b3": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "5ec9faa1f43f09536db29f5508830744": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "5ecb04f4960bd4511a0ba085cf0d2dde": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "attacks-on-american-soil-pearl-harbor-and-september-11"
+      ]
+    },
+    "5eddac1d6d7e4435c8b230c5757d758b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-emily-dickinson"
+      ]
+    },
+    "5ef487641a2baf925a92f54b8092035a": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "5f00c9c81710a710605b784998b3a850": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "5f0e830051a5f3d81f4d7bad7fdfeb87": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "social-realism"
+      ]
+    },
+    "5f50e441adc84c546b1e458ef5f9a125": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "5f8b36a816273039735e5706ab110b9c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cuban-immigration-after-the-revolution-1959-1973"
+      ]
+    },
+    "5f9eeeeffa762bf8368b182f7f3259ef": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "5fb4e4c6be3d0b6f90795ac2e6eaa99b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "attacks-on-american-soil-pearl-harbor-and-september-11"
+      ]
+    },
+    "5fcd972cdafe5e362fbf0fd5cfa731ab": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "5fce0f5333497095adbb42ce9be58080": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "5fd1653479ec47bbf1cc1f4b8fdf0c30": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beloved-by-toni-morrison"
+      ]
+    },
+    "5fd5d90481813edd7723f4572fbfeb24": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "5feffe739f72f08b90f9b93d4b0b9e92": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "60038b19766b1d9d47427210ce9c1467": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "6008cf5c0fc081dcfe1e102a101ae4d1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "full-steam-ahead-the-steam-engine-and-transportation-in-the-nineteenth-century"
+      ]
+    },
+    "601c2e8987339e0ab29813ee44e2fcbb": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "602796792c9b4c153abc4a0e21f7e077": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "incidents-in-the-life-of-a-slave-girl-by-harriet-jacobs"
+      ]
+    },
+    "604364861869e71ecc0b81d67a103535": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "60464b3a0574647c0d68fef595db7144": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "604af66b55a58e05e8b3c2cd116708f6": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "605280bdb6b8c4599b59c1ca97cd55c6": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "605e80886821a06d4cc49dd238b66e9a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-things-they-carried-by-tim-o-brien"
+      ]
+    },
+    "605f6f8ac197ad1991a2981557fc8a53": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "declaration-of-the-rights-of-man-and-of-the-citizen"
+      ]
+    },
+    "606a0b37366431c1a39649a196e48ee6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "dutch-new-netherland"
+      ]
+    },
+    "608a4990ee885cbe794deb3cd51beb0f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "puerto-rican-migration-to-the-us"
+      ]
+    },
+    "608bcaf23792cc68daca61e9790a7a4d": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "60b431276679ded24cff32b6fceab004": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "60c5c00873db1973f03b733ad7fee731": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "boomtimes-again-twentieth-century-mining-in-the-mojave-desert"
+      ]
+    },
+    "60d119a405dc893bf6b4c7abeea90df3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "truth-justice-and-the-birth-of-the-superhero-comic-book"
+      ]
+    },
+    "60e29a1c3983f2b1a077750352d7ad30": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beloved-by-toni-morrison"
+      ]
+    },
+    "61122e6aa1279a1b82af4add9cf9c814": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-woman"
+      ]
+    },
+    "6117be69b91f956d5398f75d697a7388": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-rise-of-italian-fascism-and-its-influence-on-europe"
+      ]
+    },
+    "611c3a6107842205112f7c2326ef6a08": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "61287669c0bb5b5b5cf197778ad6b14d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "california-gold-rush"
+      ]
+    },
+    "615e235c3e9d65d14dc9930f73ce7eff": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cuban-immigration-after-the-revolution-1959-1973"
+      ]
+    },
+    "61627e745c70dc075fb45a28aa1380b5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "social-realism"
+      ]
+    },
+    "61901655158b0c67ffd80a6ed43465a6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-adventures-of-huckleberry-finn-by-mark-twain"
+      ]
+    },
+    "61940a227774f6da1c34a0b433527acc": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "619fa96968f508a9f7a726376cc3e50c": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "61c03e72fe9f8c827459fa25c724438d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "invisible-man-by-ralph-ellison"
+      ]
+    },
+    "6215e2d563f4eb20918516fc98facaaa": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-rise-of-italian-fascism-and-its-influence-on-europe"
+      ]
+    },
+    "6217d2d4f4a2b947efb31235402a3e01": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "621de37d945de7b660d2415eafb0005a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-acts"
+      ]
+    },
+    "622064b0694fc1ffa26268038fed7323": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "postwar-rise-of-the-suburbs"
+      ]
+    },
+    "622d044817a76960015abe2bb69673f4": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "624c119f80cb9de5df65136922aadd43": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "attacks-on-american-soil-pearl-harbor-and-september-11"
+      ]
+    },
+    "625a689c7551afa799fd40e8d67f9b8b": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "6268690c43a64c119d93e3098879ea6c": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "6269940d63147f5e1d799f264f798ae2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-absolutely-true-diary-of-a-part-time-indian-by-sherman-alexie"
+      ]
+    },
+    "6272add5bec5737e6399de92c4c87274": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "628c0a7bf213ede7ad7a01800e02711c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-crucible-by-arthur-miller"
+      ]
+    },
+    "6295b667d8b06048dc7cc8a3e947ece3": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "629a45541f62b871b9f787388f2e1e76": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "62a52d372aff12514c83c96cc6a7fa9b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-s-suffrage-the-campaign-for-the-nineteenth-amendment"
+      ]
+    },
+    "62b6eced2e0b0406626e73ffaa143f5c": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "62b96b23eee9b7bc139d9ae585b1b719": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "62c5ea3a9df1d5dfef6c8bf09db19667": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mormon-migration"
+      ]
+    },
+    "62c96d22b63c26bc00e0d86aeff7d90e": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "62eeda08491e73253eb25219a5ac7fff": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "patronage-and-populism-the-politics-of-the-gilded-age"
+      ]
+    },
+    "62f372682f1e72259bd5ca6b43868988": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-absolutely-true-diary-of-a-part-time-indian-by-sherman-alexie"
+      ]
+    },
+    "630947bfae32c4072e9548167c56d41b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-woman"
+      ]
+    },
+    "631145ffe20b8cdcbfcdf5c87f48e1b0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-abolitionist-movement"
+      ]
+    },
+    "632fc1df861d84cab6446900dd9782d9": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "6332aa334fa7f4c8968dd4651a1f5d4d": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "63474e4f3072abdea4cca59a3c6b8443": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-adventures-of-huckleberry-finn-by-mark-twain"
+      ]
+    },
+    "6357d1fe690d050037d233aa829e66ba": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-awakening-by-kate-chopin"
+      ]
+    },
+    "635d5e38ecf5797518cc624b545d9a90": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "63601809f6bcb7b11a84529cf4133b47": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panama-canal"
+      ]
+    },
+    "63758efc6b682f4b00d69f89bb0c16f0": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "637d279a9332edde2b16ab15da3b18f8": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "638c81539942483f12e94e70220d5196": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "63911513d52fd528ad9797b1a55e6b02": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "63aab65493588f208bcd6412abee45a7": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "63b6d61d7330039771d0b10cdbc5dd4a": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "63c29f55dbd8db65e6d02a4af88a1cb4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-war-of-1812"
+      ]
+    },
+    "63ceb02b29805a9a4f913bdfde7ed640": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "to-kill-a-mockingbird-by-harper-lee"
+      ]
+    },
+    "63d61e7962ce697d086eeb5d91d3eafe": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "of-mice-and-men-by-john-steinbeck"
+      ]
+    },
+    "63dd61c83c29c0d1e197d173ac6a57a2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-abolitionist-movement"
+      ]
+    },
+    "63f20dc8aeef9eb02577ea44736c7e48": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "640eb468d9377402e89ef4ac959e97b4": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "6420c78a697a3fa54507f5edc8b4285b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-in-the-civil-war"
+      ]
+    },
+    "64290ba5be9c0f04a043a20ec6fef07b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panama-canal"
+      ]
+    },
+    "643ca67e4a408eede6965bdfa396c234": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "there-is-no-cure-for-polio"
+      ]
+    },
+    "644ea912e5c0654b763ecb1b23d19e3b": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "647c063e5f1edba83792a2c9dc99fd62": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jacksonian-democracy"
+      ]
+    },
+    "647f41ef796460b143d1866563072cef": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "648fb0e8af6738bf3fb2740a745cc2bb": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "649f367dc5b658216d83844037d7b4f3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "northern-draft-riots-during-the-civil-war"
+      ]
+    },
+    "64a8dcc45e70c5a9b1b1bcd708a48286": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "64b67350c5c36add962c16976bb953de": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "64b71cb8511c7ed2cb0fdd367c3426b5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-s-eastern-front-operation-barbarossa"
+      ]
+    },
+    "64eb4c9dba10556ef5bc3647d684749c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-crucible-by-arthur-miller"
+      ]
+    },
+    "64f3645799cb3cca91acbe0d37492755": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "negro-league-baseball"
+      ]
+    },
+    "64fc29bfc1a023adca00e4425be5aa22": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "650190d8a72f5ef0a5cce4d8f602d34c": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": [
+        "second-ku-klux-klan-and-the-birth-of-a-nation"
+      ]
+    },
+    "6512ec9fc5c1b58b8e3a84b7e20d0102": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "6514cd35c500017c51f02b0803f46c3c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "commodore-perry-s-expedition-to-japan"
+      ]
+    },
+    "6524c893091ea09fd83b893c7491f798": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-women-on-the-home-front"
+      ]
+    },
+    "6530b7f4cd1ffe445c9a883b70de7f7a": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "6540608aa8df304dc328d1ba88f88482": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "65429be7ea1df03fcd2ed199adf0d550": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "latin-american-revolutionaries"
+      ]
+    },
+    "655cc459e0f7d506e11b587eba44142b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-in-the-civil-war"
+      ]
+    },
+    "65741dacebd49814daf7ef9a23aa8714": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "settlement-houses-in-the-progressive-era"
+      ]
+    },
+    "658d48cdae85862e24844fd8efd5678e": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "658f42290cd4842c82b7dfea81be8af8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mormon-migration"
+      ]
+    },
+    "6592970f0deea2797b0c87c7e5d54995": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "65c41e2b681813a54e88ea8728c7d62a": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "65e3b5219fd183b2ed45e988778fa35e": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": [
+        "patronage-and-populism-the-politics-of-the-gilded-age"
+      ]
+    },
+    "65e5a27a0d43b33f4508769627f3b405": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-temperance-movement"
+      ]
+    },
+    "65e81d4f384e61d4a1dc9795a1bf019c": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "65f3abec84bc3a3c21a799c9af5f9f05": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-colonies-motivations-and-realities"
+      ]
+    },
+    "661bef1abccc97f5f2e585949c822d5b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "act-up-and-the-aids-crisis"
+      ]
+    },
+    "6621cab29fe377fbd3b0ad3a6c5b8cb3": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "663e63fac196d34f93b41cd24e406cf4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "revolutionary-war-turning-points-saratoga-and-valley-forge"
+      ]
+    },
+    "66433b50b44da0613912c111b370dbb9": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "66484a6f1b0abe0573c51ea35bbe76e7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "full-steam-ahead-the-steam-engine-and-transportation-in-the-nineteenth-century"
+      ]
+    },
+    "664c1fd903234fa3c986e52de1ed1e8d": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "664f0b7e63e3964b7fc3298f59d5bcdf": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "665ce5e062437dd126cbee9f261bc0e2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frank-lloyd-wright-and-modern-american-architecture"
+      ]
+    },
+    "665d541e51c4ef02aaa05e17754632e0": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "6666bdd0763cd18f3cab886a889e64fc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-freedmen-s-bureau"
+      ]
+    },
+    "666a99955990c2d4b359ed10e024c9c9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-s-eastern-front-operation-barbarossa"
+      ]
+    },
+    "668d9e6f8cd6d083668b09b95366d9f6": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "669fca84c4e5b91357ed8675f5587bb2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-maya-angelou"
+      ]
+    },
+    "66a8b62825a457aa00fedb0bd9f0399d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-in-the-civil-war"
+      ]
+    },
+    "66baec54edf6616cb2f20e7584398d26": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "66bc190d6db55b59f1562416bbc88e1f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "dutch-new-netherland"
+      ]
+    },
+    "66c134689466411a06eee49a8d6bd177": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "early-chinese-immigration-to-the-us"
+      ]
+    },
+    "66c46915fadab5f2e1213ab19db85a58": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-indian-movement-1968-1978"
+      ]
+    },
+    "66e62342cfcab03c22037e30578d6f05": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "670d2ed2e434ef628d40ca37ecbdcae3": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "67160f444b5921906a16c329cded5310": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "673fb230ecf711102f24bdc356f5c656": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "674766da7e79abc0e95e464d523f4cf7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "reservations-resistance-and-the-indian-reorganization-act-1900-1940"
+      ]
+    },
+    "6747b9deb580a6c3fd362b7300a78a0c": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "6762fa9e2145bef1b3d474ff3dee1ba6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cross-cultural-colonial-conflicts"
+      ]
+    },
+    "676e23fa64772391030d015b450db48f": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "67cae6276eeacb57d97e7ba37653b454": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-acts"
+      ]
+    },
+    "67d9ac05499ed21ab67bef3d535f9f66": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "there-is-no-cure-for-polio"
+      ]
+    },
+    "67d9d93a2b26d074dc395f9e12243cd4": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "67e85497437574ff6cecbc1a443e7f5a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "voting-rights-act-of-1965"
+      ]
+    },
+    "67f2d1fe6d2b7c175b49bc4db7475ebe": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-hudson-river-school"
+      ]
+    },
+    "67f97b639e4302a00e6618937d892d47": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "6814b186226ba48d256872b0e19ca39b": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "6824acab5e03c6512e19859385da0a45": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-boston-tea-party"
+      ]
+    },
+    "6824c89d56fd02028b35e98df2d67955": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "6837832883bdda77932629f39cdd9a8b": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "683a84f12947afee747034a08325eb44": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "684763df0d3b40b5a4290e4921a13632": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "684ba704a6cafcab5203490eac01aaa1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "perspectives-on-the-french-and-indian-war"
+      ]
+    },
+    "684e943e612f8fb61f56abab95ba8721": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-whaling-industry"
+      ]
+    },
+    "686691e8a152f376af25d903b197616a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cotton-gin-and-the-expansion-of-slavery"
+      ]
+    },
+    "687179090fffc2610fb1cc3b697837e2": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "687fca5d813b01ba85e9046924b3b65d": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "68989319066836816eac65ef4d5e5307": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "68a78bf06719b44bb6644c627b0393a9": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "68afc351ef988f62b25dc6e5a7eec91d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "when-miners-strike-west-virginia-coal-mining-and-labor-history"
+      ]
+    },
+    "68cfebe4ed07d4416baf306c6e2c38a3": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "68d34cebe4d8a3a61c279793ed281bcf": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "68de172780d743e7f4516d3445a8876a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mormon-migration"
+      ]
+    },
+    "68fd883a8ff984b7d378a75882247c0a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panic-of-1837"
+      ]
+    },
+    "68ff6851b1d06fc70398379e31c51cc4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "social-realism"
+      ]
+    },
+    "692e4d712e744f469bfaf5925ceb4e4e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-in-the-civil-war"
+      ]
+    },
+    "693c02bc190917b1304fa7ac1921a03e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-in-the-civil-war"
+      ]
+    },
+    "693db1f571d88f98f71428ac9b8f4840": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "negro-league-baseball"
+      ]
+    },
+    "696a8ebba2f19a0988c0475de972ab78": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "696d4307adcebe767b399e764f32486d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-populist-movement"
+      ]
+    },
+    "6990831b087f92912d84b29c5bbb87db": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "69c22260f3a357a4411fa0108a564bf3": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "69d98c59b3c1eff954caefbf62e76bf7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "colonial-religion"
+      ]
+    },
+    "6a1bf743f8816ffee395e13d15d20963": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "early-chinese-immigration-to-the-us"
+      ]
+    },
+    "6a29827ca186a7bbfdb5db2129e6528d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "battle-of-gettysburg"
+      ]
+    },
+    "6a3e4aa24e6c5a2eab43710f1bc46d2e": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "6a520c1b6256c58de4bb09ad04ab19c0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-awakening-by-kate-chopin"
+      ]
+    },
+    "6a6d7faa94cd6761759a68e86b53927c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "colonial-religion"
+      ]
+    },
+    "6a851c8daa4dafb2ff7c63f440c2796c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-imperialism-the-spanish-american-war"
+      ]
+    },
+    "6aa30ad7da502d08eb24f989596a2da4": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "6ac2333979a34ed997e9ba516ec9ed11": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "revolutionary-war-turning-points-saratoga-and-valley-forge"
+      ]
+    },
+    "6ad6fdfd0863e5721340cbb3c4df9c3e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "social-realism",
+        "the-grapes-of-wrath-by-john-steinbeck"
+      ]
+    },
+    "6adfaf60c6470c076b2fcb0eda8e0b68": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "6af67b670787683f72053917ee72654a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "african-american-soldiers-in-world-war-i"
+      ]
+    },
+    "6af84c8866bda8924857c2e1808e931c": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "6afdc490b56f6af2eb2fd587f772b134": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "6b319b219a0d09312025c5ada0bc4321": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "blackface-minstrelsy-in-modern-america"
+      ]
+    },
+    "6b3beff49b9ed5d62c690f1b5ec5e4b7": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "6b6c23c2e6ea23b545466a472e6436dd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-acts"
+      ]
+    },
+    "6b8f1395c43d9a18e26a21407ba7d260": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-underground-railroad-and-the-fugitive-slave-act-of-1850"
+      ]
+    },
+    "6b94ceb27b3e94eef524aacefbce4d09": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-acts"
+      ]
+    },
+    "6b99aa702af41e8a4267f44021e0140c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "blackface-minstrelsy-in-modern-america"
+      ]
+    },
+    "6b9a6d754dece80c21de4ceba7cfb3ef": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "reservations-resistance-and-the-indian-reorganization-act-1900-1940"
+      ]
+    },
+    "6b9e99f0519e7e54afb4a7d07c398f32": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "6ba166fc0ca9db62ba6cac7500de8cb7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "puerto-rican-migration-to-the-us"
+      ]
+    },
+    "6bafba9167912bb60ae83c9d37af355b": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "6bbf393733162caa0a6171caab062b78": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "6c0fb2e3894c4f10d5c60a9368d6a32e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-freedmen-s-bureau"
+      ]
+    },
+    "6c10e1f6b65cca6a61d6234ef799b93a": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "6c248923f0d8841f5d5908cdb011f140": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "6c29ed5b9b12c7ead98b76ae3fcccc16": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "6c39701033e2ac2b8f07ed330bf62448": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "northern-draft-riots-during-the-civil-war"
+      ]
+    },
+    "6c6dc7a9c694e455471e863155907892": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "6c945714aa04820f6905dd29cf8806b8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-migration"
+      ]
+    },
+    "6c958a3af7c2e9461f62505c80da6ca0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "battle-of-gettysburg"
+      ]
+    },
+    "6ca2d0601d7960e03d25724ceeabd441": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "ida-b-wells-and-anti-lynching-activism"
+      ]
+    },
+    "6cb708a5a4a492520509fc849ff55e2e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "spanish-missions-in-california"
+      ]
+    },
+    "6cba33e0445631394ebb673a8fcf4308": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "6cbd5b23c88e24d837dd5acb9b93f212": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "6cdd4ed94d7a5ae610ff949c993c3dd7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-indian-boarding-schools"
+      ]
+    },
+    "6ce780fcd11c9f2a3229fafcb471bda4": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "6cf31e1c802cca9a11d0639ff096330c": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "6cf4742751b5c1530b720a27e513ffc5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "nineteenth-century-schools-for-the-deaf-and-blind"
+      ]
+    },
+    "6d037d5fb7ae9d8f8ee702555a58d2ec": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "to-kill-a-mockingbird-by-harper-lee"
+      ]
+    },
+    "6d0e3820e335f075016c4bc9e44d6b9a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "space-race"
+      ]
+    },
+    "6d15e599095736ef80eadd73097528c1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "attacks-on-american-soil-pearl-harbor-and-september-11"
+      ]
+    },
+    "6d1b8e51441216de67319179c457684d": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "6d1fc6e684875b17266e1f5ef077458d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-migration",
+        "to-kill-a-mockingbird-by-harper-lee"
+      ]
+    },
+    "6d24fa0660be4d3befe998d14ab6c8f3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "feeding-the-hungry-with-food-stamp-programs"
+      ]
+    },
+    "6d4db90ce2ba6543dc00899976ff2003": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "feeding-the-hungry-with-food-stamp-programs"
+      ]
+    },
+    "6d8efc89d83e4afebdebe4d1e76f5485": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "shays-rebellion"
+      ]
+    },
+    "6d8f9eb1e897afe0d482373595cb059e": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "6d98e1d289820e9ef9e5c6f16522b850": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "6d9ca31bb4737755167fe8640fbc751f": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "6dab6b180bb68bbfcd1152185c3dee3b": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "6dab92b0dcacde0000faefb4ccbdeed1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-adventures-of-huckleberry-finn-by-mark-twain"
+      ]
+    },
+    "6dafe07e7a3f7452a2dd03e6699fd4df": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "6db54ac08d2ecbe206b2bb2b19ba3552": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "dutch-new-netherland"
+      ]
+    },
+    "6db62a7ded4b7f9adb992955072b946b": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "6db7a95a707fc175857ed326fb3974b3": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "6dbaafb4f2fe71e6ef3a5c8481225e67": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "northern-draft-riots-during-the-civil-war"
+      ]
+    },
+    "6dbc79ba863046ae3e7d25058a383d6c": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "6dc567b2d13077b0650a41c9c0712f38": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "6de9a614fc4a7c85a803f621e7e4e32d": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "6e22c799c0416f6bd3b662a3f8e58d73": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "little-women-by-louisa-may-alcott"
+      ]
+    },
+    "6e6c704a0012343ee13634588c639d45": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "6e7c51106464d7999acc27cf4fd9f3a7": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "6e9c590b57dc6d7ec0e1cb0a29fc8b63": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-s-eastern-front-operation-barbarossa"
+      ]
+    },
+    "6e9d1c465a0a303bc070576e4c559545": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "6ea30912fffb4b222f24bd652d3d11f0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "reservations-resistance-and-the-indian-reorganization-act-1900-1940"
+      ]
+    },
+    "6ec5f86f585a556cb557ec25a3d7c755": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jacksonian-democracy"
+      ]
+    },
+    "6ec923cd64846cdbf2221fe75642f479": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-abolitionist-movement"
+      ]
+    },
+    "6ed15a468298cb3fd399d021b36f4d17": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "6edfc825d6aaaa54fb3c094409f204e1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-hudson-river-school"
+      ]
+    },
+    "6ef686c0c876fba61ce081ccfc65285b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cherokee-removal-and-the-trail-of-tears"
+      ]
+    },
+    "6f005f3e8c0e03dc6c0a33f6b609a739": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "6f1e3d904a2e349deba97600701a0138": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "6f215ea6acfac77167d153143248840f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-acts"
+      ]
+    },
+    "6f24c2ce7ad449334a285d2acd16b2b1": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "6f28ec8b571b1b0c32bfa233c9f30c3f": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "6f3ce9c47b9328495254c9f77ac5a766": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "6f415d2ab361201206f7bf78c57cd082": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "reservations-resistance-and-the-indian-reorganization-act-1900-1940"
+      ]
+    },
+    "6f49016eb0d7f9870c05737b50e213ad": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "6f50f3564fbf95d5c3d1fee8ffb7670c": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "6f5e8d9e61e5e88d035937154ecd3937": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "elie-wiesel-s-night-and-the-holocaust"
+      ]
+    },
+    "6f6aadc999c9094b7388ddd7f4cdfadd": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "6f6c793c98869d757ce9dfd16e91b8c5": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "6f7198ea5053bbd5e4de3eef5246786a": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "6f72d6ddd9eda47d92f0525124884abd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-impact-of-television-on-news-media"
+      ]
+    },
+    "6f776fd76530edaa796e9552717646b3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "california-gold-rush"
+      ]
+    },
+    "6f930655c7744e146abe01eaf3078270": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "6fa8473bb1313d073d5789149ce1771c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-transatlantic-slave-trade"
+      ]
+    },
+    "6fbf2b3504f07936566bfd7b68359c57": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-wounded-knee-massacre"
+      ]
+    },
+    "6fc3f242eeac3f3df3694a25521a4904": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "6fd54a55b4bf4bd543d96f1da539d4e7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-in-the-civil-war"
+      ]
+    },
+    "7000ab6e5b39f71e5fcfdc95a96025a1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "japanese-american-internment-during-world-war-ii"
+      ]
+    },
+    "7003077a469dc5f633d5c279a15edecb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-freedmen-s-bureau"
+      ]
+    },
+    "701b0ce0d475ea8a56aec9c8c0ec258d": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "702db10b5c2595d9b90a31bdb3a4af23": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": [
+        "japanese-american-internment-during-world-war-ii"
+      ]
+    },
+    "702eaad0a3bb89775a0f243b91de1166": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-underground-railroad-and-the-fugitive-slave-act-of-1850"
+      ]
+    },
+    "7040fbaf3b9674f7775e750771ac36ab": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "70635367eafa43ab1e899f784671efb3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "invisible-man-by-ralph-ellison"
+      ]
+    },
+    "706e2dae044f9e7ce77ec238bbce93fa": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "707f5f7469f9303c088eeeb7b3af0d4e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "african-american-soldiers-in-world-war-i"
+      ]
+    },
+    "70848a5284f1d7eb835d18845038042d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panic-of-1837"
+      ]
+    },
+    "70f87e851b9064971c9c2a04e98546ac": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "70f9dfc85dcb019aab09724cd25b51e2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "visual-art-during-the-harlem-renaissance"
+      ]
+    },
+    "71078c9d2f0b010942002366642e1ace": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "710a977aa40772b58464c7f6acd223f3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "northern-draft-riots-during-the-civil-war"
+      ]
+    },
+    "7126276621b8bdfd5446e58853a0e845": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "712a89a39d0e09c0d818bacf4a682e5b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cross-cultural-colonial-conflicts"
+      ]
+    },
+    "7134e53700561486b1a7d3480af6834a": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "713c213f2dc45841aca01bd454fd5afe": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-temperance-movement"
+      ]
+    },
+    "71570a7ccb8fdca3b9e303b44f1e471e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-gatsby-by-f-scott-fitzgerald"
+      ]
+    },
+    "715790a3fdc2a538782260284e8dac73": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "71739ac6973e1bd9dfb17afa3e41034d": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "719b3471e3989bd190587f3a2e1a213d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-i-america-heads-to-war"
+      ]
+    },
+    "71a9e47cff0ed3d3da1fecbfee714215": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-imperialism-the-spanish-american-war"
+      ]
+    },
+    "71ae06db03ac5869432da505c6a75d45": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cherokee-removal-and-the-trail-of-tears"
+      ]
+    },
+    "71b0a89d5660fc01dc53b860287c6696": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "71b26110965bf76c38286352d6809e1e": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "71bb99087e5d68942eacd2fe8aae6e3a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "71c1c2b8f0279b05609ccc88cbbda636": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "71d76b5afba571b39c3dd16aa76ab00f": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "71d8661ff69d97fbe9de20fba22fd17b": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "71e9d52ed2ab294482e87e79b4c34b27": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "71f5340e5f828be407f28abec8111baa": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "72288d4e9eea59ee045caf8efcf15b67": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "john-brown-s-raid-on-harper-s-ferry"
+      ]
+    },
+    "7235fe9d49d65d3ca4240a7a1cf1137a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "john-brown-s-raid-on-harper-s-ferry"
+      ]
+    },
+    "7237fb0800dcb58ccbe6e14bcdbe3d54": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "72443e5097d400639d836ee05a6e14a8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "victorian-era"
+      ]
+    },
+    "7245f9997d821663222a54a3dde59580": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "creating-the-us-constitution"
+      ]
+    },
+    "725cacf9f8f7c45264a53d038c679914": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "environmental-preservation-in-the-progressive-era"
+      ]
+    },
+    "727650e123b4630d54443b614acb14cb": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "72d00207c6609998bf267de0b1010198": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-invention-of-the-telephone"
+      ]
+    },
+    "72d7fefeebb596e41b661e4bdbaac364": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-blues"
+      ]
+    },
+    "732c1d33eb211983e532f0ccc808c3f5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "perspectives-on-the-french-and-indian-war"
+      ]
+    },
+    "732f0b8ec881bdcd2c0b2b2690536590": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "735dd3885a41c1b01959ab79642596fc": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "737dcf32ea14534989114b734dfb680d": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "73989e310d5d26ca8cec72a9e8fc042e": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "73b9f7b5b2fac522e5ec8ab9ff9bc366": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pop-art-in-the-us"
+      ]
+    },
+    "73c31cc46d30c32cb5c4ca51b3ab3f94": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "73d399b083a16665072a573b0faf28d3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "postwar-rise-of-the-suburbs"
+      ]
+    },
+    "73fbdd0672d05c24ea67626d6caef538": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fannie-lou-hamer-and-the-civil-rights-movement-in-rural-mississippi"
+      ]
+    },
+    "73feb8626b2c3dbd62956cac7ec65706": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "74062bac6a963bc8891c4be837b4cf5e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-woman-warrior-by-maxine-hong-kingston"
+      ]
+    },
+    "740cddbd5234d594a2082a1781c07543": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-equal-rights-amendment"
+      ]
+    },
+    "74379e505752c968eaa1f3b17e6d9171": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-yellow-fever-epidemic-of-1878"
+      ]
+    },
+    "7449cbb9b9b106a39f37f6500c99d865": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "there-is-no-cure-for-polio"
+      ]
+    },
+    "745fd384dfa6b4b7c31c6c33754ce8b6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-s-suffrage-the-campaign-for-the-nineteenth-amendment"
+      ]
+    },
+    "748ab3ae6a447fa45edd4e22565a9766": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "748d317ce2556c8a9e474a7ac4012847": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "social-realism"
+      ]
+    },
+    "749c9341321cced7ef6c5b25774fc4bb": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "74bde53d61d8a37712e4456805af0acf": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "74ed082f3d8c99f67deae3b053a0485b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fire-next-time-by-james-baldwin"
+      ]
+    },
+    "74f22065b8b5d2910c4aeb566af54391": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "creating-the-us-constitution",
+        "shays-rebellion"
+      ]
+    },
+    "7505c90cbe08d765803f1dbbec39fe0a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "negro-league-baseball"
+      ]
+    },
+    "751831699f2e11bdedca38edf90e7113": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "a-raisin-in-the-sun-by-lorraine-hansberry"
+      ]
+    },
+    "7530d44c0e7c2ae4046fa04e491e5467": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "7532a1fe7168fa10df78b0795ed8e1ee": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "757da4a7813cd4a0daec26c397aeb1ee": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "758168a4cf4c679dad15ae7f031885ce": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "elie-wiesel-s-night-and-the-holocaust"
+      ]
+    },
+    "758b7c711c404579221f34a64f4dfe1a": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "759d45c3be444615162caca7e92c7ea9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "boomtimes-again-twentieth-century-mining-in-the-mojave-desert"
+      ]
+    },
+    "75acbc1f6368fa23ad7750109441a9d0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-of-the-antebellum-reform-movement"
+      ]
+    },
+    "75c331ad7a84d7e4d91c1770d8a230bc": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "75ce0b3291c6a9f4f8c69d61f2698786": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exploration-of-the-americas"
+      ]
+    },
+    "75d0f0eba89780358413fbe01255510a": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "75e08d374eb576274eb44c279d403592": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "spanish-missions-in-california"
+      ]
+    },
+    "75f37238a66c3f54aa5907763d2276e1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-equal-rights-amendment"
+      ]
+    },
+    "75fe7e1a561ef0f94128ff0ab438b140": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "7612052ec3fcd48ce25964f4837c865d": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "76143bcf9f6fede4b0c619bba4bd1857": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": [
+        "world-war-i-america-heads-to-war"
+      ]
+    },
+    "76188c4758c04f7c024713d8556e3dc1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "colonial-religion"
+      ]
+    },
+    "761be283c7d2c3e5895b7076b514b979": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-wounded-knee-massacre"
+      ]
+    },
+    "761f86bdb2db41d2fae63df3fae85023": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "7633733ecaa58307ca72dd784e5f2514": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "battle-of-gettysburg"
+      ]
+    },
+    "763e79f2adb4b79cb08801a71ea5bfe3": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "76585f60967f99e1857bc4207224c63d": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "766840182b2aaad29ca36e379fb31aab": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "spanish-missions-in-california"
+      ]
+    },
+    "7683bc80b832bbceb16a1d6017ffc7e0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "henry-clay-the-great-compromiser"
+      ]
+    },
+    "76a58daedeb3f863019bb3d8a857f9d5": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "76c45c7662e92a02e02f4f7e6ba2d864": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "76d2e89ea43b6bda1b0eed609c636c99": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "76e0fbd61b3f30db6aa2f280d74293ac": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "of-mice-and-men-by-john-steinbeck"
+      ]
+    },
+    "76fb75fe63ef025f6fd0b12d99b6a24e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "revolutionary-war-turning-points-saratoga-and-valley-forge"
+      ]
+    },
+    "76fd4607080ba9e4592780a422fd6a0e": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "7702c594181a097dc06fa478b6e3a3c6": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "7719d5975f919e388948331c68ee53e5": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "771a51d5399fda80328337d802f95c9d": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "773ea5dce5f76e136ff6f39d336ffed9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-colonies-motivations-and-realities"
+      ]
+    },
+    "7746d7498788f92bd9a3707833f787f5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "victorian-era"
+      ]
+    },
+    "7750d8aa639e8c26d1512981af6839a9": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "775ed2148a1220ef247927f3f04133ce": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-in-the-civil-war"
+      ]
+    },
+    "7776e7cfd939ff756bb870dea3488493": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "full-steam-ahead-the-steam-engine-and-transportation-in-the-nineteenth-century"
+      ]
+    },
+    "778f7cf1ab134fa123e11050b9bfd878": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "77aafeb1a2d4ac0cde82f7800975f3e0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "early-chinese-immigration-to-the-us"
+      ]
+    },
+    "77aea8565b52680097d7098ce1ae26f3": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "77bd2cc5f22bdf50d5bf86c89ccb45a5": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "77c9f7ae2c7a1bd706d5c3c844b72b88": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-strike"
+      ]
+    },
+    "77d558aaeb2b653e9cb4548724b70a22": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "social-realism"
+      ]
+    },
+    "77f0918af5ecf7a043e8fddb8882f9ce": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fake-news-in-the-1890s-yellow-journalism"
+      ]
+    },
+    "77f50c66d4b5cdd97e15cec5d04a7a47": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-freedmen-s-bureau"
+      ]
+    },
+    "77f8d29620483a32a35262d75b03f288": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "77f921b55dfe39642ca20ee993a41fc7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-wounded-knee-massacre"
+      ]
+    },
+    "7802d07652d976301b04af522dcd9cbd": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "780796cb197f3d2faa42133ced186d76": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "7815ddbda7746873a2569f37edb3014c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "voting-rights-act-of-1965"
+      ]
+    },
+    "782ae237741d52c39262a3150fa385ce": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "negro-league-baseball"
+      ]
+    },
+    "7847ceeb2869faf148db999e27b90366": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "78785eee884562000e8ae875b0ce02a2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "early-chinese-immigration-to-the-us"
+      ]
+    },
+    "7893b0e26cb55418d216b5a4b387457d": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "78a6d7a54b72561442bae3e53c5b55e0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-hudson-river-school"
+      ]
+    },
+    "78a70a86bf33ba966c5d2a534fd05b4a": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "78ac6edaba77977f24e6b7e076d6eca7": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "78ae9acd2d9dd717639ba6ead2d38f60": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "78afaf073426ebf22fd86e7bffc94668": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "78dbc26b351a63743064e683496e8c00": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "78e7908b9275d0e5bbc59581b0ff471e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "treaty-of-versailles-and-the-end-of-world-war-i"
+      ]
+    },
+    "791f68cbe2e41f677598bf9dafd37202": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "7934a66e3d40ea9d4ac65e8dc3d4f4e1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fire-next-time-by-james-baldwin"
+      ]
+    },
+    "793c1f551cc2ef6046a2fa7a8a28f5fa": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "79556db9d1bbdce98432746056e13008": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-imperialism-the-spanish-american-war"
+      ]
+    },
+    "795cdd14de839079ec76244c7b4423b0": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "795dc282d31aef467bc33f29bd2a6905": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "reservations-resistance-and-the-indian-reorganization-act-1900-1940"
+      ]
+    },
+    "7976290d5154e620eec7f22a593e4f87": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panama-canal"
+      ]
+    },
+    "797b1aca29bacbc916d86242fc5bf4e4": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "7986e0d9726310d6108b9970404261c1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-acts"
+      ]
+    },
+    "7989d010c73bc2226385dfc36405941a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-yellow-fever-epidemic-of-1878"
+      ]
+    },
+    "79974831fe91cdbbebd57baa2d95eb09": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "eugenics-movement-in-the-united-states"
+      ]
+    },
+    "79a616dbfbe4f275f4d2f94109f49d38": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "79ad5b02d4998678298a783a8f290d60": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "postwar-rise-of-the-suburbs"
+      ]
+    },
+    "79c12abe28396d7043a1c500e9b33c77": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "79d1a2e34104a17261c3bd516fb931c1": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "79dbffcc5c69d3771244099ad09fb53a": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "7a0f731b565863e1e815260d39930cd0": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "7a2f62daf223e4b30f1e30e1989db472": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "7a3fb09780e324427c4e22368245295b": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "7a4da9dfdb661a5d12e99ccc6269ab11": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "7a7cc3bacbf4c85c8c07c2c17b8173fa": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "social-realism"
+      ]
+    },
+    "7a981303e8a0f07aeb36a72a7cf92a15": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-migration"
+      ]
+    },
+    "7abbbafc45699147f0ae6639b6023885": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "7abc52ebb9497725120b9289364afe70": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-transatlantic-slave-trade"
+      ]
+    },
+    "7ac5fc13c3f7f9c0e576d41d524b0b1e": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "7accf8908b87cd4e9c5c43d0301dc7b5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "ida-b-wells-and-anti-lynching-activism"
+      ]
+    },
+    "7ad73b1f911079fd5b694c2bf81cb414": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exodusters-african-american-migration-to-the-great-plains"
+      ]
+    },
+    "7adf1d1579026fe77e325aa17fafc9a6": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "7ae51a3af61dcecd6fe439ebab1e3086": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "7b002b78d77f07117f95e9d07322b4d3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "busing-beyond-school-desegregation-in-boston"
+      ]
+    },
+    "7b2a8cc259354a0140d91f251aa669e4": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "7b3b8e259a08f880d986d3b0b18efff1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-boston-tea-party"
+      ]
+    },
+    "7b70dcaae1d6002d9d778d74173cab7f": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "7ba2decb89dc7487653b5cff58d275c1": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "7ba736036213f45d6ee3463c198591e5": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "7bc080ea747147bb7a20b1966771043a": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "7bc0e002ef5530ac39085c0adac2c274": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "incidents-in-the-life-of-a-slave-girl-by-harriet-jacobs"
+      ]
+    },
+    "7bc250ac31b13c43c02b7f4a77f32e93": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "7bd106296bb62f379054f750cbaeabf8": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "7c013907b42c1baf4df428515d76082f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-indian-movement-1968-1978"
+      ]
+    },
+    "7c0ad06a4b746cf11b3acacdc4e44a19": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-hudson-river-school"
+      ]
+    },
+    "7c30c0e7238c504aa9835cb239ecfe9a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "second-ku-klux-klan-and-the-birth-of-a-nation"
+      ]
+    },
+    "7c5a42d8ffcd09f83ea624f16fc608c8": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "7c5ab84fd51a1d0e33fd92e350335ddd": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "7c6243374b2db40db8e749cf4847ab69": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "7c67b5bfd03f693f0c8481907de5f76f": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "7c75f28a105b5c4526016b4eef99f63e": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "7c91ea2f45ed1242a591567880053aa3": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "7c9a2842bed5010adf4cac947275bd43": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "7c9ba4cb971eb1020b9a982838c3ab27": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "7cb5e8957d3424d244bad2fbe1fa50aa": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "7ccc4e2ffde58dc9e059daea8284a865": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "treaty-of-versailles-and-the-end-of-world-war-i"
+      ]
+    },
+    "7cd1f65cfa2e12432b102e19e432ecfe": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "7d192a6cc822bb454e851ecd1e716714": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "7d215e58a51dbcac3018a77b9fc1fe8d": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "7d2e1afe6e53f19c63b89531193a24ea": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "7d30c06dbe047c4f386237bd08a5552f": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "7d40e75c893f2c0631eb9ce1824b780b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-adventures-of-huckleberry-finn-by-mark-twain"
+      ]
+    },
+    "7d4cccf3fcc8dbd66ba015cbf4e223bb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rise-of-conservatism-in-the-1980s"
+      ]
+    },
+    "7d505c483572b99b274e4928597edf7f": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "7d521b4598d731772f972a1f8b70abb7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "uncle-tom-s-cabin-by-harriet-beecher-stowe"
+      ]
+    },
+    "7d67ccc702c3e5994cf09ef6623e795b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pablo-picasso-s-guernica-and-modern-war"
+      ]
+    },
+    "7d6d32546571db10329387fe914107da": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "full-steam-ahead-the-steam-engine-and-transportation-in-the-nineteenth-century"
+      ]
+    },
+    "7d8cea2eeb0b647372ba7fb6ca58aef1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cuban-immigration-after-the-revolution-1959-1973"
+      ]
+    },
+    "7d8e02120b152cd0232c708e747c5b14": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-lewis-and-clark-expedition"
+      ]
+    },
+    "7d979e032e299308268483005be39e47": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "7db0f127cd792a1aa2c898617677634b": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "7db3d0554acc6751d3a997f03fbbbfb0": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "7dbabc02f95cfb5e0e9c0ea90c50a3e9": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "7dbc47e5949abd0d598d940b162381ce": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "dutch-new-netherland"
+      ]
+    },
+    "7dca6250cef240a8370a7ee777d92ba2": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "7dccc57e8ced0350330ef1aedc0c50d9": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "7dd456bcd662dc613fa9719f0b409532": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "electrifying-america"
+      ]
+    },
+    "7ddb0ddfa030c1ad9f490efade719aea": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "7dde533ec31ed65bfd4c223d5b90f2e0": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "7deb09be4a0d5b7d4caaf734479cde31": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-raven-by-edgar-allan-poe"
+      ]
+    },
+    "7df225f6872e9ff6ba6651bc5a1e51cf": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-black-power-movement"
+      ]
+    },
+    "7e23024f3dabd40549f48b48d11e1b2a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-i-america-heads-to-war"
+      ]
+    },
+    "7e30a8969742c36dbf63ba95d5ece540": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-boston-tea-party"
+      ]
+    },
+    "7e58757a36c8dfa3b3e20338ff864755": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "7e99f7414b3790f91dab5131bbd62306": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-invention-of-the-telephone"
+      ]
+    },
+    "7eb50743df37ad3f3de1b9477c014e60": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "7efcfa86f60fad80031d60f950f97b49": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "7efdc6aafca2fc61ddf165b856032dd8": {
+      "exhibitions": [
+        "gold-rush",
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "7f0f0aab11a7772f9bb810f116891d2e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "act-up-and-the-aids-crisis"
+      ]
+    },
+    "7f1ec4fd8b805005399b7715629560c5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "patronage-and-populism-the-politics-of-the-gilded-age"
+      ]
+    },
+    "7f21ee154f5f764e0889b085bf99c3a4": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "7f2497cd3f6a400a5d19cab0f70a7aa6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scopes-trial"
+      ]
+    },
+    "7f2e35fa9a9e3cb30e3b7db2c2f909e4": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "7f334eff06b506e2e3ad3c5d88f3d1af": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "treaty-of-versailles-and-the-end-of-world-war-i"
+      ]
+    },
+    "7f3640f2e88dd4650ad40e1b40ae0563": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "7f51495ccafcdd311981455379ada77d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-woman",
+        "women-s-suffrage-the-campaign-for-the-nineteenth-amendment"
+      ]
+    },
+    "7f587c9d9bae30734dfc514fdb0faf34": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "social-realism"
+      ]
+    },
+    "7f814f33ad3f7fd3686a2251c123e008": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mexican-labor-and-world-war-ii-the-bracero-program"
+      ]
+    },
+    "7f87a5af5d9f8f58f46b3019c90ba947": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exploration-of-the-americas"
+      ]
+    },
+    "7fbd6a05db4a2eca93be2ae1cb37d7c0": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "7fc661066cfc62296b98af0146224419": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "truth-justice-and-the-birth-of-the-superhero-comic-book"
+      ]
+    },
+    "7fd9fb34b5e436d8f0d7f871b52b178b": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "7ffd591c93fbe6ee029f30b84d2edd50": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "80040862e65ba822238854769bd7197b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "elie-wiesel-s-night-and-the-holocaust"
+      ]
+    },
+    "8015720c25e27e1dfc5e4792098b2f19": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "802860a05b2d8d8858626e3bf0d90507": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "802b8f38ffdea73d5dd825def6ae6e36": {
+      "exhibitions": [
+        "gold-rush",
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "8035cd456891b7034fa87808727aec14": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "80549414e743d4a9ac04848498738d6c": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "8069b56ea587e8148d76bbf6898001e7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "uncle-tom-s-cabin-by-harriet-beecher-stowe"
+      ]
+    },
+    "8082a546e25a2bd15e5196be27c0d751": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mormon-migration"
+      ]
+    },
+    "80b821ee9cc395a73fabc2f014290546": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cotton-gin-and-the-expansion-of-slavery"
+      ]
+    },
+    "80d09c2df44cc6b5121c5775932fa827": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-united-farm-workers-and-the-delano-grape-strike"
+      ]
+    },
+    "810aad4d4402c50919a1a31af41ea729": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mexican-labor-and-world-war-ii-the-bracero-program"
+      ]
+    },
+    "81170b174c68f134ef58431122daa6d1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pablo-picasso-s-guernica-and-modern-war"
+      ]
+    },
+    "8132ead3367a1a264f6040f978981e41": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "busing-beyond-school-desegregation-in-boston"
+      ]
+    },
+    "814f01579500604fbed263d36e4364c4": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "815b52395f207c348c8739c5dc3b982c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-abolitionist-movement"
+      ]
+    },
+    "8180a9e971c46037acff946e1be41e56": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-black-power-movement"
+      ]
+    },
+    "8189778e05b1575ba117f89c1b605fa4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "shays-rebellion"
+      ]
+    },
+    "818c034a379ab5febb742bac5a689e45": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "818f62f6b9cb0b9c2f5f93d6490b50cf": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cotton-gin-and-the-expansion-of-slavery"
+      ]
+    },
+    "81a0e8a722e56c9d36eef88418e2b08f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "boomtimes-again-twentieth-century-mining-in-the-mojave-desert"
+      ]
+    },
+    "81afe0659fcdc0b8a4d8e974c1a8b600": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "81b2bb54ecca9dbc44944c5f8b0d4b2a": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "81d59f1112868c8a552ab363d0e004d3": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "821567a4509c13c237dc63f2eb7fdb92": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-abolitionist-movement"
+      ]
+    },
+    "8220d3093692b9a9904b2c70edd2afc7": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "822b69c74b584f53a29230873e2deae2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "theodore-dreiser-s-sister-carrie-and-the-urbanization-of-chicago"
+      ]
+    },
+    "822e6a8a18a88ebee092525c4765739f": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "822ec78b8a6a5b11b1797e2d102e9f32": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "8230b9e7d2628362caea6e019f4d5c09": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "826167643834faa2cf931c4615552617": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panic-of-1837"
+      ]
+    },
+    "826fe861fdb0a251af4caa3c534188e0": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "828e1c0070e78a6eb3722e00393d7800": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "8295431583862b0cec91121e5afc6ad2": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "829eb6f7c6e9aa39e631d9cc14370d9e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "treaty-of-versailles-and-the-end-of-world-war-i"
+      ]
+    },
+    "82c28a42f02bccc8e32369ddb7eeddbe": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "82e0cc218544f76e1fa00258f85c2d76": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "82e4279312d8f5ac43f4223da59e2a0a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "visual-art-during-the-harlem-renaissance"
+      ]
+    },
+    "82ed5f91dc5238e0a4d7e707f622fc1b": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "82efe6ec6db67b79c39f401d64a87ef2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-deal"
+      ]
+    },
+    "831ce6f31c37ab66d037d219e5a7a39e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-atomic-bomb-and-the-nuclear-age"
+      ]
+    },
+    "832e56a849a36dcfdd0b2edf46adbc1f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "space-race"
+      ]
+    },
+    "833f8ae74438bbbb5fc74897168c3fe5": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": [
+        "world-war-ii-women-on-the-home-front"
+      ]
+    },
+    "8350e41a3ccbeeb8a96e21fb5474ecc3": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "836303376e1cd2b9aa7d07362279aacd": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "836b1000701eb6173f051e89f9871625": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "83824fcbb2a88d3f30b03814b5bfad51": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "83ab8119168ea5cb94af50edade40c3f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-transatlantic-slave-trade"
+      ]
+    },
+    "83d10ff2a17e25a249c4f95138416d7c": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "83d8bbd4c3b84c86b82e3538aeb99ebc": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "83f15b153d6555bdeac0b3b412576476": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-hudson-river-school"
+      ]
+    },
+    "84054fe4b9a5f10ef6aac7217f2a595b": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "842f67237ba235315fa57a4ee10ef9d3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-invention-of-the-telephone"
+      ]
+    },
+    "847377a4f7e2cc8bbab3637505de01a2": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "847ee8631528e9d971c9dad1ed4527c1": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "848ab350950069cb1db0e1f562eec538": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fire-next-time-by-james-baldwin"
+      ]
+    },
+    "849616ff61a5bdf96771bfbcb25b654e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "a-raisin-in-the-sun-by-lorraine-hansberry"
+      ]
+    },
+    "849c0bf94332952cc3b4e48aa74d0a17": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "849c1137784e96a4c92f2518884cab0a": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "84ba178cc0ebf1273a49bb420e0e1b30": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "84f0ff53a04e2536d1f59de01fabb2b6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cotton-gin-and-the-expansion-of-slavery"
+      ]
+    },
+    "8501088a0a069455e5218b38a87ae69c": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "850abc156158d925c758ea49ea4737fe": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "850e675f6e71f868f9241a2df5941ecf": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "8546c1f0ce7b0399d64631a1016ed530": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jitterbugs-swing-kids-and-lindy-hoppers"
+      ]
+    },
+    "8554e9eee6046e276bdfdea56e95869d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-emily-dickinson"
+      ]
+    },
+    "85674596ced99409968cdccd034403b7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pop-art-in-the-us"
+      ]
+    },
+    "857b2e136c322558566fed3df8cba689": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "invisible-man-by-ralph-ellison"
+      ]
+    },
+    "8598d8fe6fa02d23d952e154767bc2e6": {
+      "exhibitions": [
+        "children-progressive-era",
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "85a03779cbfecf578877714abe2a872d": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "85ba8c40ab601080c81e671f5edb3b8b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mormon-migration"
+      ]
+    },
+    "85bb3ab274181bcce3c2583147aa7147": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "85befcb14c374d90701578efc3986a39": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-columbian-exchange"
+      ]
+    },
+    "86103aa62aa75d677444c00fe45fd176": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "861b65dee665c3fc70b3c219e601c936": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "86377c8a8014d4a7c76a6323e7bd7258": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "86393e4c63d3c164bd26e45c2497d9d9": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "863ac78951225b8bbf0a1bc14ebe5a1c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-underground-railroad-and-the-fugitive-slave-act-of-1850"
+      ]
+    },
+    "8643a746bc8a5c3eed1c0d04e1f85684": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-emily-dickinson"
+      ]
+    },
+    "8645ead31f94ba1419f53c12004bcd85": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-grapes-of-wrath-by-john-steinbeck"
+      ]
+    },
+    "864764071dc513912253a4b721a72b7b": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "864e7d539a28e7a5a3ca23957000207a": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "86544ce69cc5d0677a175501a3b64179": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "8654700462531253e469c773dac274d5": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "86a0b69d881ede0609c5478d9bedf4b1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "little-women-by-louisa-may-alcott"
+      ]
+    },
+    "86a432db252a1949f5d3a8f1b5cdddac": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "86bc4afefd36754267e542eb0d2f6f3d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fannie-lou-hamer-and-the-civil-rights-movement-in-rural-mississippi"
+      ]
+    },
+    "86cc9584a60b31a41e3b3638e15d6cd2": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "86e1d08305c257233a8e59e0acd64159": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-maya-angelou"
+      ]
+    },
+    "86e96c8baf0d0bef59cb9e0a9a8031a6": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "87006c6afdbbac332383849e8a9e778c": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "87012dbe49129e4a5eddbee46f29606c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-temperance-movement"
+      ]
+    },
+    "87015f6a3543997da62a201c8efbd9d9": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "87037c8c0dc514bfd19bddbce9ff2ce7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "perspectives-on-the-french-and-indian-war"
+      ]
+    },
+    "8722a15545fb3418c72784d94d530ba9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mormon-migration"
+      ]
+    },
+    "874cc005b50c606f5b569f452804b0c3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frank-lloyd-wright-and-modern-american-architecture"
+      ]
+    },
+    "877054664144845cf010c35b4da7a6c5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "colonial-religion"
+      ]
+    },
+    "87a0c7c56a51dc95c088d09e5f8fcc37": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "87b624673df509250073242b99fbf52d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "manifest-destiny"
+      ]
+    },
+    "87b8f01ec2ce02426d5bc895f331c354": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frederick-douglass-and-abraham-lincoln"
+      ]
+    },
+    "87df7b5a59aa8e9472c4ab2d1ae2ee56": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-golden-age-of-broadway"
+      ]
+    },
+    "87f8ec60b8734afde39419339379d53f": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "88247d7588aa7831f6a26c36c38d6dd9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-absolutely-true-diary-of-a-part-time-indian-by-sherman-alexie"
+      ]
+    },
+    "883674420e41f8fad2949ec603cca58e": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "883dc41b7157c2376d2dce35dfbc66fd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "truth-justice-and-the-birth-of-the-superhero-comic-book"
+      ]
+    },
+    "88557d4b1effd8ff66791298c36f791d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "nineteenth-century-schools-for-the-deaf-and-blind"
+      ]
+    },
+    "885fd1d49489157b63c516bb9a033668": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "88694bade10d9a1f2885761a676041b9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-columbian-exchange"
+      ]
+    },
+    "8880ff0227ebb12070f5979a42286d50": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "888ba4428f4c2270a8d5f5e608c5cf80": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "secession-of-the-southern-states"
+      ]
+    },
+    "888dc7df4b5867a4282d277df838db3b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "patronage-and-populism-the-politics-of-the-gilded-age"
+      ]
+    },
+    "88a13fa36cf1994eb9d29f339e3e7ac5": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "88a3414d4bbf3acb5a235fa0c4937db8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-through-angel-island"
+      ]
+    },
+    "88ac057d8ed2b784b7971c62f8d22761": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-columbian-exchange"
+      ]
+    },
+    "88b32941f3681b6a4a49cc50953f15c9": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "88bcd9a524b02dee3b667c0c8cda1baf": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "to-kill-a-mockingbird-by-harper-lee"
+      ]
+    },
+    "88c3b083a46bc179a4edee2f89660e5b": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "88da5efcbed768111411f92df930cd59": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "890b9b7a19b6140d2e9db55d7d6fe030": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scopes-trial"
+      ]
+    },
+    "89110e386fc29925bec1fccd2f2a55f2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-grapes-of-wrath-by-john-steinbeck"
+      ]
+    },
+    "891125144ff870cdf901a18bfe4372c2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "colonial-religion"
+      ]
+    },
+    "892d41c6b3a030075bdd61ab8663dd45": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "attacks-on-american-soil-pearl-harbor-and-september-11"
+      ]
+    },
+    "89350965bada5529c85f93c43088a7a8": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "89416a286774820d92828d91d22c251e": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "8952b18dde43949537d27cf2dff3d773": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "89796a448f031ef60f804b9122235e17": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "89893bb0aa0e5eb2b62488341d8cda75": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-maya-angelou"
+      ]
+    },
+    "898c9b0ca06fae401f0bbf6fe0003bd3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cherokee-removal-and-the-trail-of-tears"
+      ]
+    },
+    "898df2f39aeddabad178fc971b36d451": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-lewis-and-clark-expedition"
+      ]
+    },
+    "89b1104a78007225021a53b01516cf36": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pop-art-in-the-us"
+      ]
+    },
+    "89b81cd69f7653b46ec58401fd0e349d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-watsons-go-to-birmingham-1963-by-christopher-paul-curtis"
+      ]
+    },
+    "89d75123e99a06ac4c4561c3adeb849d": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "89dcbf2b7e43c981f27c30b265ba9ff0": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "89ddd867d31c89a7763d9f8f4484888c": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "89e2a968a39ae200e937154df89a28e0": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "89eb042a29700ee49db183edbdac3116": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "89f4abb49a39e2040e928aecc46315af": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cotton-gin-and-the-expansion-of-slavery"
+      ]
+    },
+    "8a34097426ba35a0ae94e42557307e65": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-through-angel-island"
+      ]
+    },
+    "8a51f04b3660f4242112b29ee4a59a61": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "negro-league-baseball"
+      ]
+    },
+    "8a5b0ed743d4fba765821859b6049091": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "little-women-by-louisa-may-alcott"
+      ]
+    },
+    "8a64b00808ac30adf619d1e43a951cfb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "commodore-perry-s-expedition-to-japan"
+      ]
+    },
+    "8a7f0d605855a20616536112304586f5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cotton-gin-and-the-expansion-of-slavery"
+      ]
+    },
+    "8a929ccf2049341e5a26f12321344c03": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "8a956b98750cb74aee2e816df5e11673": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "8ab4f71b5b748bc37fb65fe064d2d88e": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "8ad109f66a58cbf3fdb9e2cab240dd75": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "revolutionary-war-turning-points-saratoga-and-valley-forge"
+      ]
+    },
+    "8ad359639b26a30a96792e3a65a071f6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-raven-by-edgar-allan-poe"
+      ]
+    },
+    "8ad64333bf9bc7ba45775c1f55a4c90f": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "8ad907f0b8421ca5aafa84827d98fe60": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scarlet-letter-by-nathaniel-hawthorne"
+      ]
+    },
+    "8aebf7ceafcd8e84a37ee780192856c9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "act-up-and-the-aids-crisis"
+      ]
+    },
+    "8b17133a18de73d6ba7d0a36b132d7ed": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "8b2050fc10ec27456da23c88d9d2b8ce": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-rise-of-italian-fascism-and-its-influence-on-europe"
+      ]
+    },
+    "8b270200a24c4e994467620c9d0efd7c": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "8b47935c636a0624671121831591800d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-atomic-bomb-and-the-nuclear-age"
+      ]
+    },
+    "8b4c4750ad7de51396a00ed90eb848ae": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "8b4e7d380ec73bc62428f78196e06a25": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "a-raisin-in-the-sun-by-lorraine-hansberry"
+      ]
+    },
+    "8b6d7018d9f968ef7e13c5fbedd88338": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "8b6f8ca6cc1105f9767cfcd79bf854cb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fire-next-time-by-james-baldwin"
+      ]
+    },
+    "8b758f2f403528f7933e36fb891197df": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-s-suffrage-the-campaign-for-the-nineteenth-amendment"
+      ]
+    },
+    "8b7e2538f279061e1b42d868f97e8203": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "8b801ae265920894719986bc2df0abf1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cross-cultural-colonial-conflicts"
+      ]
+    },
+    "8b938408684adf790536e4d608d97ae7": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "8bbadebadfeb5534b52c1af4304776c0": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "8bbfddd84dc3f7c581fe4fb6acd8e913": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "8bc54d540ed276aadd08279bf58136d8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frederick-douglass-and-abraham-lincoln"
+      ]
+    },
+    "8bc9ba97023753425ab0feb0c94cbbb0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "creating-the-us-constitution"
+      ]
+    },
+    "8bdb3e336641ab822791a576ab91c62b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-imperialism-the-spanish-american-war"
+      ]
+    },
+    "8c01a41c17c0e22c06a668b543c8ae17": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "8c08e491f90f73f8859ae3a76c73203d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panama-canal"
+      ]
+    },
+    "8c102f33bcfb9e64e6adc293e41e820b": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "8c140eab1b23a90cb5d20961a8c4ace2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "manifest-destiny"
+      ]
+    },
+    "8c1d06b93d1d8d19f5a13279c8cb163b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jitterbugs-swing-kids-and-lindy-hoppers"
+      ]
+    },
+    "8c2d4f483e1c1cb860d9cc44d7f125c9": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "8c352b820cf89e43445a2487ddc3b6c5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "full-steam-ahead-the-steam-engine-and-transportation-in-the-nineteenth-century"
+      ]
+    },
+    "8c4062d58d1d80fa924d18a91ed6239b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-gatsby-by-f-scott-fitzgerald"
+      ]
+    },
+    "8c4e32ff1fe7a3a5c6ed614100f6d845": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-equal-rights-amendment"
+      ]
+    },
+    "8c5214aedd753d3be99475923e473cae": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "8c59663029792e36b14d630cad59dfd6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frederick-douglass-and-abraham-lincoln"
+      ]
+    },
+    "8c7db23a6d492a6065dbb0e8e6f8c213": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-abolitionist-movement"
+      ]
+    },
+    "8c86020373de10fe03dff9014846aa62": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "postwar-rise-of-the-suburbs"
+      ]
+    },
+    "8c86d0b8603d68da52c0e020edcce330": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "8c92bd35df28535364db056fc0135bb3": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "8c9b42f2e7ea4d63314119261b236b72": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "8caba62b34f3acfb24f7a49c85656d0e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "henry-clay-the-great-compromiser"
+      ]
+    },
+    "8d06694fe853119155585a7ff50ef52a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scarlet-letter-by-nathaniel-hawthorne"
+      ]
+    },
+    "8d06a5263751a7feb763b8912aa58bb6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pop-art-in-the-us"
+      ]
+    },
+    "8d121c16d8de9ba06f50b032dfdab2e3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "lyndon-johnson-s-great-society"
+      ]
+    },
+    "8d1d01b1a19b417893042e7705ccce9e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "feeding-the-hungry-with-food-stamp-programs"
+      ]
+    },
+    "8d20d216adc1d0c4166f0b07fe337745": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "8d4bd9c043acecdcd03c8d791f9667f2": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "8d56ee75cf6cd0ddbc2bdfac004fb229": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frank-lloyd-wright-and-modern-american-architecture"
+      ]
+    },
+    "8d5a4b7ce6089eef65c878fcc998866f": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "8d6ec403adef58fe19dd5badea8f0e52": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "colonial-religion"
+      ]
+    },
+    "8d75960db0dec8d5cc9350e33ffd58ee": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "8d9b03fcae2825674837dc7345a13537": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "8d9ed327731b9495f55ac6b5feda7463": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-impact-of-television-on-news-media"
+      ]
+    },
+    "8db30d1e15bec8d255176a887a82c455": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "8dd3cd8e3f4a3d2c06d0f46fedd1f5cf": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "8de798db5dd1583c3ba1d1f6039a2cff": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "8def15ec6e5fb5e838b5e650496cec7b": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "8e35b4d7fe9b23457a1f3f8321e78d70": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "8e4a55e272f8811491c462f115801805": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "of-mice-and-men-by-john-steinbeck"
+      ]
+    },
+    "8e74662c8af21cb99ed1b3f4f393c5d1": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "8e75bc4a27f9681e061a55b168132489": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-adventures-of-huckleberry-finn-by-mark-twain"
+      ]
+    },
+    "8e8f4124310bab5f86b336cb30ec87d5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "reservations-resistance-and-the-indian-reorganization-act-1900-1940"
+      ]
+    },
+    "8ea2da40f42fc8831a2882a6d3040e3c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "victorian-era"
+      ]
+    },
+    "8ed77001b70f769931f04b6f8b272140": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "stonewall-and-its-impact-on-the-gay-liberation-movement"
+      ]
+    },
+    "8efabd3fdb44542a11a3fa1948caa088": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-colonies-motivations-and-realities"
+      ]
+    },
+    "8f2cd74c55ed47e1775e57c1f78d167c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "when-miners-strike-west-virginia-coal-mining-and-labor-history"
+      ]
+    },
+    "8f35f37a47a15dcf2d069b941d7aac30": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "8f38f893b4dd79d2fd6a8d464dbf03ac": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jitterbugs-swing-kids-and-lindy-hoppers"
+      ]
+    },
+    "8f3e3904b2cb87959970a995f12d3833": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "8f6a51ec6d265bce9ce9174808e992fd": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "8f6f513946083642a1fd1aa7ef95bddf": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "8f750ed40bf1db08410957142e70d37c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "henry-clay-the-great-compromiser"
+      ]
+    },
+    "8f79660a23b17cb92cf8abd410167e06": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "busing-beyond-school-desegregation-in-boston"
+      ]
+    },
+    "8fa6d13228bc667fe8a3288b85290a9a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-woman"
+      ]
+    },
+    "8fb5de7373858a8014c03bae1036ce82": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rock-and-roll-beginnings-to-woodstock"
+      ]
+    },
+    "8fdc4cecc932be68b7af2180ed2468d8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "ida-b-wells-and-anti-lynching-activism"
+      ]
+    },
+    "8feecafdb1414356a26d9db69414331c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "uncle-tom-s-cabin-by-harriet-beecher-stowe"
+      ]
+    },
+    "8ff69eed48a2e411f84759c860457804": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "9001a9b27ca0ccb013abdbe2d8e4e297": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-women-on-the-home-front"
+      ]
+    },
+    "900f611a6436ec199875fc78f06abea6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "second-ku-klux-klan-and-the-birth-of-a-nation"
+      ]
+    },
+    "9051ed577b628317be9ca20e0efe16fb": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "90666b71405cd1655a38de0836f986b1": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "907a41aa50eb89a67eb0bcd98b2bc512": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "907f5430e9d86582f475ef48e4ef79ca": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-strike"
+      ]
+    },
+    "9083ad7c057cf96cae92f709bca12bde": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "9088723521d57d1ac81963cf8a4687c2": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "908d23973d2e7c4acc1e9350f8ee238c": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "90958abcba39a1c07c6f7d2270a9257e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-in-the-civil-war"
+      ]
+    },
+    "909dce97401a7518b730b0a61a809346": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beginnings-of-the-american-red-cross"
+      ]
+    },
+    "90b1bc45abb81ad2e69c80a6b7911ac9": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "90c92b3437171c6cfafc884f82911e8b": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "90f1c3612f525d3b19b0d7fa80434725": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "90fd51f638972d31960bb5cdd8fb8d07": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "9127289c0b4a0e86e0b518ac9cf4a29f": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "915d7d0626428accd0d5f164a0883959": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "915e1e319cceec20c34c61e02afd54d8": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "916a912bd160a58bdfe1bb3a12a99156": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cherokee-removal-and-the-trail-of-tears"
+      ]
+    },
+    "916fd7183bd26561cc30eff825b6b226": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "negro-league-baseball"
+      ]
+    },
+    "917954b899478aede9b6102d9a28dc19": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "9187e6be1e1e9db0ead9144ef5d0dd5f": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "91911f1c32207960397776ac48702821": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-boston-tea-party"
+      ]
+    },
+    "919926dd983f72d68acbc782e8bd6601": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "91a280f6bc84f93d0d66ab97ac961a97": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "91b71f0ea9268c821cca2c2154393308": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "91badd6dbadda9b6e8b295e47d8d070c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "of-mice-and-men-by-john-steinbeck"
+      ]
+    },
+    "91bd63c9cceae6af0ea190b7b8ebb40a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "boomtimes-again-twentieth-century-mining-in-the-mojave-desert"
+      ]
+    },
+    "91c5fdf7c118506c61c103d889bdedb6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "to-kill-a-mockingbird-by-harper-lee"
+      ]
+    },
+    "91c60849686a902b52fba553cd99e04f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-i-america-heads-to-war"
+      ]
+    },
+    "91c64f55e9e02c3644edb981627a6327": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "91d2d9cc6bf33508583cb4af2f4d2776": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "91e77ebca91e18548fdc315bb4e925e4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-watsons-go-to-birmingham-1963-by-christopher-paul-curtis"
+      ]
+    },
+    "920e087e08819f16dcbe7949b8cf0ca0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rise-of-conservatism-in-the-1980s"
+      ]
+    },
+    "9235417714ccecbf41eed15ad0418dc8": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "923ad1dde3a677fcb6c3078fa7077e38": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-wounded-knee-massacre"
+      ]
+    },
+    "92402d3c3c27316c6d7c931bfb366bec": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "9275bc34eede3e992e608ba43e3a45b6": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "92878c018c9f5736c9eeb6fb22dbe59f": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "929276a7174d9011de92a5809d3319d3": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "92a91ad56244473a07939bbafd7ba49e": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "92b46c845cb861b83520bf07625273ca": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "social-realism"
+      ]
+    },
+    "92c35f7c191abd271fc443d0f4243a02": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "93161388cfff8c63add7e4101aa86233": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "japanese-american-internment-during-world-war-ii"
+      ]
+    },
+    "93236305295b82defe62eaae4eec7a20": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "to-kill-a-mockingbird-by-harper-lee"
+      ]
+    },
+    "9327c62b98768cb15f2c5d7be123f42c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "stonewall-and-its-impact-on-the-gay-liberation-movement"
+      ]
+    },
+    "932e44092f0eadcf50195cf6ff1c30e1": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "9339d99be8ca4eb3261b10bbe4e296ab": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "9341c1fa9698b843f90312949e427b04": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "reservations-resistance-and-the-indian-reorganization-act-1900-1940"
+      ]
+    },
+    "9342c0788caa9f6cda435a2b57aaad19": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "93460d2e2531158f9a9cdea6d69a1994": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "victorian-era"
+      ]
+    },
+    "935f8e26f883b80449730cf475825bf7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mexican-labor-and-world-war-ii-the-bracero-program"
+      ]
+    },
+    "9386687f7a897160e2209167b40dce7c": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "93971ba38ec9f4419af2a32c44bf0c6e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fannie-lou-hamer-and-the-civil-rights-movement-in-rural-mississippi"
+      ]
+    },
+    "93c06e778e5a54d04463a848e533f939": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "patronage-and-populism-the-politics-of-the-gilded-age"
+      ]
+    },
+    "93c3845eaeb82c8722ffc32d1f7d73ed": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "93cb0346b15ba9ce6268e644023c2a35": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "93cb3455f966dd7201ddb4f1de2f7a6a": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "93cf0835df70dc032542089c58f49787": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "93d709bbd7ae06a35eafcde4c67114ab": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "93eb1c929b351123f792553233d561cc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frank-lloyd-wright-and-modern-american-architecture"
+      ]
+    },
+    "93f90708efb94716d1daed2e72e2bf89": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-and-americanization-1880-1930"
+      ]
+    },
+    "9406c429c27035fa3d3efa731a481f18": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "941a5d477dbe4d20b3bbdea0268c3a9b": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "94247f4795791cb33a24665a2b8533b8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "commodore-perry-s-expedition-to-japan"
+      ]
+    },
+    "9438fba6e8143b832263885e4390b6cc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pablo-picasso-s-guernica-and-modern-war"
+      ]
+    },
+    "9447874b56b8dbd34ea589c7de2c0519": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "944d594fadc88f84b6803cc236c03a71": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "945c61f26d4d2b198fad946a4c90fdfa": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "9463c88ae32695c8e01b827097d5fec4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-of-the-antebellum-reform-movement"
+      ]
+    },
+    "9470eaf5ec9036693e28ddde2d5e5891": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-gatsby-by-f-scott-fitzgerald"
+      ]
+    },
+    "94965de550e24dfff0251d273a82ffb7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "henry-clay-the-great-compromiser"
+      ]
+    },
+    "949b7a9cad0f892c4240886ccaaf143d": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "94a1838dc070b4aba2d0a4fc32779dcf": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "94bbe540c813d363a7a7a0516ca61e22": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-yellow-fever-epidemic-of-1878"
+      ]
+    },
+    "94c2b5e84a09e70210b762348ddd5e5a": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "94cdd3b1ee6033fc6362fcd96ac7e9cb": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": [
+        "early-chinese-immigration-to-the-us"
+      ]
+    },
+    "950280f7a7dcf858135502e982cf3fac": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "to-kill-a-mockingbird-by-harper-lee"
+      ]
+    },
+    "950ce71dff3e059fb1976145b985046a": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "950cf1bc974ccb77fb8a3a494529d672": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "reservations-resistance-and-the-indian-reorganization-act-1900-1940"
+      ]
+    },
+    "9516d75ad91d4460bb820847081f9382": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "a-raisin-in-the-sun-by-lorraine-hansberry"
+      ]
+    },
+    "95263807f6954c312567cf474bbd4dd9": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "953ed5dab99c0d286f93b17f227493c3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-whaling-industry"
+      ]
+    },
+    "95557105d08993516702587b5982e293": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-raven-by-edgar-allan-poe"
+      ]
+    },
+    "9562a6a62c121e50eec67c89c0832f2f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "california-gold-rush"
+      ]
+    },
+    "9574287d0627796a85ee3fbb985cb838": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "957ef3459c838e7fee7e01b18b743b66": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "95ba39c25f08c4657f1769d026e21966": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "95cb6e335b06f814aecd9c01c4370118": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "african-american-soldiers-in-world-war-i"
+      ]
+    },
+    "95cd360a9338cafa4be46d8544e2f221": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "95f7fda47cf002549c92c42e3b127113": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "96135b857c9a5ebc2b4dfeb50071f8ea": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "964fba4e90b88fb09fcd02ffc8a7b19b": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "965ccd48847dd26afc75564911f38790": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "full-steam-ahead-the-steam-engine-and-transportation-in-the-nineteenth-century"
+      ]
+    },
+    "96882d7e6bc99e66ce922c7182cd6d91": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "96a182da677d2d39125e179127a6541c": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "96a985cc5dee672bb681af447e1c740b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-through-angel-island"
+      ]
+    },
+    "96bae468b09c25c486054597ad5d744e": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "96d60b8bf26d5ec98c9bd4d4eb6140a4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-boston-tea-party"
+      ]
+    },
+    "96d74564c76029e9eb09a91955f6e912": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "96dd3376e522b64e8ad138bce0d68004": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-deal"
+      ]
+    },
+    "96ddbc49ec555b7d09095363db887dac": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "96dfce181410cb866f7e3f55253c7844": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "96e0c3f2a21de853609be6b0e600f765": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "96e462ccb6b2d5a784b28bc67d823c9c": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "9718961e5eafe42c094be044cced2fdb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "revolutionary-war-turning-points-saratoga-and-valley-forge"
+      ]
+    },
+    "971a499145ce92d6f77eb0b15c241389": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cherokee-removal-and-the-trail-of-tears"
+      ]
+    },
+    "9726f692d01dab12de526ff852401786": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "97321ea9b26faf6b8a12e82d0b4f6156": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "9739de53eb8e1a5e1dea6308697a7ae3": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "973a3266520797684f0d553a3d537ba4": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "9746336221612cd4a7a22ce8819c60be": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mexican-labor-and-world-war-ii-the-bracero-program"
+      ]
+    },
+    "974c08d9859dc555f58fdd78a36c118b": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "9759569f9859a5370373f707e995156b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "spanish-missions-in-california"
+      ]
+    },
+    "975fec010aae0cd945d8c914d99bd996": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "truth-justice-and-the-birth-of-the-superhero-comic-book"
+      ]
+    },
+    "976507b8990b89bb66d3d6238d46e36a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-atomic-bomb-and-the-nuclear-age"
+      ]
+    },
+    "978323e0b247af7d88cf736db800c454": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "97863d9600136fa8f78d4a71d90cc2bd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "declaration-of-the-rights-of-man-and-of-the-citizen"
+      ]
+    },
+    "978b0a5e5442b1906257f07dac220a79": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "97a0b80a07c07dc91cdad995ba3a9de7": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "97cfaa193ea3df3b2c50a4a751626743": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cuban-immigration-after-the-revolution-1959-1973"
+      ]
+    },
+    "97d195f80e3093e288be62750cc7d598": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "97d726eb5a964e4a3a2866f35c099f2e": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "97f92913cabdd26b0b07b0973cb92b43": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "980729f9329919e14b4bc26204640edc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-lewis-and-clark-expedition"
+      ]
+    },
+    "980f4bdd16e8bbe23ff742977cb2b9bb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scarlet-letter-by-nathaniel-hawthorne"
+      ]
+    },
+    "980ff00c8c0036b868fa5ada237ae616": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "9820336ea0b0d063ad5cd9b1fa03ba11": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "latin-american-revolutionaries"
+      ]
+    },
+    "982a71e1da4c8b2761e885865db6638f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-things-they-carried-by-tim-o-brien"
+      ]
+    },
+    "984c3697d4b9c8625200997923e9ff31": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pop-art-in-the-us"
+      ]
+    },
+    "985cf07abeb336d7d90915d48626ced5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cotton-gin-and-the-expansion-of-slavery"
+      ]
+    },
+    "9868926a0037d30b309113c5f9ff4d2b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "attacks-on-american-soil-pearl-harbor-and-september-11"
+      ]
+    },
+    "98767a4f99c2ce2f70d6cc1e5d0b91a8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-i-america-heads-to-war"
+      ]
+    },
+    "988116c94d3c416d0c1395a318e7648c": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "988e63426c7541fde9ee2541d51296ca": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "989110df8d599199c4d17fe2f7fe2e78": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "postwar-rise-of-the-suburbs"
+      ]
+    },
+    "989fb00977a8e6a387ebfd258b8b91b8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "northern-draft-riots-during-the-civil-war"
+      ]
+    },
+    "989fe9175ef9e0b2438fdf74e78e3044": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "ida-b-wells-and-anti-lynching-activism"
+      ]
+    },
+    "98a4c77f44e317a2eaec15e256f9f130": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "there-is-no-cure-for-polio"
+      ]
+    },
+    "98b42b93bcf6c1d7cafecf4feee699fa": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "98ce1da9b54bec9989e466f8f12e2c16": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "98d5269ca48d28016373414a5c1b4882": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "eugenics-movement-in-the-united-states"
+      ]
+    },
+    "98ede460650fea7031ff8dcb2424b492": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-yellow-fever-epidemic-of-1878"
+      ]
+    },
+    "98f4b884d4d564861b4e9eb8b23a914b": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "98fb757ad0da4134e10f22393b7d4f90": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "9908c22de72cde66488f86c81fb928d9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-underground-railroad-and-the-fugitive-slave-act-of-1850"
+      ]
+    },
+    "99136548229174c95235325fa8123499": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "99245ff725ef7cd4613141131c09be2b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beginnings-of-the-american-red-cross"
+      ]
+    },
+    "9940423d6c6ae02027e047d097e45951": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-wounded-knee-massacre"
+      ]
+    },
+    "99424e3786094c9d9dd31ad009e8e37b": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "994b87b4dc501455d6969a940ccda818": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "9955785ada22268423a18c165c13911d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scarlet-letter-by-nathaniel-hawthorne"
+      ]
+    },
+    "99714183ba3dcd4d83a40b323fb685bc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scarlet-letter-by-nathaniel-hawthorne"
+      ]
+    },
+    "9972e7e50ff102e6c5bcaf000ff14837": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "998f370ba71873dc95eabeb52df3501a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "secession-of-the-southern-states"
+      ]
+    },
+    "999f2fcc4f38bf1f3be3ce48d60ef1d2": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "99ee66bcce77cb7ff7452d877a5e0cf9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-war-of-1812"
+      ]
+    },
+    "99fbf337af37f98cfb8ffcb0aab7833d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-women-on-the-home-front"
+      ]
+    },
+    "9a014ef89211c1bcd68da4330f1d7d1b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beginnings-of-the-american-red-cross"
+      ]
+    },
+    "9a089c6fdef3aaafeec96ef192bfccf2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "victorian-era"
+      ]
+    },
+    "9a14d4dd2593a4ee1d8a2f7d2183eae4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-maya-angelou"
+      ]
+    },
+    "9a1f5ee6f57e2b2c0b67a794cf857324": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "9a22be5ddaf9c252a3569eac30f8ca45": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "eugenics-movement-in-the-united-states"
+      ]
+    },
+    "9a246e3d00532950e0dc359c54153ba8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-impact-of-television-on-news-media"
+      ]
+    },
+    "9a24b0d7cf7f85a59d4111a13b1c1643": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "electrifying-america"
+      ]
+    },
+    "9a2ad3bd1300d426241f3808d6a9a6f3": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "9a4bc09e3ba9d21303a61122dbca46f0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-freedmen-s-bureau"
+      ]
+    },
+    "9a5b149b13b6d78b5975f2146f9fae19": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "9a813ff37f096431f4f79afa718d1369": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "9a8660682ee58e04f0feb96c938aa4dc": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "9a9da9a888eadffdae2f0becd6fd891c": {
+      "exhibitions": [
+        "spirits",
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "9a9ecce2c37042b9dfeb0c61a41ac613": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "9aab31c15fd7f2b571fc084056d9833b": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "9aba1060f130dbb0bfe503193a08ff11": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "9ad080d570e465e502fe97dd6c1036bf": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "9adb8a03d72d021f6e7c91fe06cafbb1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "eugenics-movement-in-the-united-states"
+      ]
+    },
+    "9adc6b9c15eecdd51680fb55ee46d07b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cherokee-removal-and-the-trail-of-tears"
+      ]
+    },
+    "9ae61de8d08ae9a9ead76546acca689d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "feeding-the-hungry-with-food-stamp-programs"
+      ]
+    },
+    "9aeaaa8f2f506f66d5c98ab6d3b8ce2f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "second-ku-klux-klan-and-the-birth-of-a-nation"
+      ]
+    },
+    "9aef6a84117483ff3020c96dd0b789bf": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "blackface-minstrelsy-in-modern-america"
+      ]
+    },
+    "9b01c7f122b2dde1b41f26ab38967ecd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "revolutionary-war-turning-points-saratoga-and-valley-forge"
+      ]
+    },
+    "9b1c7362dbe67b7c933e2b246f109bc6": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "9b3ac1fb3bec8f26a500e42b9a0c5eb7": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "9b6c51c8d53466ada14d0351a15ff16d": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "9b73bc98a10c9bb1f42cdcf278a13211": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-awakening-by-kate-chopin"
+      ]
+    },
+    "9baefa7db0e38240b3b31b8a4f9d8b5b": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "9bb3c5dc2e2cc238bb22168d1a8562c4": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": [
+        "battle-of-gettysburg"
+      ]
+    },
+    "9bddd62dbf8bc09182b49b7bb2394bfe": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "japanese-american-internment-during-world-war-ii"
+      ]
+    },
+    "9beaa325590704c0319fea1943fb61a7": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "9bf17118af984e7b49ccd4ec7f682c4d": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "9bfeb2bff97c99c6371d0e49a70917f6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "john-brown-s-raid-on-harper-s-ferry"
+      ]
+    },
+    "9c0b87593676fbe266ef8999317b3747": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "9c0e4ebfbdcd3f4d60bea0d74d73953c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "boomtimes-again-twentieth-century-mining-in-the-mojave-desert"
+      ]
+    },
+    "9c1bb7543b35c8b812cc74708efa083b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "negro-league-baseball"
+      ]
+    },
+    "9c42e146e478789695d26bd1e3fac5c6": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "9c49ad43e8fbe3d6df0f2b18591ad77f": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "9c4fb38670ed7e318d6fca731802da85": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-lewis-and-clark-expedition"
+      ]
+    },
+    "9c610c7da78c501557f872e811589181": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-awakening-by-kate-chopin"
+      ]
+    },
+    "9c69290c3af4e5e8f3b286e9b8814a53": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "9c6b210af94af2e69a6cc3a75ef5aa5d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-woman-warrior-by-maxine-hong-kingston"
+      ]
+    },
+    "9cb6c625af54b24bd16a0f99470815fc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-watsons-go-to-birmingham-1963-by-christopher-paul-curtis"
+      ]
+    },
+    "9ccc7082e81666316c66f2d14cd98068": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "9ccceac248458ef00ea2ffc59ae48013": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "9cde395aa89d4b663b1ed79f6d80a844": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "9d251acb088fe49f6ee09de5b8e509ff": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-gatsby-by-f-scott-fitzgerald"
+      ]
+    },
+    "9d27360e2cccf78a41cb55dbdae5d42e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-golden-age-of-broadway"
+      ]
+    },
+    "9d3750ec2c60aee918d9e9a6653d46f2": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "9d555500764f95140cb413abc85f9c5e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "of-mice-and-men-by-john-steinbeck"
+      ]
+    },
+    "9d95a8cb50a4a8efdd70633eb3129e99": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "revolutionary-war-turning-points-saratoga-and-valley-forge"
+      ]
+    },
+    "9d96d8a05ac00003bf43454494454016": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "9d983c8a5707bafbab346c2a9e7caa51": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exodusters-african-american-migration-to-the-great-plains"
+      ]
+    },
+    "9dbdfad022b28767f74e4eafbf6190f4": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "9dde142f00e1a32a4ec9ec03cd9dd576": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "9de18b1eeb390a2cee9efe917be453a4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-imperialism-the-spanish-american-war"
+      ]
+    },
+    "9dec6b15834ff861ebdc3128500f81ff": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jacksonian-democracy"
+      ]
+    },
+    "9dfea9c7abdaceb190aae483118f67a0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-watsons-go-to-birmingham-1963-by-christopher-paul-curtis"
+      ]
+    },
+    "9dff8c66d5ec450105c5358d9824ebe3": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "9e14fda18843503ed15da115bb090e5f": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "9e1fb01124195a84e6f3785e74064c05": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "9e21017b16a4d70a749f40f77f5bb1e9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mexican-labor-and-world-war-ii-the-bracero-program"
+      ]
+    },
+    "9e3184e92a3b717d2331c196a72d299c": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "9e31a8799a0e8325df1ac82354006941": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cross-cultural-colonial-conflicts"
+      ]
+    },
+    "9e5962629f5e60ff7255e7e82e0ea638": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "shays-rebellion"
+      ]
+    },
+    "9e6ced0b4b6f679249db0a54eff42b1c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panic-of-1837"
+      ]
+    },
+    "9e808659b46656abda53f6685141013e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fifteenth-amendment"
+      ]
+    },
+    "9e814394adaedb698028b97f437796f5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "little-women-by-louisa-may-alcott"
+      ]
+    },
+    "9e99239d141f36e96f153ada3f79d2b1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "dutch-new-netherland"
+      ]
+    },
+    "9ea555b7fdcd2e856b8b91f969c709b7": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "9ebde58917cc8490d2a71be985554962": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cross-cultural-colonial-conflicts"
+      ]
+    },
+    "9ec59e4d3e24ddb8e73436c65195bf63": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jitterbugs-swing-kids-and-lindy-hoppers"
+      ]
+    },
+    "9ec935602492229f271b6611cdfd53a6": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "9ed23109d36f04a1e74da178c185a25c": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "9ed50a25d27808c127906a475ff6dd71": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "9ed62388d90211482dc733c18fd2d034": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "visual-art-during-the-harlem-renaissance"
+      ]
+    },
+    "9f09290d1c186af7ece259a0cb6fe25b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-woman-warrior-by-maxine-hong-kingston"
+      ]
+    },
+    "9f19b16a0297790158e54f7e7954e8a5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-grapes-of-wrath-by-john-steinbeck"
+      ]
+    },
+    "9f3488341c3b3fbf2d1515e69c428af2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-watsons-go-to-birmingham-1963-by-christopher-paul-curtis"
+      ]
+    },
+    "9f3cd1a823c652c32735f5c6d60bfedb": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "9f47df42156ddda30e369adda0c85e87": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scarlet-letter-by-nathaniel-hawthorne"
+      ]
+    },
+    "9f51ff07c8ebfcf0c13ff2ebf5d559df": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "9f5c92563d0661ce8cee82d4f6db81d4": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "9f6d7166c3fb2c6eae2af4a60fdb9671": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-things-they-carried-by-tim-o-brien"
+      ]
+    },
+    "9f73098a989b29ba3cfe3142f5ca4dcb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cherokee-removal-and-the-trail-of-tears"
+      ]
+    },
+    "9f8ad2a602989206d42a94f36b42431b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-colonies-motivations-and-realities"
+      ]
+    },
+    "9f99dfe2074adb2a40125f73d1f2ce54": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-woman-warrior-by-maxine-hong-kingston"
+      ]
+    },
+    "9fa54d8697074d5e6b2ef6257ee4892f": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "9fc8dcf0f8bf8d03a9e913f582a8b018": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "invisible-man-by-ralph-ellison"
+      ]
+    },
+    "9fcc02808d7ee982a3d4346e07cd5b07": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "9fe157236062db0df416513c82ee6359": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-indian-boarding-schools"
+      ]
+    },
+    "9ffcbfaf8d53efbcc43e23908b410a6a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mormon-migration"
+      ]
+    },
+    "a0019ca333238274892f912728ba710d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frederick-douglass-and-abraham-lincoln"
+      ]
+    },
+    "a013db0f3ea3581ab7a67e46219e4288": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "a018401932a9e29d9e966abe5bca06e5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "electrifying-america"
+      ]
+    },
+    "a0189c212274e3ce2fde569fb076beba": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beginnings-of-the-american-red-cross"
+      ]
+    },
+    "a026cddad75be73210f993f325e051c5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-freedmen-s-bureau"
+      ]
+    },
+    "a03e720b54e68e3182b9a6453a291307": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "a0446714c5031ece57443bae4a49681f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "puerto-rican-migration-to-the-us"
+      ]
+    },
+    "a0518124c16a0ecf32b583f51de1bc59": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "boomtimes-again-twentieth-century-mining-in-the-mojave-desert"
+      ]
+    },
+    "a060ffbf3b91cca8fa395489b14ced27": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "a0878224d9da6ceb3b8f5c21b98ea77f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "creating-the-us-constitution"
+      ]
+    },
+    "a0a0acce2d2b23cef606b85d4f59b16a": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "a0a6190b368f6f701f3adc6de02e0113": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "social-realism"
+      ]
+    },
+    "a0aa97ed141c6c0f485f4309b5121375": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-temperance-movement"
+      ]
+    },
+    "a0b419256e1474edd0c293690e1b3f03": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "a0bd0e14b9448a34c718dac0e566fe39": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mormon-migration"
+      ]
+    },
+    "a0f826a9f72a94b92e6070efffb58df4": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "a1035e5fbf7300b2e40d073a33b58f7b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "road-to-revolution-1763-1776"
+      ]
+    },
+    "a11b0fc4a7f66784739ce8435753def3": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "a19b06d9267e289d0828118f00ad5c33": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-woman-warrior-by-maxine-hong-kingston"
+      ]
+    },
+    "a1c983fe941d79f6959a0b164bb69da0": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "a1d3fd90fed7f94a3b7363956a5da30e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "treaty-of-versailles-and-the-end-of-world-war-i"
+      ]
+    },
+    "a1d6ea1a0e16f41dd8d11247ccd88643": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "a1dd0f2bfca04b8ee48b2369c23974d9": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "a1e0ae82b0aa7502ef9c298a5cfb1ac4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fake-news-in-the-1890s-yellow-journalism"
+      ]
+    },
+    "a1e6d06506cfbbf57cb1a03fc0fb160e": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "a1f753bf3251f5b658655a89dcaa513a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-blues"
+      ]
+    },
+    "a1fb0ad49c2de9de312877b5f17c7920": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "a1fb77c026e1d9971f8fea9a0da084a2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "settlement-houses-in-the-progressive-era"
+      ]
+    },
+    "a21ba64af42483e6fd0d1ee1ae4530a9": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "a22fd3d91810dc28cc060944079d54e7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-grapes-of-wrath-by-john-steinbeck"
+      ]
+    },
+    "a24dfca25d2d78ae404bd7dde29d5708": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "a2647a2d5dce9db524f6e2f556d35819": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exploration-of-the-americas"
+      ]
+    },
+    "a2831249d9a90b6aaba23a45f5010679": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "a2934675d1315e697c8e5de3c2c7b0cd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "henry-clay-the-great-compromiser"
+      ]
+    },
+    "a29fdc5a3e61c97ac0cc0c1cb7d7d0d9": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "a2bdf4b392e9d1106d3de775bfba9287": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "a2c29ced5a3c8e471b4d743e452071e5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panama-canal"
+      ]
+    },
+    "a2c301b71bc619c8103ef6ff40d523b6": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "a2e8ef465e29f86557c647c2e4ecbd95": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-deal"
+      ]
+    },
+    "a2f03fe8efe3227b597f7d4a9a7d5586": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "a33398a6df17f53e088ae72fe6d966ab": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-woman"
+      ]
+    },
+    "a35643d88465504cf3090c1211d69f5c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-rise-of-italian-fascism-and-its-influence-on-europe"
+      ]
+    },
+    "a3572421fd7561cc0d242d17b6e4ec30": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panic-of-1837"
+      ]
+    },
+    "a384430af227fe7dd609c11c26288ba8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-gatsby-by-f-scott-fitzgerald"
+      ]
+    },
+    "a3c81226cf76f6cd0d02ca6b8a96ccf4": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "a3cb93ea9a05f651b0a660d00fb41823": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-temperance-movement"
+      ]
+    },
+    "a3e9e27979c87bb191d5a43a56d20120": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "declaration-of-the-rights-of-man-and-of-the-citizen"
+      ]
+    },
+    "a3eaf6672e2917e9e7c287df6c1b8421": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "spanish-missions-in-california"
+      ]
+    },
+    "a3f773a8e8554fb7b52e679c6547b897": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cuban-immigration-after-the-revolution-1959-1973"
+      ]
+    },
+    "a40bd73182269f95d741deadea9b515d": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "a40d52fcafb0761b9cecec9b058bc98b": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "a413b9ca38b983c25d0ac23ee19dfd4d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "texas-revolution"
+      ]
+    },
+    "a42f37866addc29f55d65fb3b9be7dea": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "a451bcf99a316eed8d8b99cce9009630": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pablo-picasso-s-guernica-and-modern-war"
+      ]
+    },
+    "a486a3bf06bde4b474422f8766d95947": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "powhatan-people-and-the-english-at-jamestown"
+      ]
+    },
+    "a49727d229dc1d65ce1f5f47985d5bd8": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "a4c47e967728690b148fb8555e4a9dae": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-yellow-fever-epidemic-of-1878"
+      ]
+    },
+    "a4cc3d089948cf2a3970693ef8f6640e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fannie-lou-hamer-and-the-civil-rights-movement-in-rural-mississippi"
+      ]
+    },
+    "a4e174bc5960a2422251a51c8ae21bba": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "elie-wiesel-s-night-and-the-holocaust"
+      ]
+    },
+    "a4e7e703e837025aafbbd5fa144dc799": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "a4f8d96d84fb503c5cc374d7edfd9d75": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "there-is-no-cure-for-polio"
+      ]
+    },
+    "a4f922ccdbd40cd3f55999c47649f6eb": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "a4fd9cce78d56adc2cee1ba023d839f9": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "a500c9e6361c6f91db0415464679aa96": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "declaration-of-the-rights-of-man-and-of-the-citizen"
+      ]
+    },
+    "a50cc32130ae8dfcf5e37f7d4f26435c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "patronage-and-populism-the-politics-of-the-gilded-age"
+      ]
+    },
+    "a52fa0b6cb3291f1590f67b3ac39c0b6": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "a556cea8c37906026a5ae9db941c3372": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "a560e20356ccefb5a5d9e8a86fb32823": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panic-of-1837"
+      ]
+    },
+    "a5a98e4c4d6db894eda092f40b304926": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panic-of-1837"
+      ]
+    },
+    "a5bcf5a4ff90f1fb06d48e43ef11831c": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "a5bdb443f938721ffb460d8afd1fcfb0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "declaration-of-the-rights-of-man-and-of-the-citizen"
+      ]
+    },
+    "a5cb097b8d5d13a44e9fdc35499fea5a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "victorian-era"
+      ]
+    },
+    "a5ccfbb62ab1fb8c997de3f10941f6a5": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "a5d5a0349a0eac2ef47d7261461a465f": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "a5db4adf0bf51a4c93c9213a17527630": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "a5de709fb428d3aa8694e48795eabc22": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "a5dff970ec7183e97742a17a3f82c574": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "a60651d8e2207cdc48d63c2d1ee404df": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "a617a9255d253c7aa2cccd0df9bec550": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "settlement-houses-in-the-progressive-era"
+      ]
+    },
+    "a61e9d31f55db539e0c918d2d073ed69": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "a62588352f03b54598df02429a6d76f5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "nineteenth-century-schools-for-the-deaf-and-blind"
+      ]
+    },
+    "a62ccd542578b25eed6a9484c2de0049": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "their-eyes-were-watching-god-by-zora-neale-hurston"
+      ]
+    },
+    "a6488491bd43f678bf56254ff930bcd9": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "a65f6d0b6210c18d17c596908ebcf270": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "creating-the-us-constitution"
+      ]
+    },
+    "a6677babc0f3f1e769ab473e1db98a50": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-underground-railroad-and-the-fugitive-slave-act-of-1850"
+      ]
+    },
+    "a67b9a0c339e2edf60560b3c7d0f8ef7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "eugenics-movement-in-the-united-states"
+      ]
+    },
+    "a68c703c52ade84438e78c83a96929fa": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rise-of-conservatism-in-the-1980s"
+      ]
+    },
+    "a6956243b663c9d388b20e2360dd103e": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "a6ce8f23167d6512215adef9b3f0dcd5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-of-the-antebellum-reform-movement"
+      ]
+    },
+    "a6d1b7813ff76b9c1fc03332ac7c5ae5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-indian-boarding-schools"
+      ]
+    },
+    "a6ea266968676531b786fa5e0832c406": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "a6efabb82a9d065214b45bfa82a5b91e": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "a6fa4c2d0e8092626efba259f539644d": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "a70aac3eced3ff6648f346fb0effe1eb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-impact-of-television-on-news-media"
+      ]
+    },
+    "a757bae38fea7ed36c608b82b4980298": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "a76fa8c3f335b8d81461f43fecfcf5bd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "ida-b-wells-and-anti-lynching-activism"
+      ]
+    },
+    "a7732481de8a396d4866f5434e47838b": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "a774007adeb68cdf90bbe583a29a9495": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "a775e6a7496dff85ea1a636439e40c59": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scarlet-letter-by-nathaniel-hawthorne"
+      ]
+    },
+    "a781c2e74a6275112e58037be630a8f5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "latin-american-revolutionaries"
+      ]
+    },
+    "a78270f5915d93a49449f59fa6e8cded": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-grapes-of-wrath-by-john-steinbeck"
+      ]
+    },
+    "a791974e09fa4ff5baef36dd9f02d85f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "elie-wiesel-s-night-and-the-holocaust"
+      ]
+    },
+    "a7b4673052a9396bcd92277dcdd22f9d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "visual-art-during-the-harlem-renaissance"
+      ]
+    },
+    "a7bcd051d2a994aeb34c70b626f0ff71": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "a7bda1ee04a262a16c93a657b250a208": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "a7f265af31779c982fb09bb1a119d92d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "little-women-by-louisa-may-alcott"
+      ]
+    },
+    "a7f913f1b958e91def2e05c720663678": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exodusters-african-american-migration-to-the-great-plains"
+      ]
+    },
+    "a837cd9837df471c919f88da92959cc6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-and-americanization-1880-1930"
+      ]
+    },
+    "a840169be0469622019b3ba6446050b5": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "a84937d954b4160904328002e24c5fba": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "a851aa63c54a619b42e188b23b6a3214": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "a85eff0134a8df099a7a6072baa4e4ee": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-golden-age-of-broadway"
+      ]
+    },
+    "a8739a9301dfebb47d1a2687ec99e7ac": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "a8952bb20069837e276546cf243a506c": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "a8bc7eabed5441cdba02bf030ffd51de": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "postwar-rise-of-the-suburbs"
+      ]
+    },
+    "a8bd4c5ef048410215643567f5bf2ce2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-i-america-heads-to-war"
+      ]
+    },
+    "a8ca9a385814d96f3b7ed8eb42c6e190": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "a8d46991302e774db82d9a15db4992fd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fannie-lou-hamer-and-the-civil-rights-movement-in-rural-mississippi"
+      ]
+    },
+    "a8e558ddffc95baa1186d30c1c9c06ae": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-boston-tea-party"
+      ]
+    },
+    "a8ea9e7f1b56bc2730d68d0835a7c6a7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-indian-boarding-schools"
+      ]
+    },
+    "a8f58e3ee32ef7d6525b3289b7f2670d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-migration"
+      ]
+    },
+    "a8fc14bfdbad4ed08caa0dbfd47464ad": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beginnings-of-the-american-red-cross"
+      ]
+    },
+    "a91ed09f4b95963abd6930f4d90db009": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "a92556833d12573edf94f4776e27bea8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "revolutionary-war-turning-points-saratoga-and-valley-forge"
+      ]
+    },
+    "a94448616d7c025cc994a5049c73d4cb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "dutch-new-netherland"
+      ]
+    },
+    "a95312a4bb1f7630293b0d0b13532e7d": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": [
+        "the-fire-next-time-by-james-baldwin"
+      ]
+    },
+    "a95464a40bf0707f0750828cfd222d33": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "a989bbac59c594a3d0ed0087fceccd09": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "a98ee9c52915216c31debd99325e0271": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "a9906efbbc408c7cf83ef6744ab38d46": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "a9945ff57398433479d53c3534d7d2c7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "northern-draft-riots-during-the-civil-war"
+      ]
+    },
+    "a99b2c28312a02f247199740ca43bfd9": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "a9aa318ee8d3cc00187196322c474b20": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "a9c21ea70b7318f2983551607ebdffb8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cross-cultural-colonial-conflicts"
+      ]
+    },
+    "a9e42538acabc77dd26ee3254033df1d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "japanese-american-internment-during-world-war-ii"
+      ]
+    },
+    "a9e7ae85867526a524c793d6a3af0b8b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "creating-the-us-constitution",
+        "jacksonian-democracy"
+      ]
+    },
+    "a9f237fd9db921e4d4cf44a761b26bd4": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "aa0567253f9e09561c3debbb0086a0a4": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "aa1676ce92df70d4ccc87b810c0f34ba": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "busing-beyond-school-desegregation-in-boston"
+      ]
+    },
+    "aa18b8140fc073152c3d8a455d67b60e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-s-suffrage-the-campaign-for-the-nineteenth-amendment"
+      ]
+    },
+    "aa22efcfff09f55442daa947f25d3765": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-freedmen-s-bureau"
+      ]
+    },
+    "aa397574e7d15891c5e1a5bae64b835c": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "aa57286989ab83560180e9ffc7fade31": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pop-art-in-the-us"
+      ]
+    },
+    "aa5773b1f95ff14f19113ee73d691c52": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "aa88b7ba381ef6706f82a923cdb6584f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exploration-of-the-americas"
+      ]
+    },
+    "aaa27166fd4c50105aa90791635c8c3e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-united-farm-workers-and-the-delano-grape-strike"
+      ]
+    },
+    "aabc69922d1db1ca0560fb9eba41b2c8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-s-eastern-front-operation-barbarossa"
+      ]
+    },
+    "aabeadfa35bfd39c5136a3e8f3b9c529": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "aac42a4493f190ee7a6a32aaa3164f61": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "space-race"
+      ]
+    },
+    "aae65496ab7a8b5539e706215fc5e981": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "aaf611be2448bc5b501a3e25551b3440": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "ab5d5b6c34c8a80d7731578bf465691a": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "ab7accf20ce2793458238bd2f76378da": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "ab9551ef4229656598a4b9326273f72f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-equal-rights-amendment"
+      ]
+    },
+    "abb6341dc8c706e7faf73410d2422d17": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "abc1e5db3d398ce784b3ff7180744c47": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "ac17a133d1d6071a989476eef8f728ca": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "ac2f9e212ed45f762f3faf7f8594a2a3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "patronage-and-populism-the-politics-of-the-gilded-age",
+        "the-populist-movement"
+      ]
+    },
+    "ac5932eb055597bf6a0de03ea0fa9b8b": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "ac5a2daa844eea2cdc7808df5b11f832": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "reservations-resistance-and-the-indian-reorganization-act-1900-1940"
+      ]
+    },
+    "ac62fefd7bdf800878c0e791a5a50c61": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "ac7cb0395f7e44b45b459a456c7bf392": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-boston-tea-party"
+      ]
+    },
+    "ac8872f5c523606d0511b165e4b12f52": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fire-next-time-by-james-baldwin"
+      ]
+    },
+    "ac8d873da2453578e7f7de789cdcf2c1": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "acad651fd286b828f9a38edce6101021": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-golden-age-of-broadway"
+      ]
+    },
+    "accc680d44afbc3bd41a541bfbc10a87": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-equal-rights-amendment"
+      ]
+    },
+    "acd46707e16c652edca745ebbe6df165": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "theodore-dreiser-s-sister-carrie-and-the-urbanization-of-chicago"
+      ]
+    },
+    "acdd6260ff4b22acf4a4b2a5a7d774a5": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "acdffb5db47bf4b83601836dd1c756f6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-deal"
+      ]
+    },
+    "acf11f5d375ae822f4700a9f4ad0c92c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-equal-rights-amendment"
+      ]
+    },
+    "ad0aa4761c72246d5c8018d18ca3767f": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "ad1ce3b57bc0a43c0e6b6c76b49e776e": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "ad2942e67b2ce20974cd73ffa0e77f5f": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "ad43aca8c59a60e4490e94bb0def9d2c": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "ad5df98491d8051310520198b14e2cc8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "social-realism"
+      ]
+    },
+    "ad66917e5e4c64e1cbc838694570c089": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "ad7308e2bdedbd18fb85a3545eec0dea": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "ad86f868723875f9933e458bcd19d23d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-united-farm-workers-and-the-delano-grape-strike"
+      ]
+    },
+    "adb4d686ef58aeefb95c7d3befa0aca4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "space-race"
+      ]
+    },
+    "adb7cd09b3e98cba761493188c9e2c74": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frederick-douglass-and-abraham-lincoln"
+      ]
+    },
+    "adbaade507ab7a8c244ab4ab5a99ce53": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mormon-migration"
+      ]
+    },
+    "add36cdf1f185c62e6a22dc50638ad5d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exploration-of-the-americas"
+      ]
+    },
+    "addc0896b1149ba9e3cc1253ae45a66c": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "ae0422c661e6862245b50f42ecfcc629": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "ae0ef4c66a9be21c6db7d21ad2db838a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-things-they-carried-by-tim-o-brien"
+      ]
+    },
+    "ae262aa1e8ae7647b94e58743cbed56e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "busing-beyond-school-desegregation-in-boston"
+      ]
+    },
+    "ae6d68e921767bd85ab50ff84d8ac767": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "lyndon-johnson-s-great-society"
+      ]
+    },
+    "aea4c14b576c79116367976fbebfe5b9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "japanese-american-internment-during-world-war-ii"
+      ]
+    },
+    "aeca0321bb66b6dc222b7d62ba787f0b": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "aed31b2120e766f9a5d3a20b1ca85af0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "treaty-of-versailles-and-the-end-of-world-war-i"
+      ]
+    },
+    "aed68241976ede8ed5e7674e379f66ca": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "aef8df2d77f314060b4d58f09a6bec8a": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "af09b33075ce19ea93de09594802c38a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-awakening-by-kate-chopin"
+      ]
+    },
+    "af0a8fdac70fcef62ad39967ef4c58e6": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "af0e3d446cb31eb6ce85f4fb28535755": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "af35475b01ebde1158da8aea5085cb4a": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "af44385fc555ec8a29eb916318b9df8e": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "af55ff897cf75c777cc0118b39d1b43e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "road-to-revolution-1763-1776"
+      ]
+    },
+    "af66f6f2423ed5078233ae1eb71211c5": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "af7f6384e00bf7d4a761164a851e91fd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-woman"
+      ]
+    },
+    "af919be3a07d1656cb97329a49037712": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "blackface-minstrelsy-in-modern-america"
+      ]
+    },
+    "af9ccffabbc20ca9d3e0ec50e30346c6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-of-the-antebellum-reform-movement"
+      ]
+    },
+    "afa23a335d05126e9aa5ae23c7ab8295": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panic-of-1837"
+      ]
+    },
+    "afac27c19de10502772ed373cdbc27cb": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "afbe5f5f70aeb4a9670bde205225070a": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "afca03cc1882a7b00d149a3290e65e7f": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "afca7728074b9079b7c334857e5a7669": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "their-eyes-were-watching-god-by-zora-neale-hurston"
+      ]
+    },
+    "afddf582af7db25a3076810818a76a46": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-hudson-river-school"
+      ]
+    },
+    "afee8c0f94afab8dde19812ad7b8d264": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "afef6025dd7e1a8ae2221aa16bc535f2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-rise-of-italian-fascism-and-its-influence-on-europe"
+      ]
+    },
+    "affd56313cbb2ec0fa4419c99fa4b61b": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "b001babddab4a6b83dd3bf1b3a0a0e95": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "b00795098d5594403700c39b745738aa": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "b024e53bfba73eb1325426e51409bc51": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-columbian-exchange"
+      ]
+    },
+    "b02b9d55be33971f27dc8aed39802f7d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fake-news-in-the-1890s-yellow-journalism"
+      ]
+    },
+    "b03b54e0ecdde2c6979fb23086b49c38": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "b041cac85a71c1981bac732e06abe3e2": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "b052a93236abd592dbdb9525e97787f0": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "b05d20ed5e17a48ff5f0fb0883b4ae83": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "b060b61b09a662d8cad5b37915132ef7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "early-chinese-immigration-to-the-us"
+      ]
+    },
+    "b066144b8d491387ebfd5fdd4433363f": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "b07de79b46c7ee311856fd1144cbfb32": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "attacks-on-american-soil-pearl-harbor-and-september-11"
+      ]
+    },
+    "b0cc58e06f5a9e033cd90c0deefc7cd1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "b0e2cbf8d22d2f823e0456c87c269f7d": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "b0e3a6991b4f3d299d75fd696e62581c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "victorian-era"
+      ]
+    },
+    "b11123c3d2a485589c5544b590c5488e": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "b13d69108e4c7cbcf6ff94eb49e82539": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "b13db1a92baebe7b3bc254fcb63ccc08": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "b1596c67e1fde56bb0c16ec4bcfcba04": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "b15f135e3d80f5ef64b1b23ae29837c0": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "b1679bd88e8dd92811332de04ad9f1f1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "boomtimes-again-twentieth-century-mining-in-the-mojave-desert"
+      ]
+    },
+    "b16e6a5cd325dd6bd7f83e5ac8aed35b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-populist-movement"
+      ]
+    },
+    "b16eb50d2cec20fecd2afb8f09d66773": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "b18e7ec243ff8afdaf8b1a5d879f1b9a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "battle-of-gettysburg"
+      ]
+    },
+    "b192e8ac0092c6348564faaea7a4f2d9": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "b1c753502cd4125b7e1484bd9348e528": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "b20054c0f0fe0a6da41147c5ba24c437": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-invention-of-the-telephone"
+      ]
+    },
+    "b210c44ae594228c86c332da2e438797": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cherokee-removal-and-the-trail-of-tears"
+      ]
+    },
+    "b240bf74aa3933f2f34449d60c53fe92": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "their-eyes-were-watching-god-by-zora-neale-hurston"
+      ]
+    },
+    "b24a64e3b4bf47fdf71cbae8b22aff4d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-columbian-exchange"
+      ]
+    },
+    "b26d20a9fe487eaf9b20ffbd5683b50f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "when-miners-strike-west-virginia-coal-mining-and-labor-history"
+      ]
+    },
+    "b27235d9aeb6919088f3d5ab39221666": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-boston-tea-party"
+      ]
+    },
+    "b27700816694c62a099050865d56222e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "space-race"
+      ]
+    },
+    "b27ac4bb847f0e43a5f833b864e7c1d3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "incidents-in-the-life-of-a-slave-girl-by-harriet-jacobs"
+      ]
+    },
+    "b27acdd210e9ed661f529e5f2c515da1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jitterbugs-swing-kids-and-lindy-hoppers"
+      ]
+    },
+    "b28010875bf350918988f31f12ab8d71": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "stonewall-and-its-impact-on-the-gay-liberation-movement"
+      ]
+    },
+    "b28881bf8ecce08d43d07402615389f1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scopes-trial"
+      ]
+    },
+    "b28bc19200b96f4f759c05557967ebb4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-and-americanization-1880-1930"
+      ]
+    },
+    "b29570800390f8729e05b2bd7af9178c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "stonewall-and-its-impact-on-the-gay-liberation-movement"
+      ]
+    },
+    "b2a87eefa65f6f3fcdc58d9cc054bfcb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-things-they-carried-by-tim-o-brien"
+      ]
+    },
+    "b2accde3f685977a62514532bac9eae6": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "b2b34918c97db7a30064f14c5f25fec7": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "b2b6c9969cc7d472d357606252a49da3": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "b2b977a092cc837e84278c216a769bbc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "invisible-man-by-ralph-ellison"
+      ]
+    },
+    "b2c245c406c8fa0898f108a469ccd226": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "commodore-perry-s-expedition-to-japan"
+      ]
+    },
+    "b2dedbb4e409a589d8749b4ab377de70": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "b3334f08d4e1127ffc9af3b6961b1b71": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "b3588e9f147080aa9f3608899f3da024": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "b35ab1673ff5d8a50c4357eb49ab0e0b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "eugenics-movement-in-the-united-states"
+      ]
+    },
+    "b35ea5f527c05dd6ef3d4a4bda9ce60c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-things-they-carried-by-tim-o-brien"
+      ]
+    },
+    "b361b073e1e87fe9af0b971b9d777b56": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "b36242b55dcc71e093d6ff1dcb4a7d92": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "b3a2afed93631747ee7bd0675faca58a": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "b3a8887a72feadff5b6a8da0264812ff": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "b3aa47a3284b8fe7cfe6d9b95a10401e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "creating-the-us-constitution",
+        "shays-rebellion"
+      ]
+    },
+    "b3adc9c3c5b13f12831e1f9c84f545d8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "of-mice-and-men-by-john-steinbeck"
+      ]
+    },
+    "b3b776a4ce83e4585b8e6b29fa22c4bf": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "colonial-religion"
+      ]
+    },
+    "b3c0ad1afa363f699adc9cabed46bc6f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-crucible-by-arthur-miller"
+      ]
+    },
+    "b3da3fdbe8c886d04a36872465638b3a": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "b3db5b769b9985cb94169814d5725f87": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beloved-by-toni-morrison"
+      ]
+    },
+    "b3df530612c1a865faa04a0d407e102b": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "b3e917d1044c968ae33c5d435325249c": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "b3f539a3c4962bd7426dae3996090665": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-indian-movement-1968-1978"
+      ]
+    },
+    "b3f6a6115ade55dbff8148dc1f9f2b66": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "b40b816deabcc30eb24c7917a58d122e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "postwar-rise-of-the-suburbs"
+      ]
+    },
+    "b4197f5dadbcc73a3b66d2170634d06c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beloved-by-toni-morrison"
+      ]
+    },
+    "b41bd16ab2c6692c2366d13ae4b8a59a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "dutch-new-netherland"
+      ]
+    },
+    "b436ecd74ee1c23af239fa9a5ce562a9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "commodore-perry-s-expedition-to-japan"
+      ]
+    },
+    "b447d7772b7ccd6df3b60d4777000baa": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-whaling-industry"
+      ]
+    },
+    "b45718b3fc8d21816b00702b71396b8b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "to-kill-a-mockingbird-by-harper-lee"
+      ]
+    },
+    "b47014bbeb8fec477d5cbbbae087bb27": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "feeding-the-hungry-with-food-stamp-programs"
+      ]
+    },
+    "b49577515555da07aac99ccd4a3754df": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "b4aa3359fe2ffa99c2627444b82a348f": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": [
+        "the-fire-next-time-by-james-baldwin"
+      ]
+    },
+    "b4adc12e6b74c02ee190f7fd9ba2c85a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "manifest-destiny"
+      ]
+    },
+    "b4c447bea81eee6f0089a34e6b729dd0": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "b4c88df30cd1556d75f3bc0a5c773a5f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pop-art-in-the-us"
+      ]
+    },
+    "b4d68255ccb7c43daee3c5f30febdc13": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "environmental-preservation-in-the-progressive-era"
+      ]
+    },
+    "b4da85e7100b75322a816f910a922b75": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "b4ea8ebc09f67d3702d8e2c9a5a47897": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "b4eb02db2bbaf86a44af99a088096266": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "b4eb54f1ea7edafd2451798794935247": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "secession-of-the-southern-states"
+      ]
+    },
+    "b50bba1763e6a48ca7e4486f98808f12": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exodusters-african-american-migration-to-the-great-plains"
+      ]
+    },
+    "b50bc5ef0e75832085837f612b4ac89e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-impact-of-television-on-news-media"
+      ]
+    },
+    "b53c4a993b7cb4f19e0650434834c8d5": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "b54abc65284bad80725b8cee0b2dc2c2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "stonewall-and-its-impact-on-the-gay-liberation-movement"
+      ]
+    },
+    "b5746a90dc8c92db1fe36d85a3a6eec0": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "b58d631f6eac3e50613709640e76486c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "voting-rights-act-of-1965"
+      ]
+    },
+    "b59d46ffe93b998fe351554b6bca9cef": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "b59e5b1e28dacacb70e09e48464ed812": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "negro-league-baseball"
+      ]
+    },
+    "b5c59972e74dfd831b648aa59d218777": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "b5cd6c4918b6836ff8237b0d08ec1984": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "b5d684b4cbc1c6c91dae2266720df2fa": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "b5da6546ea5351e2800eb3984f32ddab": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-lewis-and-clark-expedition"
+      ]
+    },
+    "b5db2f1e87d3358de57693fc7e0c4b3a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-migration"
+      ]
+    },
+    "b5e46260508afcf1d841f7937a483d1e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "act-up-and-the-aids-crisis"
+      ]
+    },
+    "b5f882cf011d97aa3b00ba147e46e611": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "b5ff2086d91cf285e64e100e9aab3ff9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "victorian-era"
+      ]
+    },
+    "b614411c79c1a536fe3e49d0456d4fe9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-grapes-of-wrath-by-john-steinbeck"
+      ]
+    },
+    "b61568af33c7755b3daf9e2833ef76dc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "boomtimes-again-twentieth-century-mining-in-the-mojave-desert"
+      ]
+    },
+    "b6173d8dec7776eecbc73fb2befe83e5": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "b63e2e27182576252a133e9df19a3c2d": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "b65a368d6d49457488b1ce7d261dc9ae": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-invention-of-the-telephone"
+      ]
+    },
+    "b676e4cdbe661c9a4096ec700631d10c": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "b67e807b3b84d9c995252bac4b8099a7": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "b6838d24e336465b39ed5f0d958a33bd": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "b6acc3d579469715c27e876a77f78104": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "b6afcfae38203361dff2a5f8816b7990": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cuban-immigration-after-the-revolution-1959-1973"
+      ]
+    },
+    "b70cb636b053e2d46e44781128726b0d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scarlet-letter-by-nathaniel-hawthorne"
+      ]
+    },
+    "b7177ed32fd9049651ff810b90a74fb1": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "b71f53f92d06ea3c874fa97f4518a765": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-underground-railroad-and-the-fugitive-slave-act-of-1850"
+      ]
+    },
+    "b7308b36c14d60f7eb6dc1e521d4e74b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "there-is-no-cure-for-polio"
+      ]
+    },
+    "b747b0d7ab8bd370f301e3715e2b9dd6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "road-to-revolution-1763-1776"
+      ]
+    },
+    "b7570d1e27033e0c16fc0b4038d1db1e": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "b762aeb87821c795e6b9171b9678113c": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "b7807750c2cbb83d01bd29f289097e5d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-boston-tea-party"
+      ]
+    },
+    "b781f9310e50da26fec5cadd0e6228d8": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "b782c46147aa1d49f47b0add00105ef3": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": [
+        "the-homestead-acts"
+      ]
+    },
+    "b7a9aa2e8aae4a7975633587a18b32ac": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-i-america-heads-to-war"
+      ]
+    },
+    "b7b99b8ef3ff96401dd6cffab22c8959": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "truth-justice-and-the-birth-of-the-superhero-comic-book"
+      ]
+    },
+    "b7be8145e0a242c5d37a2d38c21210a5": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "b8117769a14cde52e9000b24a3df3b1b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-and-americanization-1880-1930"
+      ]
+    },
+    "b83c3f3039361de41ff62b9304f90ad5": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "b83cb5cff173d2486dc00004820f97ed": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-boston-tea-party"
+      ]
+    },
+    "b8456b188989f1ff7d4ba74eef7ae88e": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "b86b4178fa361a1eb96d704586795d2d": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "b8a379ebf3bf81503a8416ae591dc049": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-freedmen-s-bureau"
+      ]
+    },
+    "b8bc58b87be12b80581281c1c2fdc5b1": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "b8cadd1f870bfec7864d9e9fe5d89ab1": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "b8cde60ef637800001e5dc24e2c406d1": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "b8e0bb56e21c10da63c3a1e2f89eb96e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "visual-art-during-the-harlem-renaissance"
+      ]
+    },
+    "b8ecaad23a06dafbb547464620b97a35": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-whaling-industry"
+      ]
+    },
+    "b8f04096861c8ad6754e362b9f473902": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-colonies-motivations-and-realities"
+      ]
+    },
+    "b8f379dede2486668698c94678997052": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "b8f5eb406f643526778238f1a5c4f04e": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "b9126c09786ec3947d6e487803ea79d3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "boomtimes-again-twentieth-century-mining-in-the-mojave-desert"
+      ]
+    },
+    "b9310d403dfecda3edda7fc96bde699c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-raven-by-edgar-allan-poe"
+      ]
+    },
+    "b942b43d97da74d19dd5a3641e113cf2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "reservations-resistance-and-the-indian-reorganization-act-1900-1940"
+      ]
+    },
+    "b945bc5a8bda295b5e0765a190a3e075": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "visual-art-during-the-harlem-renaissance"
+      ]
+    },
+    "b954151320d23d7b52f15bdb936713ce": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "when-miners-strike-west-virginia-coal-mining-and-labor-history"
+      ]
+    },
+    "b96e1e0acd00ba30cc709b22b1611c7e": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "b9adbb759575eab936202823f8c5a9fa": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "b9afa3d1e72e1cde5458f84350b3d0e1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-equal-rights-amendment"
+      ]
+    },
+    "b9f59e35405ae287afb2d404cb089235": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "battle-of-gettysburg"
+      ]
+    },
+    "ba13a77af52f51184a2c4d9fe9f09968": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "ba32ca7b5e1122a4e493354f22eadb41": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-watsons-go-to-birmingham-1963-by-christopher-paul-curtis"
+      ]
+    },
+    "ba433d26fb668a65bdd2a75204214cf8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "theodore-dreiser-s-sister-carrie-and-the-urbanization-of-chicago"
+      ]
+    },
+    "ba4eb3e216c3e353bb4e26bdc849e9c7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-hudson-river-school"
+      ]
+    },
+    "ba6422662aeee359fc404a02eed967fa": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "voting-rights-act-of-1965"
+      ]
+    },
+    "ba6ce88b19d9997ccf0de6cbdbddcb22": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "uncle-tom-s-cabin-by-harriet-beecher-stowe"
+      ]
+    },
+    "ba7c0acab0a66e26fdf0819cc019ee12": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "full-steam-ahead-the-steam-engine-and-transportation-in-the-nineteenth-century"
+      ]
+    },
+    "ba7f2ad4c2c45431e7ebd8f4ade30987": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "ba82c732260700cffcd86da7026dc696": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "creating-the-us-constitution"
+      ]
+    },
+    "bab119738ce4b1c10bb6f2601a66c03d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "northern-draft-riots-during-the-civil-war"
+      ]
+    },
+    "badd0106bd03b6f4d593e3ca73b097b4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "battle-of-gettysburg"
+      ]
+    },
+    "bafd36376c00aa3e9c2e497df6ac3068": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "bb2cde75acafe9999f58b3d4f799d45f": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "bb3c1c150df6bc63885462fe916da568": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "bb491cbacf0cda017d91ec130b73b931": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "bb6a2d4dabb5fd42b443aca86471cb35": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "secession-of-the-southern-states"
+      ]
+    },
+    "bb6b7684d5915253128da3949a6f2856": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "african-american-soldiers-in-world-war-i"
+      ]
+    },
+    "bb6b934fcd4c2b72b87263d30f832847": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "when-miners-strike-west-virginia-coal-mining-and-labor-history"
+      ]
+    },
+    "bb8d812d896697e9560dfae9290cfb0a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-boston-tea-party"
+      ]
+    },
+    "bbd38df7b08bba250007bd5aac6cb43d": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "bbd7f2f4fdb714d6a84972673278c42c": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "bbdabae3e7e97dc28b213387f5fba2c4": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "bbdac47ff9478111f3bd399c9013dc6b": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "bc0f6feeb28059140fa46e782a1daca8": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "bc88b4a325ff192e261e344f2a1e673e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-boston-tea-party"
+      ]
+    },
+    "bca8699496ed5c6a249e0a323efdaf25": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "lyndon-johnson-s-great-society"
+      ]
+    },
+    "bcadc57bf5d3143caa9233b405d9d54a": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "bcb3565672507fab22e92ccfcac6dfb0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-invention-of-the-telephone"
+      ]
+    },
+    "bcb799624e9305f200a0502ef73ddaa7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scarlet-letter-by-nathaniel-hawthorne"
+      ]
+    },
+    "bcc77b49492fc48e495cfae104844a13": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "bcc833c1238ec0614e89323344944721": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "bcec86c81a33f389bc176b7373b01ae1": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "bd3231ddd728eaa3c1c41ac679d36fb1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cuban-immigration-after-the-revolution-1959-1973"
+      ]
+    },
+    "bd38a5a466f2a135d6d8b1476354c88e": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "bd42d8df16c615744be86b5a0bce55ad": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-black-power-movement"
+      ]
+    },
+    "bd4f3ae14496e657e63ce9d667d06fbc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "declaration-of-the-rights-of-man-and-of-the-citizen"
+      ]
+    },
+    "bd89e3fb3d6003e08beb1f34fa523058": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "latin-american-revolutionaries"
+      ]
+    },
+    "bda98f669dbe173b67264b5df40f2e94": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "bdbea8bdf4d616fed31ffce031e6b863": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "bdc897104409e73e8d0b3d6d95cbe002": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "bdc9d797d1272973f9d615a7c7168f4c": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "bdcba2443b3a7462c03509789ced7eb7": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "bdd099860fcac5c30acf2ce2dac0bee6": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "bdfa883ea3785009bd7a613e1dfe1326": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "be44f91acc53c516dad9a356f884eef2": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "be4a5df7c00db5fef796eeb9102a5bb1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "their-eyes-were-watching-god-by-zora-neale-hurston"
+      ]
+    },
+    "be4fabe6f2e35388cb19bfcc1dffff9d": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "be5658a3f2be838bc3e6e0737c100651": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jitterbugs-swing-kids-and-lindy-hoppers"
+      ]
+    },
+    "be569595f40a12b116004e9c399b4470": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "be600bc3e54258fcca5a8bab2b555c90": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "invisible-man-by-ralph-ellison"
+      ]
+    },
+    "be6383e0200fa2156ed7ae3acfbdd747": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "henry-clay-the-great-compromiser"
+      ]
+    },
+    "be745810f9d704c1e7fac7968d3fd4b9": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "be7c6e596d4e8168655d81e5fbfc9bce": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-colonies-motivations-and-realities"
+      ]
+    },
+    "be891ab498f510adcf69a5a125f2a711": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": [
+        "the-great-migration"
+      ]
+    },
+    "be958c0fccba5a0ea72be7b03d2f13e7": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "becefde175a4b3ee85927b46f7bda225": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-temperance-movement"
+      ]
+    },
+    "bef1458b2e0f2b0fe1d657fef0e1f40a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beloved-by-toni-morrison",
+        "the-transatlantic-slave-trade"
+      ]
+    },
+    "bf1121770c0694e20f57be92b70808ad": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "bf445667bfca7887b064dcc5a2d23889": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mormon-migration"
+      ]
+    },
+    "bf4cef97bbb344c42c9e4eda1a7f2fde": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-hudson-river-school"
+      ]
+    },
+    "bf4f9cbef19664085cddd9c8b2013379": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "bf55992da67c0773d5ab7ab2a8c2dae6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-through-angel-island"
+      ]
+    },
+    "bf740f3ae2b8f69321c24f526311a8dc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-colonies-motivations-and-realities"
+      ]
+    },
+    "bf78e35da299e049156e49d36aa2c946": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "early-chinese-immigration-to-the-us"
+      ]
+    },
+    "bf8325f211f6b1d65a8fd6faa2093696": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "of-mice-and-men-by-john-steinbeck"
+      ]
+    },
+    "bfa0be18b3a23e8527cc2cd423e61e0d": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "bfa87ab7c7d6270fff0f02b71ec01800": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "bfc5c1666b5cf22251b8e5719d35edae": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "bfc9bef9dffe3ea7c47d6d00fa0dc629": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "bfce4c27c6a2055d887bed8e638af107": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "battle-of-gettysburg"
+      ]
+    },
+    "c00fed513bcd8bd14c23998c57fadf60": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "c0250e3b620e9f47405c4239414e8fff": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "c02c03a4c0fdf4ec15f8ca9109ee5ac2": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "c078c26c3faef81864090a18f014e381": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "c09d16e1f09c251f912fb53dad5630d2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "c0a412e0c30f0ab00c1289642da3aecd": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "c0a4e8516a4a6be31d0651f0514bec15": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "c0ab7dca594b996e3e87e57eefeee143": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "c0b136b2e86ecdcdf1d7ccaadc358179": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "c0b93540bf1b8f4572f973f08174863d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exploration-of-the-americas"
+      ]
+    },
+    "c0d27654e6034b2a211e8fd10d13efb3": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "c0d698e8501772ea4d2e23a48957a0cf": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pop-art-in-the-us"
+      ]
+    },
+    "c0ec97fd2bfedf7bbbfaadb6ebf02fa3": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "c0f625368de23433b224bcd104280342": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "c0ff32e95329543ad4e3406760cacce6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "latin-american-revolutionaries"
+      ]
+    },
+    "c13cee2ed766a2296914eab82e59208b": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "c143d48ee133d9cb476a0b8087e5ae2f": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "c153511bbc63465ce667b8324c1e51d5": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "c16305fc2d6819f0f13ab9a8f3b783f7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "revolutionary-war-turning-points-saratoga-and-valley-forge"
+      ]
+    },
+    "c16983a05a94ec6b633da0c1e3a52978": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "c19d1efbe9407a635141862a3c7772ec": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "c1a7b8ceb327a92b139420137be2df1f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "invisible-man-by-ralph-ellison"
+      ]
+    },
+    "c1a7fb2ba642999b1fa6cd86a8d37ffe": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "c1b82969e0bec2cc308d5c73b7328169": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "c1ca257548eb535e61bb8dfa235f5b1c": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "c1cf983b4c95bbfcfe6e53cb95ee407f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "reservations-resistance-and-the-indian-reorganization-act-1900-1940"
+      ]
+    },
+    "c1d17c194622e62c221610cd6205536b": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "c1e236ce555512a288c1c7a253a2a818": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "settlement-houses-in-the-progressive-era"
+      ]
+    },
+    "c1e78a511e2c58a308cf04149a3cfb24": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-things-they-carried-by-tim-o-brien"
+      ]
+    },
+    "c22620b3b4c5182936541c5d0caf533a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scarlet-letter-by-nathaniel-hawthorne"
+      ]
+    },
+    "c229227f13a56299dfcdf66b70ede18f": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "c238c949e517bf191e2a837797d7ca7c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-indian-boarding-schools"
+      ]
+    },
+    "c2390179de33316293c12da566a3a97d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-raven-by-edgar-allan-poe"
+      ]
+    },
+    "c2423a2a55be574a9b3611500cfef3f8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pablo-picasso-s-guernica-and-modern-war"
+      ]
+    },
+    "c26f2c1990bd72b5f40e1c0a88710946": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "c27fbcdf1d5defae0b9f2626d89a50de": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "commodore-perry-s-expedition-to-japan"
+      ]
+    },
+    "c2b7710842606670c87c5cc317bcfa37": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "c3109dde3d2816b347a7e478b2364903": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-through-angel-island"
+      ]
+    },
+    "c32c223601d3d2d707d95d6403d1d042": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "c339cea1b8cb56f687889550bcff8dec": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exodusters-african-american-migration-to-the-great-plains"
+      ]
+    },
+    "c358de7e3e1c31322a2cf34d4e788975": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rock-and-roll-beginnings-to-woodstock"
+      ]
+    },
+    "c38c26d8ef40f329d1609578812b5eed": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "c38e16338562f8d3c8071148ad930a5b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "social-realism"
+      ]
+    },
+    "c3a6ed4112da97af5bcac65fa1dfed99": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "c3ae7158e1b02dd08d9b3e2147522e4a": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "c3b93e90e181452e95a3c4c9a3feafeb": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "c3d5fb6c9fcd16a276da5d80c415fc0b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-deal"
+      ]
+    },
+    "c3df95885d8d110d22e49382e48ea883": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-s-eastern-front-operation-barbarossa"
+      ]
+    },
+    "c3e6d1c4bc673585d9509b590a07e329": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "c423f11fdbd669f7cb2d312d94322eb7": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "c456d177d061dadf12a75e1f89254d2d": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "c45cbeab9d2f781527edeefa3f81a3fc": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "c4625cdb7e2decc1bab2364c650d8327": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "c48be6a04e0af992c6a5da889d1bee5e": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "c4986f72346e569d4038fabc9b76c5d7": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "c49f7199aef31a7f81dfcdbe49799e94": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-grapes-of-wrath-by-john-steinbeck"
+      ]
+    },
+    "c4a08b45418936414c60ced02983a25e": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "c4a8645ee97f9104d1ae6ef937e57317": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "manifest-destiny"
+      ]
+    },
+    "c4b0a148465370ee028bc0db83d4d8a8": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "c4f4f98897b6999810e97f79cc654b41": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-crucible-by-arthur-miller"
+      ]
+    },
+    "c507a0856f4562a4dfef6fda348b55aa": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "c50ba03fa776ec4f9ae34ce3285912ee": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-invention-of-the-telephone"
+      ]
+    },
+    "c520990f48f6a3f570869fa65d325ae5": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "c5215850d8d3ccce4220c05fddcbfa5f": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "c5242efcb64188ecabc4d1e338fe245a": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "c52b26a85c2cb77cdc90a49669bb5445": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "c53964fa64370b0820d00fc1c6151011": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-rise-of-italian-fascism-and-its-influence-on-europe"
+      ]
+    },
+    "c54c30d1e533446df510e068a959d72a": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "c5507310994de17e209823a054c65213": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "busing-beyond-school-desegregation-in-boston"
+      ]
+    },
+    "c55f90147eab47356ea0d37a0523e24d": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "c5858eedddfaa1a6202f4f4d83e39ea1": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "c59f8a480f81e80670dd7aa102d91076": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": [
+        "the-impact-of-television-on-news-media"
+      ]
+    },
+    "c5a55aa59e4ea37cec2c490e0a57fb95": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-indian-boarding-schools"
+      ]
+    },
+    "c5af48a5ee0e487f40ff8dbe2547fd4c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "a-raisin-in-the-sun-by-lorraine-hansberry"
+      ]
+    },
+    "c5bc736e85fe4e5d0b105fca67ced07e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "postwar-rise-of-the-suburbs"
+      ]
+    },
+    "c5ce35aed466b60512fb42d1c6a36935": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-through-angel-island"
+      ]
+    },
+    "c5da6ac56bd60846c5d2eb8509ec206b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "when-miners-strike-west-virginia-coal-mining-and-labor-history"
+      ]
+    },
+    "c5fe9169f6ebcdbd003cb634767f69d8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panama-canal"
+      ]
+    },
+    "c60ab9616f436dbd154a7b0d76a3b292": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pablo-picasso-s-guernica-and-modern-war"
+      ]
+    },
+    "c615ce72d719956eda4eca7fb28e7e32": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "dutch-new-netherland"
+      ]
+    },
+    "c628bc09ea746b1f7669e77e37b257c4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "a-raisin-in-the-sun-by-lorraine-hansberry"
+      ]
+    },
+    "c63d1f25418524e683f1f7a39374e3c1": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "c6406a13a652945d31b5855074b501cc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "settlement-houses-in-the-progressive-era"
+      ]
+    },
+    "c64593866ef650962bbb346b720aa267": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "c673242c58f330a7d747af3a1b246106": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-whaling-industry"
+      ]
+    },
+    "c67e2c9a4fd3234e56f6e419ba7c74ec": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fifteenth-amendment"
+      ]
+    },
+    "c68526ab13201488a47fbb0c23766c0c": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "c690941faffdcc245d9b1a1617323f0d": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "c699fd74cfa3f91a11c8404e51831e59": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "c6fd60c4181838394d7cfe79063fbf8f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "second-ku-klux-klan-and-the-birth-of-a-nation"
+      ]
+    },
+    "c7076ff66a11390578bf825d13685517": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "c71c2033f209d4102e8401e738f5be55": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-absolutely-true-diary-of-a-part-time-indian-by-sherman-alexie"
+      ]
+    },
+    "c7209e7672b5868f002dd163aad55b2a": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "c722a63f73a532ab5907c9e323722dc5": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "c75493002146f5d2c02c5473b8074283": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "c76c1666c5ae3181170abd342b5812bb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "of-mice-and-men-by-john-steinbeck"
+      ]
+    },
+    "c7a108e04b113bed90c9c46a551b5655": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "c7b1118b95b48790857c4df3a8c6ffa4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "nineteenth-century-schools-for-the-deaf-and-blind"
+      ]
+    },
+    "c7ca1ecc6282ce5873d3bf5d94d63fcc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-of-the-antebellum-reform-movement"
+      ]
+    },
+    "c7d05da3ed72c10fb51a457b3a48c46e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-of-the-antebellum-reform-movement"
+      ]
+    },
+    "c7d150ef506eca30f877661ae8fb0d60": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "c7e349b23c388b5d926bbb8ac8c4aa16": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-gatsby-by-f-scott-fitzgerald"
+      ]
+    },
+    "c7eed06590ff300cabec166f7696f9f9": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "c7f054953fe02477371eb2930fca281d": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "c8098e41b5e6d6afd789d329722894ac": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "c80e892350104b80c33b756ef877650e": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "c828ab2da6009cea41e3d9c0239e682f": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "c86ffb382408e9903a4f03a48f2456b2": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "c87339aab03db8a10ed68ed550058b77": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "c875861de80694a4cba35eb7d960c662": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "ida-b-wells-and-anti-lynching-activism"
+      ]
+    },
+    "c87d14eddb050f8d29319d97b0ab90f7": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "c8844da4c76519fd7a7b664de3d30e73": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-watsons-go-to-birmingham-1963-by-christopher-paul-curtis"
+      ]
+    },
+    "c8994ac95e70adf16c19fa0f0744108c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "to-kill-a-mockingbird-by-harper-lee"
+      ]
+    },
+    "c89f28fd2aeafa67509c88f7dd97cdb6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "settlement-houses-in-the-progressive-era"
+      ]
+    },
+    "c8a034d68a4b80d00425a1e2bf0f9af1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "spanish-missions-in-california"
+      ]
+    },
+    "c8a445b41062927318a21bf50d3287cc": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "c8e3bda18c16c5751b868d22d186f654": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "c8f14d93d047a674a5d108ddd65c9dd7": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "c8f4b6dda939204d598c7b2b8930f79e": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "c9141b9ba0d8b3c0111984ae37a8d472": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "c9356ad06bbfece0368bcfb2a59a73d3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-imperialism-the-spanish-american-war"
+      ]
+    },
+    "c94f784768d3122ba85fac235d808acf": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "c97132ff5c49355be52ed286e851d75c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-rise-of-italian-fascism-and-its-influence-on-europe"
+      ]
+    },
+    "c9827997f368504d09c6349a8329137d": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "c987c55e245fad45d93351831a4ab39a": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "c98b791435837c8c8442b80e393fb164": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "california-gold-rush"
+      ]
+    },
+    "c98efe41e98c4929536f600827a646d1": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "c991b86226c213b90c333e649e09965b": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "c9c7a2acdefd712c1feff875f9f6edc5": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "c9cc5b27edeaf8322716f1781c46012b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-raven-by-edgar-allan-poe"
+      ]
+    },
+    "c9d1532e9d1ca98a655c3a26f8544824": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "blackface-minstrelsy-in-modern-america"
+      ]
+    },
+    "c9d8ef8a3f63f7f581a8fa742b4e5f97": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-freedmen-s-bureau"
+      ]
+    },
+    "c9e0ba95ba1918aaef0f9853b95b54d3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-i-america-heads-to-war"
+      ]
+    },
+    "ca31a5447603f62ccf484da16596596d": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "ca39f55b70a9aa4c2e75220924162c5a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rock-and-roll-beginnings-to-woodstock"
+      ]
+    },
+    "ca74eab6cf5a0d1267b16d9456c60705": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exodusters-african-american-migration-to-the-great-plains"
+      ]
+    },
+    "caa2fa3f07c21f93cdcfa23d360cd65d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-columbian-exchange"
+      ]
+    },
+    "caa8a579fd61cd23388d3ee4d7c9e567": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-wounded-knee-massacre"
+      ]
+    },
+    "caac4558c85641374e528950181f32ed": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-emily-dickinson"
+      ]
+    },
+    "cab775a5f0451fa4b3cc95f8e27ceef3": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "cabaadb7e9ecc498ae97d6569a95d8ad": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "cabf14f9b95a79fbe8f137e6073ff3ea": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "cac2c9a60ed10c1928204b9c17db2733": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-grapes-of-wrath-by-john-steinbeck"
+      ]
+    },
+    "cace0c1aeb751f62965bcad0bc56561a": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "cacf22e2d4f776c4a6292de99c790553": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "lyndon-johnson-s-great-society"
+      ]
+    },
+    "cafc5a0b8952774bfcca2eaa94bca0b2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "theodore-dreiser-s-sister-carrie-and-the-urbanization-of-chicago"
+      ]
+    },
+    "cb19aa49c856df234812cf6849475b14": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "puerto-rican-migration-to-the-us"
+      ]
+    },
+    "cb388b3b9dbf409a17eafcfe9f7ffe9a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-atomic-bomb-and-the-nuclear-age"
+      ]
+    },
+    "cb42329a44c170c882b97b1ad9a7a48b": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "cb54c9d29b3206c2a97d99e0b8b934d2": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "cb5744a690b0036b531db83d143e7de8": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "cb66dc487c1984500263a15415d4963c": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "cb6cabef554ed1bf80967784c294a687": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "lyndon-johnson-s-great-society"
+      ]
+    },
+    "cb6e219ce2fbc55c4da7d8bfeab4d0f1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "battle-of-gettysburg"
+      ]
+    },
+    "cb80d288c1407c18484907a93fa32cde": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "settlement-houses-in-the-progressive-era"
+      ]
+    },
+    "cb89e98b3439b822939c5d7a544142f8": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "cb923ccbb1026bf342fcbad994005e8f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "reservations-resistance-and-the-indian-reorganization-act-1900-1940"
+      ]
+    },
+    "cb9d66763280af59d56c478f770a8ed2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "environmental-preservation-in-the-progressive-era"
+      ]
+    },
+    "cba429c01006482fd2ece0b4fbf96a19": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "cbbd73f0a60edd4cdb1214cb23806721": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "cbcdeda7bb751e1593993c5226afbcf1": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "cbddb41e50d857ff2ae6a1fb68ee4ce9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "nineteenth-century-schools-for-the-deaf-and-blind"
+      ]
+    },
+    "cbe9452de6da4949a2e15b0a26f99c4b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "creating-the-us-constitution",
+        "shays-rebellion"
+      ]
+    },
+    "cc13851c34cf3ebd38c9180fc826fb72": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-impact-of-television-on-news-media"
+      ]
+    },
+    "cc1f4cc50ba0f4e9652d7ae0fc51d5cb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rise-of-conservatism-in-the-1980s"
+      ]
+    },
+    "cc203d16798340c7f8adb8566593b36a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pop-art-in-the-us"
+      ]
+    },
+    "cc2b822b3471f3b0e9ad1e2dc15ac214": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "cc41b8db5a4540291e083f1f5d6b3d1d": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "cc4281a75eac7a2603e18832337062a4": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "cc47339fafc2da395bd91654bbf2cc5c": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "cc68db0f3c80fe1e83fef91a0930ad1d": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "cc6902ffedaf2fd3a5b9387c6f497ccc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exodusters-african-american-migration-to-the-great-plains"
+      ]
+    },
+    "cc77435cee6239daafff78b547ee9ca5": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "cc79d93df776401fea5692e0ab594597": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-transatlantic-slave-trade"
+      ]
+    },
+    "cc7ee672ae0aae74c763df01ddf86178": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "space-race"
+      ]
+    },
+    "cc80e193b31a03e35efdab57b2449cc7": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "cc84c242c77155d2c13504735c2f5762": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-strike"
+      ]
+    },
+    "cc861272ba75a747ff695e53b21a255a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "environmental-preservation-in-the-progressive-era"
+      ]
+    },
+    "cc9ab2ef05dd7161cacaa080341d3c87": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-whaling-industry"
+      ]
+    },
+    "ccb6ed3cb0f4ca4ceaef669ec98edf54": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-united-farm-workers-and-the-delano-grape-strike"
+      ]
+    },
+    "ccecb9af86393af50fd0042719916efa": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "cd0e7fecd3a371d94093bd830dca8fa9": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "cd2980944520277e407b4ca9dd2d3ccb": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "cd57c6e80f951241935714d3f7516f9c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-indian-movement-1968-1978"
+      ]
+    },
+    "cd594810eadec4c93df0939994acaff8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "postwar-rise-of-the-suburbs"
+      ]
+    },
+    "cd72cc29b2354de0b7db9c49daa14582": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "african-american-soldiers-in-world-war-i"
+      ]
+    },
+    "cd7cf702c6ae519437bfd00e8df2ffac": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "cd8985b85e7359310eafc0f675f09620": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "cdaaf15eb660d29f7a2f6d9e8fa9e652": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "secession-of-the-southern-states"
+      ]
+    },
+    "cdbf65c2b80020d373ac70c3e6ca6774": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-i-america-heads-to-war"
+      ]
+    },
+    "cdc6e6d4123419fb7e6c9c84b40e262a": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "cdcd7636365be9bc15b667ad929df330": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frederick-douglass-and-abraham-lincoln"
+      ]
+    },
+    "cdf40b0f1d0646c8b54c82410bb55413": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "cdf688e34089b1260933ef2f9985ca38": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "latin-american-revolutionaries"
+      ]
+    },
+    "ce28741c578de1b34f50f66dc27202cb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-impact-of-television-on-news-media"
+      ]
+    },
+    "ce32bfb5fe42147d95dde14b26c6d24a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pablo-picasso-s-guernica-and-modern-war"
+      ]
+    },
+    "ce377a7f62fd614f4be97ca96ed0fe6e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "japanese-american-internment-during-world-war-ii"
+      ]
+    },
+    "ce49cd320fdcf8e159a826e7b595b0c0": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "ce68c84e7ecc2e25aaafa05c673492f8": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "ce6bb6db7424c771e965e39120e00744": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "ce8802c7f9b76bf95c012ef4ad15b2bb": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "ce93f603c0348828b7d2d4b7e3898945": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "cef166e515431ea8103431704c44a52e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fannie-lou-hamer-and-the-civil-rights-movement-in-rural-mississippi"
+      ]
+    },
+    "cf004ba567859dcdeaff54d9af254be2": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "cf21b08a4f8d69a7f3b2d14ce975b531": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-equal-rights-amendment"
+      ]
+    },
+    "cf22957db6f05eca1bd0b989ad829a7a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "visual-art-during-the-harlem-renaissance"
+      ]
+    },
+    "cf3c33dbcd0d01d4b6d860556290a711": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "cf73a9bcc1d6f83d355cfd696ab6c784": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "second-ku-klux-klan-and-the-birth-of-a-nation"
+      ]
+    },
+    "cf7591766724ddc81b4d123b75072b5c": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "cfa3180c577f5810cefca2b4aff3721c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "blackface-minstrelsy-in-modern-america"
+      ]
+    },
+    "cfab2fb1d7215e0d4c5f2b7ee22b71a2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rock-and-roll-beginnings-to-woodstock"
+      ]
+    },
+    "cfae09990ed96c4eb24d82ea18fbd862": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "cfcb54f552e995caf77acffa7041cc76": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fannie-lou-hamer-and-the-civil-rights-movement-in-rural-mississippi"
+      ]
+    },
+    "cfda7912d95a08f8655cab336e1adcef": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "cff6bf83de8d484089556a63a139da11": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "d002c5fa2c9be148b452d114d71e0892": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "d01760c16f9d324d977c4158b88bb562": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "d01933d5b023641e6ab9d8d6848d1379": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "d0271af989408bd5a215817b8535e15b": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "d047e6826042b29575a67e214b2f5067": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "d04d4d5a96b47ee1b99341fdfd95752a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-wounded-knee-massacre"
+      ]
+    },
+    "d05bd7e895e572baac80c562b516632f": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "d05c69be1234e57531cc13ad83c0ee8c": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "d0617d17f8d7ef4c05dfd86896a187c7": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "d0b565f0fd2a742066e9c4601afdef40": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "d0d8aa83b230838840eca0ff9a4600d1": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "d10500d9410dc209879cfb7e378ca95d": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "d123dd700071976469a5e82c673f6d5e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "road-to-revolution-1763-1776"
+      ]
+    },
+    "d15aaeb2f7e19e6dd7afa5ea98aaa4df": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "d15ddbb3dd88d4e13c422d5994172888": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "nineteenth-century-schools-for-the-deaf-and-blind"
+      ]
+    },
+    "d16cd194c6e1d49aa2b5787ee8a055bd": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "d17b2c32f7b356902f34f00176add593": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "d191da9b8b9745c605c88221229c07cd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "voting-rights-act-of-1965"
+      ]
+    },
+    "d1a023232cd8e545f35d09cdf945b5cf": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "d1cff6bdcde7e9dfc9655c06bdc50cde": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "d1d6c941b3bbe1c56b6aaf36a448c124": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "d1dd96636e2d13daeafa56f56e50eac7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "uncle-tom-s-cabin-by-harriet-beecher-stowe"
+      ]
+    },
+    "d1ea2fda63068379cda2048d25e0b81e": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "d1f441e7d5576e30d4194b49d425131a": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "d20393ba0ae9607325b7a41e5e907012": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "d2039ee1297bf3340fe176c3e0bbd1b2": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "d239023b22939e21f58dd8775efe55ef": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-black-power-movement"
+      ]
+    },
+    "d23b478deb7d2274f7b222a1bd74ed60": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "patronage-and-populism-the-politics-of-the-gilded-age"
+      ]
+    },
+    "d2496edae61dffadabcafbfaad86aba0": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "d249871d77fb85f819bfa34cae339749": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "d24d1adde70fa923d178b9599591d0d7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beginnings-of-the-american-red-cross"
+      ]
+    },
+    "d254745ad62698b5d7ebf38b4b1c7cae": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-things-they-carried-by-tim-o-brien"
+      ]
+    },
+    "d2a0750be7506b98e72b7b299cf5c49b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cotton-gin-and-the-expansion-of-slavery"
+      ]
+    },
+    "d2a234a5eb6655db7cf9af972f617f93": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-woman-warrior-by-maxine-hong-kingston"
+      ]
+    },
+    "d2a6c123425bd7466ed4b06a4a7ad5b6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "environmental-preservation-in-the-progressive-era"
+      ]
+    },
+    "d2c343ebb2409075658be5b25a334d5b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "eugenics-movement-in-the-united-states"
+      ]
+    },
+    "d2e49349289191399bc9ba2b861468ff": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "d31cf75ab48b94232a5d155712dedbb2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "lyndon-johnson-s-great-society"
+      ]
+    },
+    "d346670fad77394195054d073ec61bd4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rise-of-conservatism-in-the-1980s"
+      ]
+    },
+    "d360c9b951612a8db1962d82317083aa": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-temperance-movement"
+      ]
+    },
+    "d36833280dda0cb833e8b0404b1243dc": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "d38128b738b9b448ed488344d633c950": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "d38c456c7f48b15491a295d02379d9ce": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "patronage-and-populism-the-politics-of-the-gilded-age"
+      ]
+    },
+    "d3ba3bfe78b2b8f4ec10a6a193cbe3a1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-absolutely-true-diary-of-a-part-time-indian-by-sherman-alexie"
+      ]
+    },
+    "d3e64c379e286d73e4588326404fad1b": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "d3e7cdbee6b96d9c6e0c076a0eb83ce7": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "d3e8bf136d3bcec1734c4ea7a069c136": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "texas-revolution"
+      ]
+    },
+    "d3f2adf5ba3c3ff323e5628f2ffc7384": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-indian-boarding-schools"
+      ]
+    },
+    "d425f10970982022d5ea5eca5f6882d4": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "d4269e50bf67df13829ed56639b1e6aa": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "space-race"
+      ]
+    },
+    "d43500c89c17ae15a9fe4586a54f661a": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "d46e88d8d83b1e43abcb572bd5c5bd44": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "busing-beyond-school-desegregation-in-boston"
+      ]
+    },
+    "d49073f2b7b00e420fd423447fc79a8a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-columbian-exchange"
+      ]
+    },
+    "d49cbe7b17c566b3d130a499ae0b561e": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "d4b5305ebb9139c416de50f41eda0479": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-i-america-heads-to-war"
+      ]
+    },
+    "d4b68e61e1f7de8ace35b20d3b734afb": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "d4b6f8a3a1f63773d985fca49a50a434": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "incidents-in-the-life-of-a-slave-girl-by-harriet-jacobs"
+      ]
+    },
+    "d4c22c16605b1a99f3a6f126959a3ad1": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "d4c6d8c2a6da021bde2caa524025f84e": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "d4ca1cbd7f73b7c5b91ae93acf184b91": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "d4d00a67ecb5b1d22e6eed72adf9af02": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "visual-art-during-the-harlem-renaissance"
+      ]
+    },
+    "d4dca77ef29d3ba4dd644ff1bc05090a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-of-the-antebellum-reform-movement"
+      ]
+    },
+    "d4de808eaee81a2a6682cabc17e536cc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-blues"
+      ]
+    },
+    "d4ed9be691f620bd95472215c4b369ba": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "stonewall-and-its-impact-on-the-gay-liberation-movement"
+      ]
+    },
+    "d501d07d73ed15486b9d36456764ff36": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "d5062e67475439cee6a85450f68ff06f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-wounded-knee-massacre"
+      ]
+    },
+    "d524d0faa2ebf58ce6a8e8cb1404bc8b": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "d526647df31d0018e50635f83fcb4ba0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "busing-beyond-school-desegregation-in-boston"
+      ]
+    },
+    "d533b3905d36791deb6a7d063fef240e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "eugenics-movement-in-the-united-states"
+      ]
+    },
+    "d54640b66bb3190bb6d0ae7017fe3767": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "d5470556b32a23f91dd9411b49dad44a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-grapes-of-wrath-by-john-steinbeck"
+      ]
+    },
+    "d54b09c9afbf05a63f056bcb2ce48309": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "d563232b96eed67f899c974a8f06a840": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "declaration-of-the-rights-of-man-and-of-the-citizen"
+      ]
+    },
+    "d56efbb7ac68ce528e3d5139f5133144": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "d56f66eabc59fa5c9d24fe2fad906706": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-s-eastern-front-operation-barbarossa"
+      ]
+    },
+    "d570ca6974ba75f246f497074506d81d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "of-mice-and-men-by-john-steinbeck"
+      ]
+    },
+    "d592239d80ef3d9f66fe5b9ca10cda53": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "northern-draft-riots-during-the-civil-war"
+      ]
+    },
+    "d5c3bf322ec23784748c68600bc4b9e7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "eugenics-movement-in-the-united-states"
+      ]
+    },
+    "d5ccb2003ea13ebe381981b79c500935": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "voting-rights-act-of-1965"
+      ]
+    },
+    "d5e180942eedebf47e84e7d0f525c854": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "reservations-resistance-and-the-indian-reorganization-act-1900-1940"
+      ]
+    },
+    "d5e2756ec548aeafcc3ef8b88bfadc8e": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "d5f855ee2fe72fcc319442525390513e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "shays-rebellion"
+      ]
+    },
+    "d5fc4b18021634635e24635c8d70377c": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "d60a9fb7e3aa82ff823e93421c9e89c2": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "d62c3a0f70c9d4dcec6f3232751a3a80": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scarlet-letter-by-nathaniel-hawthorne"
+      ]
+    },
+    "d637198aa7c2660640e1bfe435a3a667": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "d663785115dfe8cccf9dee10f499b9fb": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "d67929ef8a1c310d4cdd2db55a9d7c27": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "a-raisin-in-the-sun-by-lorraine-hansberry"
+      ]
+    },
+    "d695001760093f50dda6f38d0a363999": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "patronage-and-populism-the-politics-of-the-gilded-age"
+      ]
+    },
+    "d6a3d383e56b13a025bbbc65f59d992e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panic-of-1837"
+      ]
+    },
+    "d6b15a6c033ca6cde470bb76f3e4d076": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "d6bfabe38e69752e2bba3a4513cee6f1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-i-america-heads-to-war"
+      ]
+    },
+    "d6d3bb8d5e306149d9f7acdf92d77c5e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-awakening-by-kate-chopin"
+      ]
+    },
+    "d70a15c5779fef84fc4e34e35ddd65a3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-imperialism-the-spanish-american-war"
+      ]
+    },
+    "d731e11b3f66a578b00da03ae743962d": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "d77556de02b8dfcedccdfaaa9a68c195": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "of-mice-and-men-by-john-steinbeck"
+      ]
+    },
+    "d77c532653cd7ab7f53b39d1ef127a22": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "d7956ec54242c70e9129bbd488c42f1b": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "d7b66ae730ea268eeae416634381e1fb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fake-news-in-the-1890s-yellow-journalism"
+      ]
+    },
+    "d7c1ed0f355af5b0660f0248bef8a844": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cuban-immigration-after-the-revolution-1959-1973"
+      ]
+    },
+    "d7ca78d98ae563bfefd20c2620613c8b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-indian-boarding-schools"
+      ]
+    },
+    "d7d2a762e5ac3a700a9b88f16ab02441": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "d7e5a452be528e61eaa2c7721447d9e8": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "d7f9608f4bfe72abeaf2843c5bcae87d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "truth-justice-and-the-birth-of-the-superhero-comic-book"
+      ]
+    },
+    "d7fe9c5f7461c917c8692ea856ad8516": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "d81b6116ee5bb3fe133f15a993410b4e": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "d837d1c4631e077fea806c62bbb61d0d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cross-cultural-colonial-conflicts"
+      ]
+    },
+    "d84b5dac199df0f003984d4ace91368a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "busing-beyond-school-desegregation-in-boston"
+      ]
+    },
+    "d84f6e21a64233e15543ec681c7ce2d5": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "d86db4da133d1831327f7f3473cb07da": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "d88095835b4e5b48922f47db3c073f02": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "reservations-resistance-and-the-indian-reorganization-act-1900-1940"
+      ]
+    },
+    "d883261db9d30c383efbcda13a98cb66": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "d88ed0c9a759f0bec348871028824aaa": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "d8a5197905836bc479ae11c5c678d192": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "d8b0811d2c97f9c8d672ab0ed2acfc7c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exodusters-african-american-migration-to-the-great-plains"
+      ]
+    },
+    "d8b5b657e64ad997aeb1990800582d76": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-things-they-carried-by-tim-o-brien"
+      ]
+    },
+    "d8b99b7786bab630b1a8c67b7db36348": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "attacks-on-american-soil-pearl-harbor-and-september-11"
+      ]
+    },
+    "d8d3cff6d6c42b696ef7c1f60eb3318e": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "d8dd3027b34fad008272cf5a93560901": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "d8ee538ecd18326a1e84ca10c611dc6f": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "d8f88dff38301a20abf182cb024e8274": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-united-farm-workers-and-the-delano-grape-strike"
+      ]
+    },
+    "d90b339e1dcf1e695f3a6476b57cbcd7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "act-up-and-the-aids-crisis"
+      ]
+    },
+    "d93531bc6f8f514b0b8e645d83c769cb": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "d989a8a8739206708094e7b8a05642eb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "act-up-and-the-aids-crisis"
+      ]
+    },
+    "d9a95122ba874008dc450068273fbb57": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "lyndon-johnson-s-great-society"
+      ]
+    },
+    "d9b1a6ced94cccf8d74af9c4ec01cf00": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-of-the-antebellum-reform-movement"
+      ]
+    },
+    "d9c34cd375c9e2586c3a4dbe7b04ea49": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-underground-railroad-and-the-fugitive-slave-act-of-1850"
+      ]
+    },
+    "d9ffc6b45a96ea90a808b0753ecc1ac3": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "da03db9ec9c4becb7844b2bf06cf2024": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "da088eccd45bd98ba537a0cb75865a61": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-emily-dickinson"
+      ]
+    },
+    "da0df29ea28cbc32ca25bad727b9e4c9": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "da1ca9ae486e09b9f0af1b5a807ec423": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-invention-of-the-telephone"
+      ]
+    },
+    "da211b88b1fa85884f88a0cd9c9899c3": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "da31484e07d1dbb274d43cf57e852f88": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "negro-league-baseball"
+      ]
+    },
+    "da373fdb6ed1f5590e95a067095ec0eb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-of-the-antebellum-reform-movement"
+      ]
+    },
+    "da4309da1cd982876cfd8e295b197334": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "da541b2687c8ff20582adeb62e441d5b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-indian-movement-1968-1978"
+      ]
+    },
+    "da7d5f877d72ca70d0bc617ffb390076": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "daa25fa85e6a987b128b1de32adc2ee9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "theodore-dreiser-s-sister-carrie-and-the-urbanization-of-chicago"
+      ]
+    },
+    "daa5f2a30ef92b58ed61bdf44a7d2103": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-s-suffrage-the-campaign-for-the-nineteenth-amendment"
+      ]
+    },
+    "dacef7d8a3b2c49ba56d1d1a1160c418": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fake-news-in-the-1890s-yellow-journalism"
+      ]
+    },
+    "dad0f54a099fd2ca917e601d0fe9b6f9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exploration-of-the-americas"
+      ]
+    },
+    "dad7b2c6701fb954871e1b91a60f5e0d": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "dae3ef53e7b4336a1cb1b72c4c25150e": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "dae7ced8ba453ec726b341f795997812": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "daf5728a9aa459cb12bd8e4f1c4ca80a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "full-steam-ahead-the-steam-engine-and-transportation-in-the-nineteenth-century"
+      ]
+    },
+    "db0487b152e12df5dbc14171f69c687d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-acts"
+      ]
+    },
+    "db0a599401b96bf68c898a5803145750": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "db1573dfb364b51d515926eeeea245a1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-abolitionist-movement"
+      ]
+    },
+    "db4f91681fa0f303ea7c6f265fc7586e": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "db5873591bf36231a5f6e743a1c383b3": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "db75fdbf337bb9b2768cf3314b7ae7e5": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "db9a7ae15351c3bbd2b9510433d5b530": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "dbd4906a8925bf4688fba7f7ea3bd62a": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "dbf0608035f9a68fe57d1225c391a1fe": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "dbf119e441c33feccad352e477d6e26a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "there-is-no-cure-for-polio"
+      ]
+    },
+    "dbfc664b9423275f6e532dbf1fb50f80": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "dbffdcece610bae9ce53c0426d11cd11": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "dc013752109fb527ffb4a849d409753b": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "dc0e2756e94f3846cbc6d5cb6e22d2ca": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "dc1f3543511d3b4036cd36bbae5a093a": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "dc3418dcdcde6c7a56b49d72811a8880": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "blackface-minstrelsy-in-modern-america"
+      ]
+    },
+    "dc3a4c8dba2b4e2aed8e518f9b3121de": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "dc40bf36f736d93ce07c83f5b5f45b61": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "dc6ea846c0367dd7e86b0a3a597a0190": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jacksonian-democracy",
+        "the-panic-of-1837"
+      ]
+    },
+    "dc768feac573655c4418dc175e830a70": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "dc7b40af21e4ab8f3aef58574f05c638": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "dc7c8c23f39fe16119f884aeda2843b1": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "dcbe6e31c3bca319fb9dbbb60519fd7f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "settlement-houses-in-the-progressive-era"
+      ]
+    },
+    "dcc316ed5d21122d59aef0193fd17ce7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "negro-league-baseball"
+      ]
+    },
+    "dcc365517022607bbcc96346ca96e658": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "dcee9762b55e4fd1e9b6bd6a555022a4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-transatlantic-slave-trade"
+      ]
+    },
+    "dcf56f77b26f9ec7f4d2a69dce180962": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "dd34efa6f5b236b2b8069011ca1431f3": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "dd368578945adecba21229f895c37bf8": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "dd537a76c925896454757490c255e1a8": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "dd5a19e0edba834aa9dc938fcd9267f8": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "dd7e1aec71548225e413a1989c80b961": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "dd86b0387657f0b8b1990a9f7c482ff2": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": [
+        "voting-rights-act-of-1965"
+      ]
+    },
+    "ddf1f02d2b6502d860ed00259f32b715": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-imperialism-the-spanish-american-war"
+      ]
+    },
+    "de0671ddc8fcab49d801e35d23f652f1": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "de3247b2d36a6103daa00f1bf6d50826": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "de3f23d5b7764fb8ebd57c837277b687": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beginnings-of-the-american-red-cross"
+      ]
+    },
+    "de53cda54ed5eca4662fb7804ae5df61": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "de669d2e68637371b4c00e4355cac7fc": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "de6d62b0d4efef75772af142145fc5ff": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "puerto-rican-migration-to-the-us"
+      ]
+    },
+    "de7cf8dcff1e22b7bf6feff30d6b82c2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "settlement-houses-in-the-progressive-era"
+      ]
+    },
+    "de8004a8fe5bf23ccb750fd07f04241e": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "de97769a9d9b89e2b494bcb74fa851c8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-impact-of-television-on-news-media"
+      ]
+    },
+    "de9961d88ff6559ad7ffeebd466cb54f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "eugenics-movement-in-the-united-states"
+      ]
+    },
+    "de9ca6f6c19b62299ed63ded4afdcfb1": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "ded0f95a10abeea39757e64c13d1ca16": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "elie-wiesel-s-night-and-the-holocaust"
+      ]
+    },
+    "ded11204f6f5a7eedeec5762b4b61420": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "dee51c2b77f032b9e4147a6ddda377f4": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "def2d76d091c655c740ca7b3cb72518e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-war-of-1812"
+      ]
+    },
+    "def6b8e505e91696bb407faa5441277b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-adventures-of-huckleberry-finn-by-mark-twain"
+      ]
+    },
+    "df21090cc91f9316444bf850fb0662a6": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "df35219a4a83be36dedbad82bb9a0420": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "spanish-missions-in-california"
+      ]
+    },
+    "df38106f18e1677ed3a068e0089d481f": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "df3ec51a1fdb6f79e91a49b39c702024": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "postwar-rise-of-the-suburbs"
+      ]
+    },
+    "df531e0d8c894aa62f372f5138c8c037": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "df548416ce84fda47fbfeb760a8ad2af": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-woman-warrior-by-maxine-hong-kingston"
+      ]
+    },
+    "df55361b78dcf68e263a671a19cd2e5b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "little-women-by-louisa-may-alcott"
+      ]
+    },
+    "df55c250bea80bad66ad916fa377427e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "colonial-religion"
+      ]
+    },
+    "df8bd2627f5a54c883768812ed4cfc98": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "df93428ce6413995095dca052fb59ed6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "electrifying-america"
+      ]
+    },
+    "df9fee04c1d7cc490ae2db6ba3156ff9": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "dfa5d8e1ae8bea7fc0c5c727b1267362": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "dfe9cc30ed2fdaf46ebb3bd7a229146c": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "dff7cf23166f9fd38c8d8abfe4c1e46c": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "e028595786c6c2bc57605e40e1c58cf9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-hudson-river-school"
+      ]
+    },
+    "e04b04278d8940f730aa74d06c6c7132": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "puerto-rican-migration-to-the-us"
+      ]
+    },
+    "e06255557087abbf2526113b5a30107f": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "e06922faf69bd53618f662ab91744ee8": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "e0934a498297dd0d1a4c60068f3835fb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "japanese-american-internment-during-world-war-ii"
+      ]
+    },
+    "e0953e9c130501415c1bbeb5cef29613": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "e0a4e6c6e8a37fbf5cc6c0f627ad8751": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "e0e528bf6f5d14b01583c298289bf175": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-s-eastern-front-operation-barbarossa"
+      ]
+    },
+    "e0fa2288e69cedd1ab67c01608af7de7": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "e1179ffb6aed7a049a944285927335b8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-populist-movement"
+      ]
+    },
+    "e11fe26b10825f58004ede5601d956d9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-populist-movement"
+      ]
+    },
+    "e13186ca0fcab7084356b3855132c1b9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-migration"
+      ]
+    },
+    "e13d7aff6105421177d22e640369597b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "declaration-of-the-rights-of-man-and-of-the-citizen"
+      ]
+    },
+    "e151da56c720c8823010b63f13f8c899": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "e154f2673fd8df2fc96077d2e22865b9": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "e15e3412729e439e8ced476cdf1b3793": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "e1601fc5d378de0f0ecf6b29b7580a54": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "e160a814354b05525a51f181623f6f5d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-blues"
+      ]
+    },
+    "e176ea25dd3065e8b51c6f0957dfecf0": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "e1999e8c3d3c062057e1ecb9048872e0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-gatsby-by-f-scott-fitzgerald"
+      ]
+    },
+    "e19f47273aaef00810eed9a7b59a4450": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "e1c79c3b92b492a034ba0a0c50e4a5ac": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frederick-douglass-and-abraham-lincoln",
+        "the-fifteenth-amendment"
+      ]
+    },
+    "e237a3776a9bd12b6dad96fd97c3d470": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "e24a66296269c079653c1b5ac9713933": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "e27c88f0706ed4506844f7b23aec06dc": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "e280e710cf407d3c984a2dcb7146aa42": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-hudson-river-school"
+      ]
+    },
+    "e2965543fdfabea8465c0aba57f3e9a9": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "e2ac556bfc406e2ab929527fb5dc6693": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-gatsby-by-f-scott-fitzgerald"
+      ]
+    },
+    "e2be3b73d778a0ab2bfb4ea7919cdff7": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": [
+        "exploration-of-the-americas"
+      ]
+    },
+    "e2c215747d805c7ed5c4677ee247baf7": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "e303ab9c19a13d03a091b5a2b50e7822": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frederick-douglass-and-abraham-lincoln",
+        "the-fifteenth-amendment",
+        "voting-rights-act-of-1965"
+      ]
+    },
+    "e310e959691979ba50c3910b8dc4f0da": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "e3266d64271f8f7fd49ee1a39591342f": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "e335f5f0bffce06da353fc402d484e45": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-whaling-industry"
+      ]
+    },
+    "e3382d34116a66e3e29426a60320d82b": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "e348c730b9f892b7157fcfbfbb3b73eb": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "e34bb5ede64b4f9ee683b12c1cc7c7b3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "truth-justice-and-the-birth-of-the-superhero-comic-book"
+      ]
+    },
+    "e354d99d1ac08270997f34530f727045": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-indian-movement-1968-1978"
+      ]
+    },
+    "e35c931adbc387776f07c55b6ec5050d": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "e36dcfffb70b01a257d898889ffbdb5e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-imperialism-the-spanish-american-war"
+      ]
+    },
+    "e38408497f4a72fa64f62686f0fdb533": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "texas-revolution"
+      ]
+    },
+    "e38609d058a2a790b4e6ec738eeb0241": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "feeding-the-hungry-with-food-stamp-programs"
+      ]
+    },
+    "e391cc8d3833d8d2f9417522275461e9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "colonial-religion"
+      ]
+    },
+    "e397bc29b9040608ce427dca1f8b15f6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "treaty-of-versailles-and-the-end-of-world-war-i"
+      ]
+    },
+    "e3ad6e4709326853ee249386ff6385c5": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "e3b5d096e79e2632ce9ffd9eaa1b05b7": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "e3b6c461db95e161492935634b6871df": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "e3bd120e0da13f51e4eadcdb2fb742c3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-boston-tea-party"
+      ]
+    },
+    "e3c80d3f799bd0656e8978b377ae5b68": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cuban-immigration-after-the-revolution-1959-1973"
+      ]
+    },
+    "e3e25b35e49e34dd03d999b7ccbc4b24": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "battle-of-gettysburg"
+      ]
+    },
+    "e3eb02750fa3b79f0cda76783caf5de7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-of-the-antebellum-reform-movement"
+      ]
+    },
+    "e3f9aa682e033d4f549eb4757b5b33b4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pablo-picasso-s-guernica-and-modern-war"
+      ]
+    },
+    "e3fa4c1f30efeec403401aeafa552003": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "e41b279b32d83346c3f997c452fdc692": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "e42043d1cdacb343b6e120c2320d93ab": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "ida-b-wells-and-anti-lynching-activism"
+      ]
+    },
+    "e425ef3632829ac22e2d71b758ebdf23": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "e429e8a5fe83d505cb04e20eb44a4838": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "e45bd98b709e9765190d6cc838f6c592": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "e46212872f1ed1f0c10bb8b630572dee": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "e47a5c0f2591ef747caec05f3cbd0c93": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cotton-gin-and-the-expansion-of-slavery"
+      ]
+    },
+    "e4b4463b2cee11fe3a17ea634570c471": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "e4c32bf668d5dcad5fa58506590c186f": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "e4c9963e02e71943cb9b0196190dabd6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-imperialism-the-spanish-american-war"
+      ]
+    },
+    "e4df38fcb7c3a568bd254001346fa058": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "colonial-religion"
+      ]
+    },
+    "e4df98d4b6d0a28242b3ebdd4a191192": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-in-the-civil-war"
+      ]
+    },
+    "e513104407d6cd22854a5b16ed4bbd1c": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "e5377e2c13ad66f31fee3ad195277dbe": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "road-to-revolution-1763-1776"
+      ]
+    },
+    "e544b1080183969702773660cc535af4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "california-gold-rush"
+      ]
+    },
+    "e553fbc33f392f27d735c6216876ebf7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-yellow-fever-epidemic-of-1878"
+      ]
+    },
+    "e554ed6ade5fe0b1505d1d66660b1e5d": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "e55577bb3feb3daadcbf03ee62f230fc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "spanish-missions-in-california"
+      ]
+    },
+    "e55afcae50086852e7eb0499610d3916": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "e578a22e2904d535b6b5c426f230b066": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "social-realism"
+      ]
+    },
+    "e5bef2a6a201059d75ab34b5a0f678be": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-whaling-industry"
+      ]
+    },
+    "e5c375f9c0e73a9861d6ba0655d4cfe5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-equal-rights-amendment"
+      ]
+    },
+    "e5c9c58644b76227085b6005bf708470": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "boomtimes-again-twentieth-century-mining-in-the-mojave-desert"
+      ]
+    },
+    "e5ce5b0592a2211f311bad4e9de88260": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "e5ed4ad583c9d4178d834a3138ab7a6c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "dutch-new-netherland"
+      ]
+    },
+    "e5f2cde5495361a0a36401a9b1d6ae65": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-i-america-heads-to-war"
+      ]
+    },
+    "e606ebe2044769b88a5ad7ccb661adc2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "manifest-destiny"
+      ]
+    },
+    "e620ea107c66d02873eb8c65373b1346": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "e62a315ae996443cb8626bb565aa1984": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "when-miners-strike-west-virginia-coal-mining-and-labor-history"
+      ]
+    },
+    "e62eb6b97582a8c9d8c64b997a1c952a": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "e6352b23ebf124113ff1f4b28137df13": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-s-eastern-front-operation-barbarossa"
+      ]
+    },
+    "e63afdd3cc84ca6c0b77bca291ce1792": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-indian-movement-1968-1978"
+      ]
+    },
+    "e64a38aa657ba954921d6f1de6532c11": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "e650bdbd61b2566c14507ebeb178d708": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "settlement-houses-in-the-progressive-era"
+      ]
+    },
+    "e651472a510a16ad1c6cc517a6790fbb": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "theodore-dreiser-s-sister-carrie-and-the-urbanization-of-chicago"
+      ]
+    },
+    "e65c94582bf7b7d0366d65dcf69b2d31": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "e6671afc6c79e0bd450e193b905a0743": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "e66ddade8779c88924a7fcf41e5768ba": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "e67c4331c507da11e16e1561cc7e37d7": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "e6aa58392d3bf75dfe2006a66491b8d4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "mexican-labor-and-world-war-ii-the-bracero-program"
+      ]
+    },
+    "e6edba6460afe80d1585669a62f6ff73": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-s-eastern-front-operation-barbarossa"
+      ]
+    },
+    "e6f841ec32191dfd5a778341318d1186": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "john-brown-s-raid-on-harper-s-ferry"
+      ]
+    },
+    "e72af7fe2020791dbff410af688e2025": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frederick-douglass-and-abraham-lincoln"
+      ]
+    },
+    "e72c0383b6829d7df4f254f196ce8b34": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-columbian-exchange"
+      ]
+    },
+    "e74eca6da45487cd9fe8593cb87d63cf": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "e764a3ce8dbf6f1bf05edb0ede459f7e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "victorian-era"
+      ]
+    },
+    "e771656e687a61880d6df181f15c977f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-woman-warrior-by-maxine-hong-kingston"
+      ]
+    },
+    "e779861e1d22525ef082f2a37cce8068": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "e78f320a8354b9fad9b5038c568fba62": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-grapes-of-wrath-by-john-steinbeck"
+      ]
+    },
+    "e7963084ea280921631674f6102df4c7": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "e79b1a69b5144c57168700f71af9c0ea": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "e79f4be956224c729561321d6979778d": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "e7ae67e44b14797dfc1f9391b8f3b0b7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-s-eastern-front-operation-barbarossa"
+      ]
+    },
+    "e7b22d135ddd3caa753c96a9ca10418c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-crucible-by-arthur-miller"
+      ]
+    },
+    "e7b33a4c54bd2233cfee91ce77bd9eb7": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "e7b5193bad5328f95b7e68f142afb852": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "e80ea3f29dfc08cae764df5e8097dfbf": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-lewis-and-clark-expedition"
+      ]
+    },
+    "e83760927d5b4208bc133eb31f6afded": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "african-american-soldiers-in-world-war-i"
+      ]
+    },
+    "e8397ac5b2da71823712ead39700228e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-indian-movement-1968-1978"
+      ]
+    },
+    "e8568e8c68a57a79176bf425eb7e26a2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-transatlantic-slave-trade"
+      ]
+    },
+    "e85fba49ba311f69212c040b9fcde9c8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "their-eyes-were-watching-god-by-zora-neale-hurston"
+      ]
+    },
+    "e8670ed06003c872a5e61b0454ddecc6": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "e87247d15d04b3516095c8177f34b650": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-awakening-by-kate-chopin"
+      ]
+    },
+    "e884ed52b984821c0623f96f7db45dbd": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "e8878b0115ecb348edb8e3703087e7fa": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-united-farm-workers-and-the-delano-grape-strike"
+      ]
+    },
+    "e88e8cfb520f2334f3154d93eb14d926": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "e89a433f576a1edff4bfce303093f92e": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "e8a188e3e2d29309e4a3599fe6f3c536": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "e8d38d8e413846e2098990ed026e3542": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "e905204daafa621d1f945d29ca9b1e25": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-gatsby-by-f-scott-fitzgerald"
+      ]
+    },
+    "e90884361a6d9ad4118bc3137240580f": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "e917ed940340a7b79cc324c11752430d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "when-miners-strike-west-virginia-coal-mining-and-labor-history"
+      ]
+    },
+    "e93727668a04a9ed0044c37194f1c3c8": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "e938f4ab14615ef638ddd39417f0db7a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "ida-b-wells-and-anti-lynching-activism",
+        "the-great-migration"
+      ]
+    },
+    "e943bafcedaee389009d386dbff883ce": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-imperialism-the-spanish-american-war"
+      ]
+    },
+    "e944afc95208a0538e675c61e896340f": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "e956c4afb416b39c496288d2e1416691": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "e977f48796b1fd23614fc717f13ab880": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "commodore-perry-s-expedition-to-japan"
+      ]
+    },
+    "e97b6d5fda18f2e1a7b6dd02720296f6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "postwar-rise-of-the-suburbs"
+      ]
+    },
+    "e982075f88d522d21b51e28f3564877a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-colonies-motivations-and-realities"
+      ]
+    },
+    "e98eac589099b9b8761a3b7194f27fef": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "e98f869843ebbc9028c50841c32720a4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "latin-american-revolutionaries"
+      ]
+    },
+    "e9b1a2e804dd5507ee3060f08a34240a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pop-art-in-the-us"
+      ]
+    },
+    "e9e69519a28b9ab4aaf620fa1ef5ae83": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "e9ee55cde9dfe9c76ae4715b83fc4f1f": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "e9ef971abdadc42aab4943728e4c11c8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-emily-dickinson"
+      ]
+    },
+    "ea1c0130df6a3eb19438cbb04203d480": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-maya-angelou"
+      ]
+    },
+    "ea326a30c0c2304ed21455721781382a": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "ea3a42bf16f2db33971c612e5da3e21d": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "ea3d32b72a945e7f44d275f2ac1aff39": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "full-steam-ahead-the-steam-engine-and-transportation-in-the-nineteenth-century"
+      ]
+    },
+    "ea3f3d97b523149153ddd224d2605bff": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "puerto-rican-migration-to-the-us"
+      ]
+    },
+    "ea510a7c6a01908b1243f699d3ab88d1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "perspectives-on-the-french-and-indian-war"
+      ]
+    },
+    "ea5cde58e371e91eb63801c9f249b1df": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "invisible-man-by-ralph-ellison"
+      ]
+    },
+    "ea753eabd9b9b75036ac5983a22819f4": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "ea89fdb64e935c6986127c0a87745e8e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "uncle-tom-s-cabin-by-harriet-beecher-stowe"
+      ]
+    },
+    "ea9669c7641287aef61d262fe6c997df": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-blues"
+      ]
+    },
+    "eaec8eed77157d65f83c6aec61b69fc7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "treaty-of-versailles-and-the-end-of-world-war-i"
+      ]
+    },
+    "eaf10991b3c3b2dac80c72f71f5f5e43": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "eb0972cc2d410cf50335b3a20760d00a": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "eb0b7655123262863726813c9cc04a70": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "eb167f4df329081fcbcf0108cd6d6837": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "eb3132e2cfa51fd9852408524e70ea17": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "eb3649f93120b0a11ea043f45534d059": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-s-suffrage-the-campaign-for-the-nineteenth-amendment"
+      ]
+    },
+    "eb443c4e568041c411c747c663fd880b": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "eb5a48be46af291518c72ad1daa55162": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "boomtimes-again-twentieth-century-mining-in-the-mojave-desert"
+      ]
+    },
+    "eb5a6aadcf78a03d6b15c274eacc5948": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "eb5d1171f089657e259b5cc273820765": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "eb8db0777670cbe96f6377a42bcdab6a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rise-of-conservatism-in-the-1980s"
+      ]
+    },
+    "eb91ea42656249aad524353ece5aea72": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "eba521719b0d629d3ceb4d2867c4437f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cross-cultural-colonial-conflicts",
+        "powhatan-people-and-the-english-at-jamestown"
+      ]
+    },
+    "eba949c8c9bc2dfb5ca94b5114b260d8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "act-up-and-the-aids-crisis"
+      ]
+    },
+    "ebac9ce336565934a8b361fc8ce5c716": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "ebafb9ae02e37ae48e72edf6979a121b": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "ebb777ebc1676c65f306a0554cea5639": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scopes-trial"
+      ]
+    },
+    "ebf40dc462776a14609fb3808c6cc3af": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "ebf569ab142f5dc10ed3a3d28a72616d": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "ec1e8e760bf8be228e40db3b901aac58": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "ec1f0392ebe9d61292b47259ee08b371": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "california-gold-rush"
+      ]
+    },
+    "ec44bc0cc134e3202274c8d238f5c05a": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "ec4e2208d83340f4969f8b48679249ab": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-poetry-of-maya-angelou"
+      ]
+    },
+    "ec584d8f75d5f26a8e8ed16bb71c1d01": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "ec72c63c850e618f11b9a52c156825cb": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "ec7b8c3c3392cabd7a350b36ed25925e": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "ec960ea27fa6635c28089482c6de4f75": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "ec9defa3f41f7682c5b61254c8a0a442": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "space-race"
+      ]
+    },
+    "ecbf0667023d27672b194f0cd113f4fb": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "ecd12a7d26f515c9fd6f6a5b7546b968": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "ecda2c6ba9e25f4764bf34783eb215c0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-crucible-by-arthur-miller"
+      ]
+    },
+    "ecfc97d90ab8e5149c22dc8e689dbb8e": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "ed379690559ba1da0fb6370e9b6efffd": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-underground-railroad-and-the-fugitive-slave-act-of-1850"
+      ]
+    },
+    "ed3f4575447013c929f96d5515114c60": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "ed75a36650eaf1e7a2963e73f3c3d149": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "patronage-and-populism-the-politics-of-the-gilded-age"
+      ]
+    },
+    "ed7adc7df523e3586450e68128c93dec": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "a-raisin-in-the-sun-by-lorraine-hansberry"
+      ]
+    },
+    "ed7bf94feb1ed4e519ea3ab1bf837f81": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "ed8288df8862e935bbf0f74754e96e58": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "voting-rights-act-of-1965"
+      ]
+    },
+    "ed94efd341a2fed56aee6e37b114d61c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "john-brown-s-raid-on-harper-s-ferry"
+      ]
+    },
+    "ed9b2e171c65aaac412e04695a7f0a2a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-and-americanization-1880-1930"
+      ]
+    },
+    "eda3a91ad479dc42fc0c9047e7a1045c": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "edabfd58f661d36500c1fa1336c93317": {
+      "exhibitions": [
+        "gold-rush"
+      ],
+      "primarySourceSets": []
+    },
+    "edb8caf56887caadb3b61f8c8181d76f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-populist-movement"
+      ]
+    },
+    "ede14215bd10e17d0f5470a866ac6985": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "ede80672f3ce9f6180aa172eca40481a": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "edf3406667cb11a565e44735f55e695e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "full-steam-ahead-the-steam-engine-and-transportation-in-the-nineteenth-century"
+      ]
+    },
+    "ee007628cb3114717793c5962d4e8aaf": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "ee15fecf51bc8dd5ba4ead04c5a983a9": {
+      "exhibitions": [
+        "boston-sports-temples"
+      ],
+      "primarySourceSets": []
+    },
+    "ee3d0a710995ba7f8cf7a239ab009211": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-black-power-movement"
+      ]
+    },
+    "ee410f610a6cd8fde65233cb205d8136": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "shays-rebellion"
+      ]
+    },
+    "ee4949c9e4647ecf1a2358f616f96a52": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "perspectives-on-the-french-and-indian-war"
+      ]
+    },
+    "ee86f42aa7942eaa18f23e062ed63e30": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "ee946f0d7cc3775151bd399a2ca53d7d": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "ee9a2a924c1855c4e0824d68452c4d9f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beginnings-of-the-american-red-cross"
+      ]
+    },
+    "eec9b28e663d2c2e5f6bfbcfb086f76d": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "eed0d959d47a589b8958e254d4131ddf": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "little-women-by-louisa-may-alcott"
+      ]
+    },
+    "eed8f50fb4a9487420405a9fa909187b": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "ef16a2049f9845e45d2adae851821180": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-temperance-movement"
+      ]
+    },
+    "ef1900df694258f2f0291f9a534e5c24": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "environmental-preservation-in-the-progressive-era"
+      ]
+    },
+    "ef28218a173116d747b9b8056c334135": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "ef3d433672584636fab382e13ec6c72c": {
+      "exhibitions": [
+        "the-show"
+      ],
+      "primarySourceSets": []
+    },
+    "ef67f3de7d111bcd9a68fbfebc9ec189": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "ef939c86e0edd2d3fe5127eae173ff93": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "commodore-perry-s-expedition-to-japan"
+      ]
+    },
+    "efdaaf79c945ace241ee09e086c44d5c": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": []
+    },
+    "eff4143cc94c9f59bcccd84d64c74591": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-atomic-bomb-and-the-nuclear-age"
+      ]
+    },
+    "f00555b1e2fbf98179da99d09665866b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "manifest-destiny"
+      ]
+    },
+    "f02392e31ed936d0fafca74e2de2f1c7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-lewis-and-clark-expedition"
+      ]
+    },
+    "f036652d84794b1ae4db55302777f565": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "f04f0d4f222b6dc593dcff102d48e5ee": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "f061af4e8b0ea15e4a70d29006563fea": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "a-raisin-in-the-sun-by-lorraine-hansberry"
+      ]
+    },
+    "f069c01bc2a2a2e3751feeb8b25b94f8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-war-of-1812"
+      ]
+    },
+    "f070241d796e8b52c357d87979c33509": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "f0772ddf6caa9c22dab21c12a1905f9d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "road-to-revolution-1763-1776"
+      ]
+    },
+    "f0785cfb1f7d8e2d603607e6ad50bba8": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "f07a58ffe4d9248221c9430d1a2768db": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "powhatan-people-and-the-english-at-jamestown"
+      ]
+    },
+    "f0bcdfc7f1e3b3ea2f128abbb5cfdc02": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "f0c60ed29f7828a3acf19f7d8f8066cc": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "secession-of-the-southern-states"
+      ]
+    },
+    "f0cb8dbc7dfdf152aecdfeead788ca3d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-indian-boarding-schools"
+      ]
+    },
+    "f0cbc5296aa0e921f2108ab51adb0a2e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fifteenth-amendment"
+      ]
+    },
+    "f0e48785b991543d18fa9359049f388c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "patronage-and-populism-the-politics-of-the-gilded-age"
+      ]
+    },
+    "f0e8cf2a06c93a9cc1e9d62205a0ea8a": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jitterbugs-swing-kids-and-lindy-hoppers"
+      ]
+    },
+    "f0f560f4ff23f70ebb796bbbf120acf5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-absolutely-true-diary-of-a-part-time-indian-by-sherman-alexie"
+      ]
+    },
+    "f1100b480597066fc5898bb65ac9409b": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "f12190a3f5fae3ba74fb25cf7bb1da75": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-awakening-by-kate-chopin"
+      ]
+    },
+    "f134c5a642be1824afc96df2249cfb84": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "f13ec98478ca544856d50872d47e749f": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "f14b48f318bf6b4dcc9bcd2df89372e0": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "f157128bcfdd2278e056994d50542147": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "f169f88024ddc774757673d6cb44a1c8": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "f170ad83f01ede7a3e0e39abe8c405b5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "puerto-rican-migration-to-the-us"
+      ]
+    },
+    "f172dd29278a68ef09146f111ba991aa": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "african-american-soldiers-in-world-war-i"
+      ]
+    },
+    "f17ef3969fc95c5b86a54532445abbf4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pablo-picasso-s-guernica-and-modern-war"
+      ]
+    },
+    "f19ff7389c21d95e5aab96514bd1ad35": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "road-to-revolution-1763-1776"
+      ]
+    },
+    "f1be3a08e0bf133931d5edb3a8421621": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "boomtimes-again-twentieth-century-mining-in-the-mojave-desert"
+      ]
+    },
+    "f1d6143637f79cda41389f51c9f812b3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-woman-warrior-by-maxine-hong-kingston"
+      ]
+    },
+    "f1f1de83dcae67bbf9141e2e314460c7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-whaling-industry"
+      ]
+    },
+    "f200c7743689c4d5989006d7d189be43": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-blues"
+      ]
+    },
+    "f20a6c1d88e800caebb92899519f49c2": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "f21e6a4efb52c0ff5f94f7ad9c8d2889": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-fifteenth-amendment"
+      ]
+    },
+    "f226ae1c9ad924cfc9cecd0376c8c660": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "attacks-on-american-soil-pearl-harbor-and-september-11"
+      ]
+    },
+    "f230b367fed149a25fa985cb73c857f4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-ii-women-on-the-home-front"
+      ]
+    },
+    "f236153d4a55c83555ff3e8c32b88834": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "f23d041b53dc8ecfa3b3141455cd26ab": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "victorian-era"
+      ]
+    },
+    "f2770e51c736e22cb0e7a44753d24708": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-woman-warrior-by-maxine-hong-kingston"
+      ]
+    },
+    "f2860e336c8a371c9cba9e8b1dc1e13b": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "f2bc24827b7ef1a30f86798566cac351": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "manifest-destiny"
+      ]
+    },
+    "f2c3f6fe965fcb1088c67d1b42f06d30": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rock-and-roll-beginnings-to-woodstock"
+      ]
+    },
+    "f2db6f5d9b60e170856d05ba723ceae9": {
+      "exhibitions": [
+        "evolution-personal-camera"
+      ],
+      "primarySourceSets": []
+    },
+    "f2eee6150db3503f53f95f7f77701fbe": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "f2f61384c12e161baf324fd11a07b926": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "f2fa0d96412f6c03fb51ab9ff1b79e1d": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "f2fa382d026dfc29d322ecd3deffe457": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "women-and-the-temperance-movement"
+      ]
+    },
+    "f3063237ddd8ec3113b834c57d568667": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "victorian-era"
+      ]
+    },
+    "f30ce561e7906969a9dbb37401546fa2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-black-power-movement"
+      ]
+    },
+    "f327ce9722d9031b393f00b0f41b94b6": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "f33b7094b8465b47dd7b4f7e457ffe57": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "f349a502ef04cd89e2ccb7ab9bec858a": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "f3623d37ae66859b3aa18dea7ca28e40": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "nineteenth-century-schools-for-the-deaf-and-blind"
+      ]
+    },
+    "f367ecfef77254b97c7e87b05b508cd8": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "f3842963daaf4a9d871b346848ef807e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-acts"
+      ]
+    },
+    "f3a13aa4f398117e54b74f5808f2d7a0": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "f3aa38838249bf157760428ddc9b6232": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "f3b3582e7e9bebb7b7fdead3c43f5a32": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jitterbugs-swing-kids-and-lindy-hoppers"
+      ]
+    },
+    "f3d3ea875a686c15b1c8010bd3f55914": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "negro-league-baseball"
+      ]
+    },
+    "f3d41938aeb54f247cc1539e13e58010": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-whaling-industry"
+      ]
+    },
+    "f3e719f229b750309c97adad71865ee5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-absolutely-true-diary-of-a-part-time-indian-by-sherman-alexie"
+      ]
+    },
+    "f3f8c7e033dff7d58e217cb227144f15": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-awakening-by-kate-chopin"
+      ]
+    },
+    "f406abc9dfac69f5d156730c7654d507": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "f4070f7cd8c911493805f89784404a3b": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "f4195e84dbc6066aaf378c71e179599b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-atomic-bomb-and-the-nuclear-age"
+      ]
+    },
+    "f419b9446eec3e3e5a4447b62eac99e3": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "f41d20e8a37ad59511395ca18f2bc565": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": []
+    },
+    "f4414972e2ce1e90c374d22e47ef7b1e": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    },
+    "f46587815294b960f88d672e30f16588": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "f472749a56642ccb944c04d857d2f185": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "incidents-in-the-life-of-a-slave-girl-by-harriet-jacobs"
+      ]
+    },
+    "f4766e3686f14fe9af64ebfa48b88af6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "when-miners-strike-west-virginia-coal-mining-and-labor-history"
+      ]
+    },
+    "f4824e0408690917ceb71cd377f13190": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "f485ec3c0b918e8ba22d32890c0b27f9": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "f4ac76b36e3bad939d53de1c01a400e8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "uncle-tom-s-cabin-by-harriet-beecher-stowe"
+      ]
+    },
+    "f4aec0b720c95d04f214484e4c8f9218": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "boomtimes-again-twentieth-century-mining-in-the-mojave-desert"
+      ]
+    },
+    "f4b93adb07d34febc3e2bbcd6ba27465": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-equal-rights-amendment"
+      ]
+    },
+    "f4cf149c46438d80d1d5c271b7a1ef15": {
+      "exhibitions": [
+        "activism"
+      ],
+      "primarySourceSets": []
+    },
+    "f4d6eb6fe0b3b269a62f1711827d4d6b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-crucible-by-arthur-miller"
+      ]
+    },
+    "f4e414d7d666cddc765ec1f4751ef38c": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "f4ee9d10aecc908e3cf5c400a28821c7": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "f4f34b952ebab9b8685b32c7362e875f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "voting-rights-act-of-1965"
+      ]
+    },
+    "f4f399efea7f05c96a4cead4f954d3d4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-invention-of-the-telephone"
+      ]
+    },
+    "f53538e497724da932e012619a4b7ca0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "early-chinese-immigration-to-the-us"
+      ]
+    },
+    "f5442d65a314d15e0b3c0fbe02c4ddac": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "eugenics-movement-in-the-united-states"
+      ]
+    },
+    "f54643c7a6778c500bc88e90835ddfd5": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "f55ad63824500c3968df3eaa08d84816": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "f587237da8a5b29a66e4370929fe52cc": {
+      "exhibitions": [
+        "1918-influenza"
+      ],
+      "primarySourceSets": []
+    },
+    "f587acd2680838b85166d18e086dbd93": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-columbian-exchange"
+      ]
+    },
+    "f594168611e72a794d8577f2b1c1a58f": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "f5c85098a342cfbe21c2650dd59d8e13": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "f5d6d96167627c4b72eea5cf5bf4a31d": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "f5ef15141c3aa6107c61d9b8fe1e7f32": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "japanese-american-internment-during-world-war-ii"
+      ]
+    },
+    "f5f2ac2a8635958a931f69b7704e61ce": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "pop-art-in-the-us"
+      ]
+    },
+    "f5fd85b11c38bb54fe5899eae70ce590": {
+      "exhibitions": [
+        "japanese-internment"
+      ],
+      "primarySourceSets": []
+    },
+    "f607044397d896d0e5fc801dc0474e7a": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "f60a26b16d9d00e10e2bcc9acfc4be25": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "ida-b-wells-and-anti-lynching-activism"
+      ]
+    },
+    "f610159df886522d48580ad17fd04aac": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "lyndon-johnson-s-great-society"
+      ]
+    },
+    "f62cf34460d826cc74ed46cafecda59c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-underground-railroad-and-the-fugitive-slave-act-of-1850"
+      ]
+    },
+    "f633d52ddfb5a6ef3a5c12c4f080b7ed": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "f657e01bacaca64b37032fc9c0a223e5": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "f67976ea6c052527b1dac177e5e3ad30": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "space-race"
+      ]
+    },
+    "f689f81e1f863ec2805119e02ab76ee0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-awakening-by-kate-chopin"
+      ]
+    },
+    "f6965380aff6a11fed85f812f71f9a01": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "california-gold-rush"
+      ]
+    },
+    "f6b8dffc8fbcf3d20088adb26531c8a5": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "f6bbc8cf381ab03f3ef40ec8ad80b83b": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "rock-and-roll-beginnings-to-woodstock"
+      ]
+    },
+    "f6d0bfb93d8fa62266ee96b155a4b5e6": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "f6d73dbeb071e9a874e8c6f9697451d4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-panama-canal"
+      ]
+    },
+    "f6db90cba875321b4d386a9e53ac9ef0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "voting-rights-act-of-1965"
+      ]
+    },
+    "f6f36019bdb1129de40535f67ccbe925": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "visual-art-during-the-harlem-renaissance"
+      ]
+    },
+    "f72dfcd311ecc2c839fb13f6abb15149": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "dutch-new-netherland"
+      ]
+    },
+    "f737157e9c4d5a88e7556087f5b55611": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "of-mice-and-men-by-john-steinbeck"
+      ]
+    },
+    "f73e28d64a8baade2a75ea3031e57427": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-wounded-knee-massacre"
+      ]
+    },
+    "f7611fa29edae92a78f771396ea7f76b": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "f76713e6dbd6a68ef0ddedead80b0266": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-things-they-carried-by-tim-o-brien"
+      ]
+    },
+    "f767bc980a1525931bf04dbdee30491f": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "f776144a0741295725342bfecd133405": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "f778a28d03d47f98a0efee2f5b37edf9": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "f790e67ba188a7e1669738baeec5a703": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "lyndon-johnson-s-great-society"
+      ]
+    },
+    "f79666ebec0eb7d01eb3f4e200ba64c2": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "f79a3655c5ebc3a2836495c54fe7a7db": {
+      "exhibitions": [
+        "spirits"
+      ],
+      "primarySourceSets": []
+    },
+    "f79a5c902bef87a173f7aa53a331f3bf": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "incidents-in-the-life-of-a-slave-girl-by-harriet-jacobs"
+      ]
+    },
+    "f79f8b7d85d5ed36bfd1f8ef4a2dca05": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cross-cultural-colonial-conflicts"
+      ]
+    },
+    "f7ae8a8ad39e40609e862a11f3eb4df2": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "f7b6ae7adfd4a9c9ecbceaf3af5fa8b5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-indian-boarding-schools"
+      ]
+    },
+    "f7cdfce5be5ae742e36d2206b04853ce": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "f7de9ac33cc8dc089e58cdee3f00fa61": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-golden-age-of-broadway"
+      ]
+    },
+    "f7deadb49786cc32b33cd8d361db08a0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "texas-revolution"
+      ]
+    },
+    "f7e529cbc7442dac40653395b072ded2": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "f7fdf9c731e89ba7d886840d8fe85e69": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "secession-of-the-southern-states"
+      ]
+    },
+    "f83b221502bcaaf31595f712062d6b7d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "immigration-and-americanization-1880-1930"
+      ]
+    },
+    "f851c4f2e9eb912ee7447c8c0da6459c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-adventures-of-huckleberry-finn-by-mark-twain"
+      ]
+    },
+    "f864a41a1c7a852c9197dbea651f4009": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "their-eyes-were-watching-god-by-zora-neale-hurston"
+      ]
+    },
+    "f866e7fc1dd55aaa6983cd7acd71f722": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "their-eyes-were-watching-god-by-zora-neale-hurston"
+      ]
+    },
+    "f87058cd964a4a82d7861565059928a4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-indian-movement-1968-1978"
+      ]
+    },
+    "f873aadbc79b09806b922c6b0f5277e7": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "postwar-rise-of-the-suburbs"
+      ]
+    },
+    "f87a858ba3b54ff984b1b13e8cd166d5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-american-abolitionist-movement"
+      ]
+    },
+    "f88752ff8036cd7470188f3c5b21e9c6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "elie-wiesel-s-night-and-the-holocaust"
+      ]
+    },
+    "f8909d61be0f1c2fd9a11e149475a2a8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-woman"
+      ]
+    },
+    "f8e7512fb69e3c1bd88ec38c4d3867a1": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "f8f5ba713e0b63ec053d628f70df2696": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "f8f643b4f6937eee09391d483d6bfd78": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-underground-railroad-and-the-fugitive-slave-act-of-1850"
+      ]
+    },
+    "f908576d057fb8b67016689b7c0b0dc8": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "f928b2558ab4ab3887ffe93eee4a95f4": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "f948aa220350aa98d2eedf11382b7645": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "f948afcea6f16fcd1b9bdffec1f3b8a5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "of-mice-and-men-by-john-steinbeck"
+      ]
+    },
+    "f94a0380b2449185b46b688966b82da1": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "aviation"
+      ]
+    },
+    "f950245045afe9827d9029cc5b0f8192": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "f965dfee0ebb2c20d2946a2348431bac": {
+      "exhibitions": [
+        "children-progressive-era"
+      ],
+      "primarySourceSets": []
+    },
+    "f99068f3db4555def72b17a1d6b08a1d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "road-to-revolution-1763-1776"
+      ]
+    },
+    "f9a45eded1e670d3b33fcdff9147b396": {
+      "exhibitions": [
+        "mapping-american-civil-war"
+      ],
+      "primarySourceSets": [
+        "cotton-gin-and-the-expansion-of-slavery"
+      ]
+    },
+    "f9f1d86437d2f7f3e859fe21a2c9f5c0": {
+      "exhibitions": [
+        "erie-canal"
+      ],
+      "primarySourceSets": []
+    },
+    "fa12c04728464dd26a164d7f0e2a2e90": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "feeding-the-hungry-with-food-stamp-programs"
+      ]
+    },
+    "fa15d9114a8a0b80b36b4e6c41b91d68": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-scarlet-letter-by-nathaniel-hawthorne"
+      ]
+    },
+    "fa1fc80731d276ebda242dcea4a83dc5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "second-ku-klux-klan-and-the-birth-of-a-nation"
+      ]
+    },
+    "fa1fe42759d78d38468cbf6a094c7ab4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beginnings-of-the-american-red-cross"
+      ]
+    },
+    "fa26f893949aee04ecc63252c9dc9f7f": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "settlement-houses-in-the-progressive-era"
+      ]
+    },
+    "fa2a8577d396a8b860e8430451932c0d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "feeding-the-hungry-with-food-stamp-programs"
+      ]
+    },
+    "fa33193f17037d010f3f25c619eac45d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-new-woman"
+      ]
+    },
+    "fa59365d593885e8a23c1a79118ef906": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "fa649844b093dde042ca40b16a2a3eec": {
+      "exhibitions": [
+        "american-aviatrixes"
+      ],
+      "primarySourceSets": []
+    },
+    "fa75b6b9baee08e0d5a7117f807cd310": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "texas-revolution"
+      ]
+    },
+    "fa889f54a936874029db127d4c39f1e0": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "fa9445aea2f2782d9fea2fd9f5650c88": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "fa972bffe6a3b5657583bb67920f17a2": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-things-they-carried-by-tim-o-brien"
+      ]
+    },
+    "fa97ca450f13829b3bfe08a10f858826": {
+      "exhibitions": [
+        "civilian-conservation-corps"
+      ],
+      "primarySourceSets": [
+        "the-grapes-of-wrath-by-john-steinbeck"
+      ]
+    },
+    "fa9fc28799c5a192ad0ffe2a7504183b": {
+      "exhibitions": [
+        "race-to-the-moon"
+      ],
+      "primarySourceSets": []
+    },
+    "faafd97967582383b06263573213ad5e": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "fabe76658e687c0fa7429a68f8c9a0c5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-indian-boarding-schools"
+      ]
+    },
+    "fad88d656ef9a17b073424ab3030dbff": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "texas-revolution"
+      ]
+    },
+    "fb183d27ba7b4e9a04880bc67dfb64b4": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "fb9f590ce77bd5f26c0e3679bdeb94fe": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beloved-by-toni-morrison",
+        "incidents-in-the-life-of-a-slave-girl-by-harriet-jacobs"
+      ]
+    },
+    "fbc03479b767dd26cb3a65b7ab59fe08": {
+      "exhibitions": [
+        "radio-golden-age"
+      ],
+      "primarySourceSets": []
+    },
+    "fbe381165dc346f685d286057f102935": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-equal-rights-amendment"
+      ]
+    },
+    "fbf153baa2559511c6fc684c5a890f69": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-raven-by-edgar-allan-poe"
+      ]
+    },
+    "fbf2f91ecbdd84df713e651d2c6314ef": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "when-miners-strike-west-virginia-coal-mining-and-labor-history"
+      ]
+    },
+    "fbfdf060781613983b493a9cf0f84ed3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "theodore-dreiser-s-sister-carrie-and-the-urbanization-of-chicago"
+      ]
+    },
+    "fc0f396726585f19828d6bd04f66cf09": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-war-of-1812"
+      ]
+    },
+    "fc3ad837e1d2f19a05815d0baae9b186": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "exploration-of-the-americas"
+      ]
+    },
+    "fc713fc3ed430f5bf95965328db24b9e": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "fc91258156082d8f348b8d3d7ab4c304": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "fc9892bb69f74c4fa9fe268c4e7f93c4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "world-war-i-america-heads-to-war"
+      ]
+    },
+    "fca6a3733f1209f9d8e2ce61324fe076": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "space-race"
+      ]
+    },
+    "fcbbcb9922d7380b7e4dd5427a064895": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "act-up-and-the-aids-crisis"
+      ]
+    },
+    "fcc0caff6f91f839de4a7f770d588a5e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-acts"
+      ]
+    },
+    "fcc500b9820c93e841c9de44d051648e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-columbian-exchange"
+      ]
+    },
+    "fcc52afb0833ae0f1562d05fdd00dd3d": {
+      "exhibitions": [
+        "tourism-mountain-west"
+      ],
+      "primarySourceSets": []
+    },
+    "fccad01ec570d49af2bf7a3a80555d1e": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "beginnings-of-the-american-red-cross"
+      ]
+    },
+    "fcd87aed8001f5dfe100eaf6c8b4d698": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "fce80fba8742f5b3ba3eda3dc9901d4d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "environmental-preservation-in-the-progressive-era"
+      ]
+    },
+    "fce88807b74e32023b4ea077bf7534f4": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "fcefbd089dfb15df4a84d8af230b8189": {
+      "exhibitions": [
+        "outsiders-president-elections"
+      ],
+      "primarySourceSets": []
+    },
+    "fd22ebc867d47b3bfc64120d73f4f44b": {
+      "exhibitions": [
+        "history-us-public-libraries"
+      ],
+      "primarySourceSets": []
+    },
+    "fd2b6172a71c5080f0853f9f69ba2180": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "frank-lloyd-wright-and-modern-american-architecture"
+      ]
+    },
+    "fd2b65d463af6bb5b8d8f7ac55ff6b07": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "jacksonian-democracy"
+      ]
+    },
+    "fd39919bc20deb22c12222e9116a2e9d": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-rise-of-italian-fascism-and-its-influence-on-europe"
+      ]
+    },
+    "fd4bce3e044b2922cf7b0a42e7c4dae8": {
+      "exhibitions": [
+        "shoe-industry-massachusetts"
+      ],
+      "primarySourceSets": []
+    },
+    "fd4f56982cc3ceacd994abaa1f781d9e": {
+      "exhibitions": [
+        "urban-parks"
+      ],
+      "primarySourceSets": []
+    },
+    "fd6c6bbabb78fbabeb3a5fe1c1346f6e": {
+      "exhibitions": [
+        "breadandroses"
+      ],
+      "primarySourceSets": []
+    },
+    "fd6d0ddea12e2f978280e1f0f513b316": {
+      "exhibitions": [
+        "home-front-world-war-ii"
+      ],
+      "primarySourceSets": []
+    },
+    "fd8eb3786b8ed48dc59134bcbd4b5ae0": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "fdaefc813b70570837fee839bab05868": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "manifest-destiny"
+      ]
+    },
+    "fdb72a314d683dd506266255b5f92b02": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-golden-age-of-broadway"
+      ]
+    },
+    "fdb73aeb954756a754836e2b7c894d86": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-homestead-strike"
+      ]
+    },
+    "fdbe6957936dea85b0d4a0cdf139f5e6": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "secession-of-the-southern-states"
+      ]
+    },
+    "fdc8ce2b42a9648c44710187eb352481": {
+      "exhibitions": [
+        "leo-frank"
+      ],
+      "primarySourceSets": []
+    },
+    "fdcc39397ea71349814d341173548f29": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-great-migration"
+      ]
+    },
+    "fdee0037ebb620aafdbd673fbd4f49ce": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-crucible-by-arthur-miller"
+      ]
+    },
+    "fdf91c6cd8b1ddb81914a3dd8655e6a0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "creating-the-us-constitution"
+      ]
+    },
+    "fdfafb7837e7b67435b2c4da4026b418": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "second-ku-klux-klan-and-the-birth-of-a-nation"
+      ]
+    },
+    "fe0036c6da08ab3fc75dfc1878ca0b8c": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "american-imperialism-the-spanish-american-war"
+      ]
+    },
+    "fe049458c9a360a0d672c9f3e21c1680": {
+      "exhibitions": [
+        "new-deal"
+      ],
+      "primarySourceSets": []
+    },
+    "fe1783c6c1531476fd236ea187506ac9": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "powhatan-people-and-the-english-at-jamestown"
+      ]
+    },
+    "fe2aeec0ff7905b70bd2860d288086b6": {
+      "exhibitions": [
+        "history-of-survivance"
+      ],
+      "primarySourceSets": []
+    },
+    "fe6b2cdbab01ae23d98bfb75702e3aeb": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "fe7345fe370597da86b4627797ecb126": {
+      "exhibitions": [
+        "industries-settled-montana"
+      ],
+      "primarySourceSets": []
+    },
+    "fe80e332e7784875cec48cc1164df38f": {
+      "exhibitions": [
+        "maps-in-american-culture"
+      ],
+      "primarySourceSets": []
+    },
+    "fea0c19c16bc42569b6c3a7cf81b4ff0": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "the-lewis-and-clark-expedition"
+      ]
+    },
+    "fea592598c47e900d7b732696e32433a": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "fea9479b76dea723699a81045eaba1d8": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "nineteenth-century-schools-for-the-deaf-and-blind"
+      ]
+    },
+    "fed87884b313a9fbf84be9505f0f3426": {
+      "exhibitions": [
+        "american-empire"
+      ],
+      "primarySourceSets": []
+    },
+    "fed8f843c1c2dc81f3cb907211556c3e": {
+      "exhibitions": [
+        "patent-medicine"
+      ],
+      "primarySourceSets": []
+    },
+    "feec47fb3ac0b340137e75db241bdc89": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "dutch-new-netherland"
+      ]
+    },
+    "feefba4a7858dca428fdd31e291e3237": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "cherokee-removal-and-the-trail-of-tears"
+      ]
+    },
+    "fef629068d90f9de1164fb33cc1464f5": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "electrifying-america"
+      ]
+    },
+    "ff056c8168aeda1fce272131bd1c3ae4": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "full-steam-ahead-the-steam-engine-and-transportation-in-the-nineteenth-century"
+      ]
+    },
+    "ff10513a4615d7b985d064d2f7b7d095": {
+      "exhibitions": [
+        "transcontinental-railroad"
+      ],
+      "primarySourceSets": []
+    },
+    "ff45ee9598142b7f9cf703cbb802ada3": {
+      "exhibitions": [],
+      "primarySourceSets": [
+        "fake-news-in-the-1890s-yellow-journalism"
+      ]
+    },
+    "ffffbf7e75045b202c47350d2c6a8aea": {
+      "exhibitions": [
+        "america-world-war-i"
+      ],
+      "primarySourceSets": []
+    }
+  }
+}

--- a/src/main/resources/curated/curated-membership.json
+++ b/src/main/resources/curated/curated-membership.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-18T22:59:21Z",
+  "generated": "2026-08-19T00:36:42Z",
   "items": {
     "0003baba3c1b4837a24bdf1f0a7b37a3": {
       "exhibitions": [

--- a/src/main/resources/curated/curated-membership.json
+++ b/src/main/resources/curated/curated-membership.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-19T00:36:42Z",
+  "generated": "2026-08-19T00:50:58Z",
   "items": {
     "0003baba3c1b4837a24bdf1f0a7b37a3": {
       "exhibitions": [

--- a/src/main/scala/dpla/ingestion3/entries/utils/NaraFilecoin.scala
+++ b/src/main/scala/dpla/ingestion3/entries/utils/NaraFilecoin.scala
@@ -2,7 +2,7 @@ package dpla.ingestion3.entries.utils
 
 import dpla.ingestion3.confs.CmdArgs
 import dpla.ingestion3.dataStorage.{InputHelper, OutputHelper}
-import dpla.ingestion3.model.{OreAggregation, jsonlRecord}
+import dpla.ingestion3.model.{CuratedMembership, OreAggregation, jsonlRecord}
 import org.apache.log4j.LogManager
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
@@ -81,7 +81,8 @@ object NaraFilecoin {
       .as[OreAggregation]
       .map(row => {
         val id = row.dplaUri.toString.split("/").last
-        val json = jsonlRecord(row)
+        // Stamp membership so this export matches the index
+        val json = jsonlRecord(row, CuratedMembership.fromResource)
         NaraWithId(id, json)
       })
 

--- a/src/main/scala/dpla/ingestion3/entries/utils/NaraFilecoin.scala
+++ b/src/main/scala/dpla/ingestion3/entries/utils/NaraFilecoin.scala
@@ -75,6 +75,10 @@ object NaraFilecoin {
     implicit val naraWithIdEncoder: ExpressionEncoder[NaraWithId] =
       ExpressionEncoder[NaraWithId]
 
+    // Load on the driver: a bad snapshot fails fast, and the snapshot in
+    // the manifest is the one the tasks apply
+    val curated = CuratedMembership.fromResource
+
     val nara = spark.read
       .format("avro")
       .load(inputDirectory)
@@ -82,7 +86,7 @@ object NaraFilecoin {
       .map(row => {
         val id = row.dplaUri.toString.split("/").last
         // Stamp membership so this export matches the index
-        val json = jsonlRecord(row, CuratedMembership.fromResource)
+        val json = jsonlRecord(row, curated)
         NaraWithId(id, json)
       })
 
@@ -115,7 +119,8 @@ object NaraFilecoin {
       "Activity" -> "JSON-L",
       "Provider" -> "nara",
       "Record count" -> indexCount.toString,
-      "Input" -> inputDirectory
+      "Input" -> inputDirectory,
+      "Curated membership snapshot" -> curated.generated
     )
 
     outputHelper.writeManifest(manifestOpts) match {

--- a/src/main/scala/dpla/ingestion3/executors/JsonlExecutor.scala
+++ b/src/main/scala/dpla/ingestion3/executors/JsonlExecutor.scala
@@ -3,7 +3,7 @@ package dpla.ingestion3.executors
 import dpla.ingestion3.dataStorage.OutputHelper
 
 import java.time.LocalDateTime
-import dpla.ingestion3.model.{OreAggregation, jsonlRecord}
+import dpla.ingestion3.model.{CuratedMembership, OreAggregation, jsonlRecord}
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{Dataset, SparkSession}
@@ -50,7 +50,17 @@ trait JsonlExecutor extends Serializable {
 
     val enrichedRows = spark.read.format("avro").load(dataIn).as[OreAggregation]
 
-    val indexRecords: Dataset[String] = enrichedRows.map(jsonlRecord)
+    // Load on the driver: a bad snapshot fails fast, and the snapshot
+    // logged below is the one the tasks apply
+    val curated = CuratedMembership.fromResource
+    logger.info(
+      s"Curated membership snapshot generated ${curated.generated}: " +
+        s"${curated.exhibitions.size} exhibition item IDs, " +
+        s"${curated.primarySourceSets.size} source set item IDs"
+    )
+
+    val indexRecords: Dataset[String] =
+      enrichedRows.map(row => jsonlRecord(row, curated))
 
     // This should always write out as #text() because if we use #json() then the
     // data will be written out inside a JSON object (e.g. {'value': <doc>}) which is
@@ -65,7 +75,8 @@ trait JsonlExecutor extends Serializable {
       "Activity" -> "JSON-L",
       "Provider" -> shortName,
       "Record count" -> indexCount.toString,
-      "Input" -> dataIn
+      "Input" -> dataIn,
+      "Curated membership snapshot" -> curated.generated
     )
 
     outputHelper.writeManifest(manifestOpts) match {

--- a/src/main/scala/dpla/ingestion3/model/CuratedMembership.scala
+++ b/src/main/scala/dpla/ingestion3/model/CuratedMembership.scala
@@ -1,0 +1,52 @@
+package dpla.ingestion3.model
+
+import dpla.ingestion3.utils.FlatFileIO
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+
+/** Maps DPLA item IDs (32-hex) to the slugs of the exhibitions and primary
+  * source sets they appear in. `generated` is the snapshot crawl timestamp.
+  */
+case class CuratedMembership(
+    generated: String,
+    exhibitions: Map[String, Seq[String]],
+    primarySourceSets: Map[String, Seq[String]]
+)
+
+object CuratedMembership {
+
+  /** Written by scripts/curated_membership.py.
+    * Re-run it and rebuild the JAR when curated content changes.
+    */
+  val resourceName = "/curated/curated-membership.json"
+
+  val empty: CuratedMembership = CuratedMembership("", Map.empty, Map.empty)
+
+  lazy val fromResource: CuratedMembership = {
+    val json = parse(new FlatFileIO().readFileAsString(resourceName))
+    val items = json \ "items" match {
+      case JObject(fields) => fields
+      case _ =>
+        throw new RuntimeException(
+          s"$resourceName is missing the items object"
+        )
+    }
+    def slugs(value: JValue): Seq[String] = value match {
+      case JArray(values) => values.collect { case JString(s) => s }
+      case _              => Seq.empty
+    }
+    def index(field: String): Map[String, Seq[String]] =
+      items.flatMap { case (id, value) =>
+        val s = slugs(value \ field)
+        if (s.nonEmpty) Some(id -> s) else None
+      }.toMap
+    val generated = json \ "generated" match {
+      case JString(s) => s
+      case _ =>
+        throw new RuntimeException(
+          s"$resourceName is missing the generated timestamp"
+        )
+    }
+    CuratedMembership(generated, index("exhibitions"), index("primarySourceSets"))
+  }
+}

--- a/src/main/scala/dpla/ingestion3/model/package.scala
+++ b/src/main/scala/dpla/ingestion3/model/package.scala
@@ -112,15 +112,19 @@ package object model {
     }
   }
 
-  def jsonlRecord(record: OreAggregation): String = {
+  def jsonlRecord(
+      record: OreAggregation,
+      curated: CuratedMembership
+  ): String = {
 
     // We require the that DPLA ID and prehash ID (the providers 'permanent' identifier) be passed forward via the
     // metadata sidecar. Currently, there is no place to store these values in either the DPLA MAPv3.1 or MAPv4.0 models
-    val dplaId = fromJsonString(record.sidecar) \ "dplaId" match {
+    val sidecar = fromJsonString(record.sidecar)
+    val dplaId = sidecar \ "dplaId" match {
       case JString(js) => js
       case _ => throw new RuntimeException("DPLA ID is not in metadata sidecar")
     }
-    val _id = fromJsonString(record.sidecar) \ "prehashId" match {
+    val _id = sidecar \ "prehashId" match {
       case JString(js) => js
       case _ =>
         throw new RuntimeException("Prehash ID is not in metadata sidecar")
@@ -237,7 +241,11 @@ package object model {
             ("title" -> record.sourceResource.title) ~
             ("type" -> record.sourceResource.`type`)) ~
           ("@type" -> "ore:Aggregation") ~
-          ("tags" -> record.tags.map { _.toString }))
+          ("tags" -> record.tags.map { _.toString }) ~
+          // Empty seqs are dropped at render; only member items get these
+          ("exhibitions" -> curated.exhibitions.getOrElse(dplaId, Seq.empty)) ~
+          ("primarySourceSets" -> curated.primarySourceSets
+            .getOrElse(dplaId, Seq.empty)))
 
     compact(render(dplaMapJsonLd))
   }

--- a/src/main/scala/dpla/ingestion3/utils/FileIO.scala
+++ b/src/main/scala/dpla/ingestion3/utils/FileIO.scala
@@ -36,6 +36,8 @@ class FlatFileIO {
     */
   def readFileAsString(name: String): String = {
     val stream = getClass.getResourceAsStream(name)
+    if (stream == null)
+      throw new RuntimeException(s"Resource not found on classpath: $name")
     val result = Source.fromInputStream(stream).mkString
     IOUtils.closeQuietly(stream)
     result

--- a/src/test/scala/dpla/ingestion3/model/CuratedMembershipTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/CuratedMembershipTest.scala
@@ -1,0 +1,33 @@
+package dpla.ingestion3.model
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+class CuratedMembershipTest extends AnyFlatSpec {
+
+  "fromResource" should "load the bundled membership snapshot" in {
+    val membership = CuratedMembership.fromResource
+    assert(membership.exhibitions.nonEmpty)
+    assert(membership.primarySourceSets.nonEmpty)
+  }
+
+  it should "key every entry on a 32-char hex DPLA item ID" in {
+    val membership = CuratedMembership.fromResource
+    val ids =
+      membership.exhibitions.keySet ++ membership.primarySourceSets.keySet
+    assert(ids.forall(_.matches("^[0-9a-f]{32}$")))
+  }
+
+  it should "map every entry to non-blank slugs" in {
+    // Slug naming belongs upstream; assert only what the script guarantees
+    val membership = CuratedMembership.fromResource
+    val slugs = (membership.exhibitions.values ++
+      membership.primarySourceSets.values).flatten
+    assert(slugs.nonEmpty)
+    assert(slugs.forall(_.matches("""^\S+$""")))
+  }
+
+  it should "record when the snapshot was generated" in {
+    val generated = CuratedMembership.fromResource.generated
+    assert(generated.matches("""^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"""))
+  }
+}

--- a/src/test/scala/dpla/ingestion3/model/JsonlStringTest.scala
+++ b/src/test/scala/dpla/ingestion3/model/JsonlStringTest.scala
@@ -9,13 +9,13 @@ import org.scalatest.flatspec.AnyFlatSpec
 class JsonlStringTest extends AnyFlatSpec {
 
   "jsonlRecord" should "print a valid JSON string" in {
-    val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord)
+    val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord, CuratedMembership.empty)
     val jvalue = parse(s)
     assert(jvalue.isInstanceOf[JValue])
   }
 
   it should "render a field that's a String" in {
-    val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord)
+    val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord, CuratedMembership.empty)
     val jvalue = parse(s)
     assert(
       compact(render(jvalue \ "_source" \ "id")) ==
@@ -24,7 +24,7 @@ class JsonlStringTest extends AnyFlatSpec {
   }
 
   it should "render a field that's a sequence" in {
-    val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord)
+    val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord, CuratedMembership.empty)
     val jvalue = parse(s)
     val title = jvalue \ "_source" \ "sourceResource" \ "title"
     assert(title.isInstanceOf[JArray])
@@ -32,7 +32,7 @@ class JsonlStringTest extends AnyFlatSpec {
   }
 
   it should "render a subject.exactMatch" in {
-      val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord)
+      val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord, CuratedMembership.empty)
       val jvalue = parse(s)
       val subjectExactMatch = jvalue \ "_source" \ "sourceResource" \ "subject" \ "exactMatch"
       assert(subjectExactMatch.isInstanceOf[JArray])
@@ -40,7 +40,7 @@ class JsonlStringTest extends AnyFlatSpec {
     }
 
   it should "render a field that requires a map() on a sequence" in {
-    val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord)
+    val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord, CuratedMembership.empty)
     val jvalue = parse(s)
     val collection = jvalue \ "_source" \ "sourceResource" \ "collection"
     assert(collection.isInstanceOf[JArray])
@@ -50,7 +50,7 @@ class JsonlStringTest extends AnyFlatSpec {
   }
 
   it should "render a iiifManfiest " in {
-    val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord)
+    val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord, CuratedMembership.empty)
     val jvalue = parse(s)
     val iiifManifest = jvalue \ "_source" \ "iiifManifest"
     assert(iiifManifest.isInstanceOf[JString])
@@ -61,11 +61,51 @@ class JsonlStringTest extends AnyFlatSpec {
 
   it should "not have empty arrays for fields that have no data" in {
     // Those fields that are optional are 0-n, so they will be arrays.
-    val s: String = jsonlRecord(EnrichedRecordFixture.minimalEnrichedRecord)
+    val s: String = jsonlRecord(EnrichedRecordFixture.minimalEnrichedRecord, CuratedMembership.empty)
     val jvalue = parse(s)
     val outputString = compact(render(jvalue \ "_source" \ "sourceResource" \ "collection"))
     assert(
        outputString == ""
+    )
+  }
+
+  it should "render exhibitions and primarySourceSets for member items" in {
+    val membership = CuratedMembership(
+      generated = "2026-08-18T00:00:00Z",
+      exhibitions =
+        Map("4b1bd605bd1d75ee23baadb0e1f24457" -> Seq("race-to-the-moon")),
+      primarySourceSets =
+        Map("4b1bd605bd1d75ee23baadb0e1f24457" -> Seq("aviation", "cold-war"))
+    )
+    val s: String = jsonlRecord(EnrichedRecordFixture.enrichedRecord, membership)
+    val jvalue = parse(s)
+    assert(
+      compact(render(jvalue \ "_source" \ "exhibitions")) ==
+        "[\"race-to-the-moon\"]"
+    )
+    assert(
+      compact(render(jvalue \ "_source" \ "primarySourceSets")) ==
+        "[\"aviation\",\"cold-war\"]"
+    )
+  }
+
+  it should "omit exhibitions and primarySourceSets for non-member items" in {
+    val s: String =
+      jsonlRecord(EnrichedRecordFixture.enrichedRecord, CuratedMembership.empty)
+    val jvalue = parse(s)
+    assert(compact(render(jvalue \ "_source" \ "exhibitions")) == "")
+    assert(compact(render(jvalue \ "_source" \ "primarySourceSets")) == "")
+  }
+
+  it should "stamp membership from the bundled snapshot" in {
+    val (id, slugs) = CuratedMembership.fromResource.exhibitions.head
+    val record = EnrichedRecordFixture.enrichedRecord.copy(
+      sidecar = s"""{"prehashId": "prehash", "dplaId": "$id"}"""
+    )
+    val jvalue = parse(jsonlRecord(record, CuratedMembership.fromResource))
+    assert(
+      (jvalue \ "_source" \ "exhibitions") ==
+        JArray(slugs.map(JString(_)).toList)
     )
   }
 


### PR DESCRIPTION
Items in DPLA exhibitions and primary source sets (PSS) are not currently marked in the index. This PR stamps two fields on member items at JSONL export: `exhibitions` and `primarySourceSets`. 

This can be helpful for any future use cases that requires knowing which items belong to any exhibition or PSS. My motivation for this is to be used by the Analytics Dashboard, to help expose when viewed items are part of exihibitions and/or PSS.

`scripts/curated_membership.py` crawls `dpla-frontend` and `pss-json` and writes a snapshot to `src/main/resources/curated/curated-membership.json` (currently 3,619 item IDs).

Data looks like:
```
  "items": {
    "0003baba3c1b4837a24bdf1f0a7b37a3": {
      "exhibitions": [
        "erie-canal"
      ],
      "primarySourceSets": []
    },
    "00050e6c830653cf21a5f6a1be325476": {
      "exhibitions": [
        "radio-golden-age"
      ],
      "primarySourceSets": []
    },
    "001325e83bb90d3714679a0edf743b83": {
      "exhibitions": [],
      "primarySourceSets": [
        "incidents-in-the-life-of-a-slave-girl-by-harriet-jacobs"
      ]
    },
    ...
```

`CuratedMembership` loads the snapshot from the JAR. `jsonlRecord` joins on DPLA ID and adds the fields.

The JSONL step logs the snapshot timestamp and writes it to `_MANIFEST`.

To refresh: re-run the script, commit, rebuild the JAR, and re-run `jsonl.sh` per hub.

# CodeRabbit Summary
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds `exhibitions` and `primarySourceSets` to JSONL records.
- Generates and loads a curated-membership snapshot from DPLA repositories.
- Joins membership data by DPLA ID.
- Records the snapshot timestamp in logs and `_MANIFEST`.
- Adds validation, retries, GitHub rate-limit handling, optional GitHub token support, and tests.

## Operational impact

- Requires a manual snapshot refresh, JAR rebuild, and `jsonl.sh` rerun for each hub.
- Does not require an ECS redeployment or manual pipeline trigger.
- Adds no environment variables or AWS Secrets Manager keys.
- Includes no database migration.
- Changes no shared infrastructure configuration.
- Changes the JSONL output shape by adding two fields.
- Adds external GitHub data inputs and optional GitHub token handling. It does not change authentication flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->