### PR TITLE
Spark Indexer Terminating Error Msg Fix

### DIFF
--- a/ingest_python_scripts/launch_indexer.py
+++ b/ingest_python_scripts/launch_indexer.py
@@ -536,7 +536,10 @@ def monitor_cluster(cluster_id):
                     slack_notify(f":x: *sparkindexer FAILED* — `{cluster_id}`\nReason: {out2.strip()}\nLogs: `{EMR_LOG_URI}{cluster_id}/`")
                     return False
 
-            if state in ("TERMINATING", "TERMINATED_WITH_ERRORS"):
+            if state == "TERMINATING":
+                print(f"\n  [{ts}] TERMINATING — cluster wrapping up, waiting for final state...")
+
+            if state == "TERMINATED_WITH_ERRORS":
                 bad(f"Cluster {state}: {detail}")
                 info(f"Check logs: {EMR_LOG_URI}{cluster_id}/")
                 slack_notify(f":x: *sparkindexer {state}* — `{cluster_id}`\n{detail}\nLogs: `{EMR_LOG_URI}{cluster_id}/`")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Treats `TERMINATING` as an informational progress state.
- Continues polling while the Spark cluster completes shutdown.
- Reports failure only for `TERMINATED_WITH_ERRORS`.

## Impact

- No manual pipeline trigger or ECS redeployment is required.
- No environment variables or AWS Secrets Manager keys changed.
- No database migration included.
- No shared infrastructure configuration changed.
- No public API response or endpoint changed.
- No security impact identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->