### PR TITLE
Fix: flush Avro writer before spark read in all API harvesters (#760)

### DIFF
--- a/src/main/scala/dpla/ingestion3/harvesters/api/IaHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/IaHarvester.scala
@@ -101,6 +101,7 @@ class IaHarvester(
       }
     })
 
+    close() // flush Avro writer before read-back (issue #760)
     spark.read.format("avro").load(tmpOutStr)
   }
 

--- a/src/main/scala/dpla/ingestion3/harvesters/api/LocHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/LocHarvester.scala
@@ -96,7 +96,8 @@ class LocHarvester(
     // @see ApiHarvester
     saveOutAll(locFetched)
 
-    // Read harvested data into Spark DataFrame and return.
+    // Flush and close the Avro writer before Spark reads the file (issue #760).
+    close()
     spark.read.format("avro").load(tmpOutStr)
   }
 

--- a/src/main/scala/dpla/ingestion3/harvesters/api/MdlHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/MdlHarvester.scala
@@ -94,7 +94,8 @@ class MdlHarvester(
         }
     }
 
-    // Read harvested data into Spark DataFrame and return.
+    // Flush and close the Avro writer before Spark reads the file (issue #760).
+    close()
     spark.read.format("avro").load(tmpOutStr)
   }
 

--- a/src/main/scala/dpla/ingestion3/harvesters/api/PrimoHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/PrimoHarvester.scala
@@ -146,7 +146,8 @@ abstract class PrimoHarvester(
         }
       case _ => throw new RuntimeException("Not sure how we got here!")
     }
-    // Read harvested data into Spark DataFrame and return.
+    // Flush and close the Avro writer before Spark reads the file (issue #760).
+    close()
     spark.read.format("avro").load(tmpOutStr)
   }
 

--- a/src/main/scala/dpla/ingestion3/harvesters/api/PrimoVEHarvester.scala
+++ b/src/main/scala/dpla/ingestion3/harvesters/api/PrimoVEHarvester.scala
@@ -106,7 +106,9 @@ abstract class PrimoVEHarvester(
             continueHarvest = false
         }
     }
-    // Read harvested data into Spark DataFrame and return.
+    // Flush and close the Avro writer before Spark reads the file.
+    // Without this the final partial block is never persisted (issue #760).
+    close()
     spark.read.format("avro").load(tmpOutStr)
   }
 


### PR DESCRIPTION
Add close() before spark.read.format(\"avro\").load(tmpOutStr) in:
- PrimoVEHarvester (GettyHarvester, MississippiHarvester)
- PrimoHarvester (MwdlHarvester)
- IaHarvester
- LocHarvester
- MdlHarvester

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Flushes and closes the Avro writer before Spark reads harvested output.
- Updates `IaHarvester`, `LocHarvester`, `MdlHarvester`, `PrimoHarvester`, and `PrimoVEHarvester`.
- Ensures the final output block is persisted before `spark.read.format("avro").load(...)`.

## Operational impact

- No manual pipeline trigger or ECS redeployment is indicated.
- No environment variables or AWS Secrets Manager keys change.
- No database migration is included.
- No shared infrastructure configuration changes.
- No public API response shapes or endpoints change.
- No security implications are introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->